### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -36,7 +36,7 @@ spec:
             description: CeilometerSpec defines the desired state of Ceilometer
             properties:
               centralImage:
-                default: quay.io/tripleomastercentos9/openstack-ceilometer-central:current-tripleo
+                default: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
                 type: string
               customServiceConfig:
                 default: '# add your customization here'
@@ -58,7 +58,7 @@ spec:
                 default: A ceilometer agent
                 type: string
               initImage:
-                default: quay.io/tripleomastercentos9/openstack-ceilometer-central:current-tripleo
+                default: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
                 type: string
               networkAttachmentDefinitions:
                 description: NetworkAttachmentDefinitions list of network attachment
@@ -67,7 +67,7 @@ spec:
                   type: string
                 type: array
               notificationImage:
-                default: quay.io/tripleomastercentos9/openstack-ceilometer-notification:current-tripleo
+                default: quay.io/podified-antelope-centos9/openstack-ceilometer-notification:current-podified
                 type: string
               passwordSelector:
                 default:

--- a/api/v1beta1/ceilometercentral_types.go
+++ b/api/v1beta1/ceilometercentral_types.go
@@ -65,16 +65,16 @@ type CeilometerCentralSpec struct {
 	// NetworkAttachmentDefinitions list of network attachment definitions the service pod gets attached to
 	NetworkAttachmentDefinitions []string `json:"networkAttachmentDefinitions,omitempty"`
 
-	// +kubebuilder:default:="quay.io/tripleomastercentos9/openstack-ceilometer-central:current-tripleo"
+	// +kubebuilder:default:="quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified"
 	CentralImage string `json:"centralImage,omitempty"`
 
-	// +kubebuilder:default:="quay.io/tripleomastercentos9/openstack-ceilometer-notification:current-tripleo"
+	// +kubebuilder:default:="quay.io/podified-antelope-centos9/openstack-ceilometer-notification:current-podified"
 	NotificationImage string `json:"notificationImage,omitempty"`
 
 	// +kubebuilder:default:="quay.io/infrawatch/sg-core:latest"
 	SgCoreImage string `json:"sgCoreImage,omitempty"`
 
-	// +kubebuilder:default:="quay.io/tripleomastercentos9/openstack-ceilometer-central:current-tripleo"
+	// +kubebuilder:default:="quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified"
 	InitImage string `json:"initImage,omitempty"`
 
 	// +kubebuilder:default:="A ceilometer agent"

--- a/config/crd/bases/telemetry.openstack.org_ceilometercentrals.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometercentrals.yaml
@@ -36,7 +36,7 @@ spec:
             description: CeilometerCentralSpec defines the desired state of CeilometerCentral
             properties:
               centralImage:
-                default: quay.io/tripleomastercentos9/openstack-ceilometer-central:current-tripleo
+                default: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
                 type: string
               customServiceConfig:
                 default: '# add your customization here'
@@ -58,7 +58,7 @@ spec:
                 default: A ceilometer agent
                 type: string
               initImage:
-                default: quay.io/tripleomastercentos9/openstack-ceilometer-central:current-tripleo
+                default: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
                 type: string
               networkAttachmentDefinitions:
                 description: NetworkAttachmentDefinitions list of network attachment
@@ -67,7 +67,7 @@ spec:
                   type: string
                 type: array
               notificationImage:
-                default: quay.io/tripleomastercentos9/openstack-ceilometer-notification:current-tripleo
+                default: quay.io/podified-antelope-centos9/openstack-ceilometer-notification:current-podified
                 type: string
               passwordSelector:
                 default:

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -40,7 +40,7 @@ spec:
                   service of this Telemetry deployment
                 properties:
                   centralImage:
-                    default: quay.io/tripleomastercentos9/openstack-ceilometer-central:current-tripleo
+                    default: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
                     type: string
                   customServiceConfig:
                     default: '# add your customization here'
@@ -62,7 +62,7 @@ spec:
                     default: A ceilometer agent
                     type: string
                   initImage:
-                    default: quay.io/tripleomastercentos9/openstack-ceilometer-central:current-tripleo
+                    default: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
                     type: string
                   networkAttachmentDefinitions:
                     description: NetworkAttachmentDefinitions list of network attachment
@@ -71,7 +71,7 @@ spec:
                       type: string
                     type: array
                   notificationImage:
-                    default: quay.io/tripleomastercentos9/openstack-ceilometer-notification:current-tripleo
+                    default: quay.io/podified-antelope-centos9/openstack-ceilometer-notification:current-podified
                     type: string
                   passwordSelector:
                     default:

--- a/config/samples/telemetry_v1beta1_telemetry.yaml
+++ b/config/samples/telemetry_v1beta1_telemetry.yaml
@@ -8,9 +8,9 @@ spec:
   rabbitMqClusterName: rabbitmq
   ceilometerCentral:
     description: A ceilometer central deployment
-    initImage: quay.io/tripleomastercentos9/openstack-ceilometer-central:current-tripleo
-    centralImage: quay.io/tripleomastercentos9/openstack-ceilometer-central:current-tripleo
-    notificationImage: quay.io/tripleomastercentos9/openstack-ceilometer-notification:current-tripleo
+    initImage: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
+    centralImage: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
+    notificationImage: quay.io/podified-antelope-centos9/openstack-ceilometer-notification:current-podified
     sgCoreImage: quay.io/infrawatch/sg-core:latest
   ceilometerCompute:
     description: A ceilometer compute deployment


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib