### PR TITLE
Reset Ready condition when update failed

### DIFF
--- a/api/v1beta1/ceilometercentral_types.go
+++ b/api/v1beta1/ceilometercentral_types.go
@@ -112,9 +112,9 @@ type CeilometerCentralList struct {
 	Items           []CeilometerCentral `json:"items"`
 }
 
-// IsReady - returns true if service is ready
+// IsReady - returns true if CeilometerCentral is reconciled successfully
 func (instance CeilometerCentral) IsReady() bool {
-	return instance.Status.Conditions.IsTrue(condition.DeploymentReadyCondition)
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 func init() {

--- a/api/v1beta1/ceilometercompute_types.go
+++ b/api/v1beta1/ceilometercompute_types.go
@@ -118,9 +118,9 @@ type CeilometerComputeList struct {
 	Items           []CeilometerCompute `json:"items"`
 }
 
-// IsReady - returns true if service is ready
+// IsReady - returns true if CeilometerCompute is reconciled successfully
 func (instance CeilometerCompute) IsReady() bool {
-	return instance.Status.Conditions.IsTrue(condition.AnsibleEECondition)
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 func init() {

--- a/api/v1beta1/infracompute_types.go
+++ b/api/v1beta1/infracompute_types.go
@@ -96,9 +96,9 @@ type InfraComputeList struct {
 	Items           []InfraCompute `json:"items"`
 }
 
-// IsReady - returns true if service is ready
+// IsReady - returns true if InfraCompute is reconciled successfully
 func (instance InfraCompute) IsReady() bool {
-	return instance.Status.Conditions.IsTrue(condition.DeploymentReadyCondition)
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 func init() {

--- a/api/v1beta1/telemetry_types.go
+++ b/api/v1beta1/telemetry_types.go
@@ -114,9 +114,9 @@ type TelemetryList struct {
 	Items           []Telemetry `json:"items"`
 }
 
-// IsReady - returns true if service is ready
+// IsReady - returns true if Telemetry is reconciled successfully
 func (instance Telemetry) IsReady() bool {
-	return instance.Status.Conditions.IsTrue(CeilometerCentralReadyCondition) && instance.Status.Conditions.IsTrue(CeilometerComputeReadyCondition)
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 func init() {

--- a/controllers/ceilometercentral_controller.go
+++ b/controllers/ceilometercentral_controller.go
@@ -94,11 +94,18 @@ func (r *CeilometerCentralReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
+			instance.Status.Conditions.MarkTrue(
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err

--- a/controllers/ceilometercentral_controller.go
+++ b/controllers/ceilometercentral_controller.go
@@ -121,6 +121,8 @@ func (r *CeilometerCentralReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
 			condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
 			condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
+			// right now we have no dedicated KeystoneServiceReadyInitMessage
+			condition.UnknownCondition(condition.KeystoneServiceReadyCondition, condition.InitReason, ""),
 		)
 
 		instance.Status.Conditions.Init(&cl)

--- a/controllers/ceilometercompute_controller.go
+++ b/controllers/ceilometercompute_controller.go
@@ -88,11 +88,18 @@ func (r *CeilometerComputeReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
+			instance.Status.Conditions.MarkTrue(
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err

--- a/controllers/infracompute_controller.go
+++ b/controllers/infracompute_controller.go
@@ -106,9 +106,7 @@ func (r *InfraComputeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		instance.Status.Conditions = condition.Conditions{}
 		// initialize conditions used later as Status=Unknown
 		cl := condition.CreateList(
-			condition.UnknownCondition(condition.InputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
-			condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
-			condition.UnknownCondition(condition.DeploymentReadyCondition, condition.InitReason, condition.DeploymentReadyInitMessage),
+			condition.UnknownCondition(condition.AnsibleEECondition, condition.InitReason, condition.AnsibleEEReadyInitMessage),
 		)
 
 		instance.Status.Conditions.Init(&cl)
@@ -204,6 +202,8 @@ func (r *InfraComputeReconciler) createAnsibleExecution(ctx context.Context, ins
 		// Error reading the object - requeue the request.
 		return ctrl.Result{}, err
 	}
+
+	instance.Status.Conditions.MarkTrue(condition.AnsibleEECondition, condition.AnsibleEEReadyMessage)
 
 	fmt.Println("Returning...")
 	return ctrl.Result{}, nil

--- a/controllers/infracompute_controller.go
+++ b/controllers/infracompute_controller.go
@@ -82,11 +82,18 @@ func (r *InfraComputeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
+			instance.Status.Conditions.MarkTrue(
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err

--- a/controllers/telemetry_controller.go
+++ b/controllers/telemetry_controller.go
@@ -109,11 +109,18 @@ func (r *TelemetryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Always patch the instance status when exiting this function so we can persist any changes.
 	defer func() {
-		// update the overall status condition if service is ready
-		if instance.IsReady() {
-			instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
+		// update the Ready condition based on the sub conditions
+		if instance.Status.Conditions.AllSubConditionIsTrue() {
+			instance.Status.Conditions.MarkTrue(
+				condition.ReadyCondition, condition.ReadyMessage)
+		} else {
+			// something is not ready so reset the Ready condition
+			instance.Status.Conditions.MarkUnknown(
+				condition.ReadyCondition, condition.InitReason, condition.ReadyInitMessage)
+			// and recalculate it based on the state of the rest of the conditions
+			instance.Status.Conditions.Set(
+				instance.Status.Conditions.Mirror(condition.ReadyCondition))
 		}
-
 		err := helper.PatchInstance(ctx, instance)
 		if err != nil {
 			_err = err


### PR DESCRIPTION
This ensures the Ready Condition is reset when CR becomes once ready but something fails during reconfiguration.

This also fixes incomplete condition handling so that all conditions are initialized and later updated properly.