### PR TITLE
Revert "Remove config/manager/kustomization.yaml from .gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ testbin/*
 #Operator SDK generated files
 /bundle/
 bundle.Dockerfile
+config/manager/kustomization.yaml
 
 # Common CI tools repository
 CI_TOOLS_REPO


### PR DESCRIPTION
This reverts commit b66b54bfaaef46a40e62ccb6597ffabd36d678d0.

Reason for revert:
The file should be kept in .gitignore, so that any update made by `make bundle` is not pulled into a git commit.