### PR TITLE
Replace RabbitMqTransportURLReady by common condition

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -21,9 +21,6 @@ import (
 
 // Telemetry Condition Types used by API objects.
 const (
-	// TelemetryRabbitMqTransportURLReadyCondition Status=True condition which indicates if the RabbitMQ TransportURLUrl is ready
-	TelemetryRabbitMqTransportURLReadyCondition condition.Type = "TelemetryRabbitMqTransportURLReady"
-
 	// CeilometerCentralReadyCondition Status=True condition which indicates if the CeilometerCentral is configured and operational
 	CeilometerCentralReadyCondition condition.Type = "CeilometerCentralReady"
 
@@ -39,21 +36,6 @@ const ()
 
 // Common Messages used by API objects.
 const (
-	//
-	// TelemetryRabbitMqTransportURLReady condition messages
-	//
-	// TelemetryRabbitMqTransportURLReadyInitMessage
-	TelemetryRabbitMqTransportURLReadyInitMessage = "TelemetryRabbitMqTransportURL not started"
-
-	// TelemetryRabbitMqTransportURLReadyRunningMessage
-	TelemetryRabbitMqTransportURLReadyRunningMessage = "TelemetryRabbitMqTransportURL creation in progress"
-
-	// TelemetryRabbitMqTransportURLReadyMessage
-	TelemetryRabbitMqTransportURLReadyMessage = "TelemetryRabbitMqTransportURL successfully created"
-
-	// TelemetryRabbitMqTransportURLReadyErrorMessage
-	TelemetryRabbitMqTransportURLReadyErrorMessage = "TelemetryRabbitMqTransportURL error occured %s"
-
 	//
 	// CeilometerCentralReady condition messages
 	//

--- a/controllers/ceilometercentral_controller.go
+++ b/controllers/ceilometercentral_controller.go
@@ -282,10 +282,10 @@ func (r *CeilometerCentralReconciler) reconcileNormal(ctx context.Context, insta
 	if err != nil {
 		r.Log.Info("Error getting transportURL. Setting error condition on status and returning")
 		instance.Status.Conditions.Set(condition.FalseCondition(
-			telemetryv1.TelemetryRabbitMqTransportURLReadyCondition,
+			condition.RabbitMqTransportURLReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityWarning,
-			telemetryv1.TelemetryRabbitMqTransportURLReadyErrorMessage,
+			condition.RabbitMqTransportURLReadyErrorMessage,
 			err.Error()))
 		return ctrl.Result{}, err
 	}
@@ -299,14 +299,14 @@ func (r *CeilometerCentralReconciler) reconcileNormal(ctx context.Context, insta
 	if instance.Spec.TransportURLSecret == "" {
 		r.Log.Info(fmt.Sprintf("Waiting for TransportURL %s secret to be created", transportURL.Name))
 		instance.Status.Conditions.Set(condition.FalseCondition(
-			telemetryv1.TelemetryRabbitMqTransportURLReadyCondition,
+			condition.RabbitMqTransportURLReadyCondition,
 			condition.RequestedReason,
 			condition.SeverityInfo,
-			telemetryv1.TelemetryRabbitMqTransportURLReadyRunningMessage))
+			condition.RabbitMqTransportURLReadyRunningMessage))
 		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 	}
 
-	instance.Status.Conditions.MarkTrue(telemetryv1.TelemetryRabbitMqTransportURLReadyCondition, telemetryv1.TelemetryRabbitMqTransportURLReadyMessage)
+	instance.Status.Conditions.MarkTrue(condition.RabbitMqTransportURLReadyCondition, condition.RabbitMqTransportURLReadyMessage)
 	// end transportURL
 
 	// ConfigMap

--- a/controllers/ceilometercompute_controller.go
+++ b/controllers/ceilometercompute_controller.go
@@ -229,10 +229,10 @@ func (r *CeilometerComputeReconciler) reconcileNormal(ctx context.Context, insta
 	if err != nil {
 		r.Log.Info("Error getting transportURL. Setting error condition on status and returning")
 		instance.Status.Conditions.Set(condition.FalseCondition(
-			telemetryv1.TelemetryRabbitMqTransportURLReadyCondition,
+			condition.RabbitMqTransportURLReadyCondition,
 			condition.ErrorReason,
 			condition.SeverityWarning,
-			telemetryv1.TelemetryRabbitMqTransportURLReadyErrorMessage,
+			condition.RabbitMqTransportURLReadyErrorMessage,
 			err.Error()))
 		return ctrl.Result{}, err
 	}
@@ -246,14 +246,14 @@ func (r *CeilometerComputeReconciler) reconcileNormal(ctx context.Context, insta
 	if instance.Spec.TransportURLSecret == "" {
 		r.Log.Info(fmt.Sprintf("Waiting for TransportURL %s secret to be created", transportURL.Name))
 		instance.Status.Conditions.Set(condition.FalseCondition(
-			telemetryv1.TelemetryRabbitMqTransportURLReadyCondition,
+			condition.RabbitMqTransportURLReadyCondition,
 			condition.RequestedReason,
 			condition.SeverityInfo,
-			telemetryv1.TelemetryRabbitMqTransportURLReadyRunningMessage))
+			condition.RabbitMqTransportURLReadyRunningMessage))
 		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 	}
 
-	instance.Status.Conditions.MarkTrue(telemetryv1.TelemetryRabbitMqTransportURLReadyCondition, telemetryv1.TelemetryRabbitMqTransportURLReadyMessage)
+	instance.Status.Conditions.MarkTrue(condition.RabbitMqTransportURLReadyCondition, condition.RabbitMqTransportURLReadyMessage)
 	// end transportURL
 
 	// ConfigMap

--- a/controllers/telemetry_controller.go
+++ b/controllers/telemetry_controller.go
@@ -126,13 +126,8 @@ func (r *TelemetryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		instance.Status.Conditions = condition.Conditions{}
 		// initialize conditions used later as Status=Unknown
 		cl := condition.CreateList(
-			condition.UnknownCondition(condition.RabbitMqTransportURLReadyCondition, condition.InitReason, condition.RabbitMqTransportURLReadyInitMessage),
 			condition.UnknownCondition(telemetryv1.CeilometerCentralReadyCondition, condition.InitReason, telemetryv1.CeilometerCentralReadyInitMessage),
 			condition.UnknownCondition(telemetryv1.CeilometerComputeReadyCondition, condition.InitReason, telemetryv1.CeilometerComputeReadyInitMessage),
-			// service account, role, rolebinding conditions
-			condition.UnknownCondition(condition.ServiceAccountReadyCondition, condition.InitReason, condition.ServiceAccountReadyInitMessage),
-			condition.UnknownCondition(condition.RoleReadyCondition, condition.InitReason, condition.RoleReadyInitMessage),
-			condition.UnknownCondition(condition.RoleBindingReadyCondition, condition.InitReason, condition.RoleBindingReadyInitMessage),
 		)
 
 		instance.Status.Conditions.Init(&cl)

--- a/controllers/telemetry_controller.go
+++ b/controllers/telemetry_controller.go
@@ -126,7 +126,7 @@ func (r *TelemetryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		instance.Status.Conditions = condition.Conditions{}
 		// initialize conditions used later as Status=Unknown
 		cl := condition.CreateList(
-			condition.UnknownCondition(telemetryv1.TelemetryRabbitMqTransportURLReadyCondition, condition.InitReason, telemetryv1.TelemetryRabbitMqTransportURLReadyInitMessage),
+			condition.UnknownCondition(condition.RabbitMqTransportURLReadyCondition, condition.InitReason, condition.RabbitMqTransportURLReadyInitMessage),
 			condition.UnknownCondition(telemetryv1.CeilometerCentralReadyCondition, condition.InitReason, telemetryv1.CeilometerCentralReadyInitMessage),
 			condition.UnknownCondition(telemetryv1.CeilometerComputeReadyCondition, condition.InitReason, telemetryv1.CeilometerComputeReadyInitMessage),
 			// service account, role, rolebinding conditions


### PR DESCRIPTION
We have added the common RabbitMqTransportURLReady to lib-common to reduce duplicate implementations.

Depends-on: https://github.com/openstack-k8s-operators/lib-common/pull/300