### PR TITLE
Update some spec fields for consistency

### DIFF
--- a/api/bases/telemetry.openstack.org_ceilometercentrals.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometercentrals.yaml
@@ -94,9 +94,6 @@ spec:
                 type: string
               sgCoreImage:
                 type: string
-              transportURLSecret:
-                description: The needed values to connect to RabbitMQ
-                type: string
             required:
             - centralImage
             - initImage
@@ -165,6 +162,9 @@ spec:
                 description: ReadyCount of ceilometercentral instances
                 format: int32
                 type: integer
+              transportURLSecret:
+                description: TransportURLSecret - Secret containing RabbitMQ transportURL
+                type: string
             type: object
         type: object
     served: true

--- a/api/bases/telemetry.openstack.org_ceilometercentrals.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometercentrals.yaml
@@ -87,10 +87,6 @@ spec:
                 description: Secret containing OpenStack password information for
                   ceilometer
                 type: string
-              serviceAccount:
-                description: ServiceAccount - service account name used internally
-                  to provide the default SA name
-                type: string
               serviceUser:
                 default: ceilometer
                 description: ServiceUser - optional username used for this service
@@ -106,7 +102,6 @@ spec:
             - initImage
             - notificationImage
             - secret
-            - serviceAccount
             - sgCoreImage
             type: object
           status:

--- a/api/bases/telemetry.openstack.org_ceilometercentrals.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometercentrals.yaml
@@ -84,7 +84,6 @@ spec:
                   that is created and used in Telemetry
                 type: string
               secret:
-                default: osp-secret
                 description: Secret containing OpenStack password information for
                   ceilometer
                 type: string
@@ -106,6 +105,7 @@ spec:
             - centralImage
             - initImage
             - notificationImage
+            - secret
             - serviceAccount
             - sgCoreImage
             type: object

--- a/api/bases/telemetry.openstack.org_ceilometercentrals.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometercentrals.yaml
@@ -53,9 +53,6 @@ spec:
                   to add additional files. Those get added to the service config dir
                   in /etc/<service> . TODO: -> implement'
                 type: object
-              description:
-                default: A ceilometer agent
-                type: string
               initImage:
                 type: string
               networkAttachmentDefinitions:

--- a/api/bases/telemetry.openstack.org_ceilometercomputes.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometercomputes.yaml
@@ -96,10 +96,6 @@ spec:
                 description: Secret containing OpenStack password information for
                   ceilometer
                 type: string
-              serviceAccount:
-                description: ServiceAccount - service account name used internally
-                  to provide the default SA name
-                type: string
               serviceUser:
                 default: ceilometer
                 description: ServiceUser - optional username used for this service
@@ -116,7 +112,6 @@ spec:
             - initImage
             - ipmiImage
             - secret
-            - serviceAccount
             type: object
           status:
             description: CeilometerComputeStatus defines the observed state of CeilometerCompute

--- a/api/bases/telemetry.openstack.org_ceilometercomputes.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometercomputes.yaml
@@ -101,10 +101,6 @@ spec:
                 description: ServiceUser - optional username used for this service
                   to register in keystone
                 type: string
-              transportURLSecret:
-                description: TransportURLSecret contains the needed values to connect
-                  to RabbitMQ
-                type: string
             required:
             - computeImage
             - dataplaneInventoryConfigMap
@@ -168,6 +164,9 @@ spec:
                 description: ReadyCount of ceilometercompute instances
                 format: int32
                 type: integer
+              transportURLSecret:
+                description: TransportURLSecret - Secret containing RabbitMQ transportURL
+                type: string
             type: object
         type: object
     served: true

--- a/api/bases/telemetry.openstack.org_ceilometercomputes.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometercomputes.yaml
@@ -61,9 +61,6 @@ spec:
                   be used to add additional files. Those get added to the service
                   config dir in /etc/<service> . TODO: -> implement'
                 type: object
-              description:
-                default: A ceilometer compute agent
-                type: string
               initImage:
                 description: InitImage is the image used for the init container
                 type: string

--- a/api/bases/telemetry.openstack.org_ceilometercomputes.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometercomputes.yaml
@@ -93,7 +93,6 @@ spec:
                   that is created and used in Telemetry
                 type: string
               secret:
-                default: osp-secret
                 description: Secret containing OpenStack password information for
                   ceilometer
                 type: string
@@ -116,6 +115,7 @@ spec:
             - dataplaneSSHSecret
             - initImage
             - ipmiImage
+            - secret
             - serviceAccount
             type: object
           status:

--- a/api/bases/telemetry.openstack.org_infracomputes.yaml
+++ b/api/bases/telemetry.openstack.org_infracomputes.yaml
@@ -56,15 +56,10 @@ spec:
                 default: deploy_infra.yml
                 description: Playbook executed
                 type: string
-              serviceAccount:
-                description: ServiceAccount - service account name used internally
-                  to provide the default SA name
-                type: string
             required:
             - dataplaneInventoryConfigMap
             - dataplaneSSHSecret
             - nodeExporterImage
-            - serviceAccount
             type: object
           status:
             description: InfraComputeStatus defines the observed state of InfraCompute

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -57,9 +57,6 @@ spec:
                       also be used to add additional files. Those get added to the
                       service config dir in /etc/<service> . TODO: -> implement'
                     type: object
-                  description:
-                    default: A ceilometer agent
-                    type: string
                   initImage:
                     type: string
                   networkAttachmentDefinitions:
@@ -135,9 +132,6 @@ spec:
                       But can also be used to add additional files. Those get added
                       to the service config dir in /etc/<service> . TODO: -> implement'
                     type: object
-                  description:
-                    default: A ceilometer compute agent
-                    type: string
                   initImage:
                     description: InitImage is the image used for the init container
                     type: string
@@ -183,9 +177,6 @@ spec:
                 - ipmiImage
                 - secret
                 type: object
-              description:
-                default: A ceilometer agent
-                type: string
               infraCompute:
                 description: InfraCompute - Spec definition for the InfraCompute service
                   of this Telemetry deployment

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -98,9 +98,6 @@ spec:
                     type: string
                   sgCoreImage:
                     type: string
-                  transportURLSecret:
-                    description: The needed values to connect to RabbitMQ
-                    type: string
                 required:
                 - centralImage
                 - initImage
@@ -177,10 +174,6 @@ spec:
                     default: ceilometer
                     description: ServiceUser - optional username used for this service
                       to register in keystone
-                    type: string
-                  transportURLSecret:
-                    description: TransportURLSecret contains the needed values to
-                      connect to RabbitMQ
                     type: string
                 required:
                 - computeImage

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -88,7 +88,6 @@ spec:
                       that is created and used in Telemetry
                     type: string
                   secret:
-                    default: osp-secret
                     description: Secret containing OpenStack password information
                       for ceilometer
                     type: string
@@ -110,6 +109,7 @@ spec:
                 - centralImage
                 - initImage
                 - notificationImage
+                - secret
                 - serviceAccount
                 - sgCoreImage
                 type: object
@@ -175,7 +175,6 @@ spec:
                       that is created and used in Telemetry
                     type: string
                   secret:
-                    default: osp-secret
                     description: Secret containing OpenStack password information
                       for ceilometer
                     type: string
@@ -198,6 +197,7 @@ spec:
                 - dataplaneSSHSecret
                 - initImage
                 - ipmiImage
+                - secret
                 - serviceAccount
                 type: object
               description:

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -91,10 +91,6 @@ spec:
                     description: Secret containing OpenStack password information
                       for ceilometer
                     type: string
-                  serviceAccount:
-                    description: ServiceAccount - service account name used internally
-                      to provide the default SA name
-                    type: string
                   serviceUser:
                     default: ceilometer
                     description: ServiceUser - optional username used for this service
@@ -110,7 +106,6 @@ spec:
                 - initImage
                 - notificationImage
                 - secret
-                - serviceAccount
                 - sgCoreImage
                 type: object
               ceilometerCompute:
@@ -178,10 +173,6 @@ spec:
                     description: Secret containing OpenStack password information
                       for ceilometer
                     type: string
-                  serviceAccount:
-                    description: ServiceAccount - service account name used internally
-                      to provide the default SA name
-                    type: string
                   serviceUser:
                     default: ceilometer
                     description: ServiceUser - optional username used for this service
@@ -198,7 +189,6 @@ spec:
                 - initImage
                 - ipmiImage
                 - secret
-                - serviceAccount
                 type: object
               description:
                 default: A ceilometer agent
@@ -228,15 +218,10 @@ spec:
                     default: deploy_infra.yml
                     description: Playbook executed
                     type: string
-                  serviceAccount:
-                    description: ServiceAccount - service account name used internally
-                      to provide the default SA name
-                    type: string
                 required:
                 - dataplaneInventoryConfigMap
                 - dataplaneSSHSecret
                 - nodeExporterImage
-                - serviceAccount
                 type: object
             required:
             - ceilometerCentral

--- a/api/v1beta1/ceilometercentral_types.go
+++ b/api/v1beta1/ceilometercentral_types.go
@@ -85,9 +85,6 @@ type CeilometerCentralSpec struct {
 
 	// +kubebuilder:default:="A ceilometer agent"
 	Description string `json:"description,omitempty"`
-
-	// ServiceAccount - service account name used internally to provide the default SA name
-	ServiceAccount string `json:"serviceAccount"`
 }
 
 // CeilometerCentralStatus defines the observed state of CeilometerCentral

--- a/api/v1beta1/ceilometercentral_types.go
+++ b/api/v1beta1/ceilometercentral_types.go
@@ -79,9 +79,6 @@ type CeilometerCentralSpec struct {
 
 	// +kubebuilder:validation:Required
 	InitImage string `json:"initImage"`
-
-	// +kubebuilder:default:="A ceilometer agent"
-	Description string `json:"description,omitempty"`
 }
 
 // CeilometerCentralStatus defines the observed state of CeilometerCentral

--- a/api/v1beta1/ceilometercentral_types.go
+++ b/api/v1beta1/ceilometercentral_types.go
@@ -54,8 +54,7 @@ type CeilometerCentralSpec struct {
 	ServiceUser string `json:"serviceUser"`
 
 	// Secret containing OpenStack password information for ceilometer
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=osp-secret
+	// +kubebuilder:validation:Required
 	Secret string `json:"secret"`
 
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,

--- a/api/v1beta1/ceilometercentral_types.go
+++ b/api/v1beta1/ceilometercentral_types.go
@@ -41,9 +41,6 @@ type CeilometerCentralSpec struct {
 	// +kubebuilder:default=rabbitmq
 	RabbitMqClusterName string `json:"rabbitMqClusterName,omitempty"`
 
-	// The needed values to connect to RabbitMQ
-	TransportURLSecret string `json:"transportURLSecret,omitempty"`
-
 	// PasswordSelectors - Selectors to identify the service from the Secret
 	// +kubebuilder:default:={service: CeilometerPassword}
 	PasswordSelectors PasswordsSelector `json:"passwordSelector,omitempty"`
@@ -97,6 +94,9 @@ type CeilometerCentralStatus struct {
 
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
+
+	// TransportURLSecret - Secret containing RabbitMQ transportURL
+	TransportURLSecret string `json:"transportURLSecret,omitempty"`
 
 	// Networks in addtion to the cluster network, the service is attached to
 	Networks []string `json:"networks,omitempty"`

--- a/api/v1beta1/ceilometercompute_types.go
+++ b/api/v1beta1/ceilometercompute_types.go
@@ -52,8 +52,7 @@ type CeilometerComputeSpec struct {
 	ServiceUser string `json:"serviceUser"`
 
 	// Secret containing OpenStack password information for ceilometer
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=osp-secret
+	// +kubebuilder:validation:Required
 	Secret string `json:"secret"`
 
 	// +kubebuilder:default:="A ceilometer compute agent"

--- a/api/v1beta1/ceilometercompute_types.go
+++ b/api/v1beta1/ceilometercompute_types.go
@@ -39,9 +39,6 @@ type CeilometerComputeSpec struct {
 	// +kubebuilder:default=rabbitmq
 	RabbitMqClusterName string `json:"rabbitMqClusterName,omitempty"`
 
-	// TransportURLSecret contains the needed values to connect to RabbitMQ
-	TransportURLSecret string `json:"transportURLSecret,omitempty"`
-
 	// PasswordSelectors - Selectors to identify the service from the Secret
 	// +kubebuilder:default:={service: CeilometerPassword}
 	PasswordSelectors PasswordsSelector `json:"passwordSelector,omitempty"`
@@ -104,6 +101,9 @@ type CeilometerComputeStatus struct {
 
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
+
+	// TransportURLSecret - Secret containing RabbitMQ transportURL
+	TransportURLSecret string `json:"transportURLSecret,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/ceilometercompute_types.go
+++ b/api/v1beta1/ceilometercompute_types.go
@@ -52,9 +52,6 @@ type CeilometerComputeSpec struct {
 	// +kubebuilder:validation:Required
 	Secret string `json:"secret"`
 
-	// +kubebuilder:default:="A ceilometer compute agent"
-	Description string `json:"description,omitempty"`
-
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
 	// or overwrite rendered information using raw OpenStack config format. The content gets added to
 	// to /etc/<service>/<service>.conf.d directory as custom.conf file.

--- a/api/v1beta1/ceilometercompute_types.go
+++ b/api/v1beta1/ceilometercompute_types.go
@@ -92,9 +92,6 @@ type CeilometerComputeSpec struct {
 	// Playbook executed
 	// +kubebuilder:default:="deploy_ceilometer.yml"
 	Playbook string `json:"playbook,omitempty"`
-
-	// ServiceAccount - service account name used internally to provide the default SA name
-	ServiceAccount string `json:"serviceAccount"`
 }
 
 // CeilometerComputeStatus defines the observed state of CeilometerCompute

--- a/api/v1beta1/infracompute_types.go
+++ b/api/v1beta1/infracompute_types.go
@@ -56,9 +56,6 @@ type InfraComputeSpec struct {
 	// The extravars ConfigMap to pass to ansible execution
 	// +kubebuilder:default:="telemetry-infracompute-extravars"
 	ExtravarsConfigMap string `json:"extravarsConfigMap,omitempty"`
-
-	// ServiceAccount - service account name used internally to provide the default SA name
-	ServiceAccount string `json:"serviceAccount"`
 }
 
 // InfraComputeStatus defines the observed state of InfraCompute

--- a/api/v1beta1/telemetry_types.go
+++ b/api/v1beta1/telemetry_types.go
@@ -33,9 +33,6 @@ type PasswordsSelector struct {
 
 // TelemetrySpec defines the desired state of Telemetry
 type TelemetrySpec struct {
-	// +kubebuilder:default:="A ceilometer agent"
-	Description string `json:"description,omitempty"`
-
 	// +kubebuilder:validation:Required
 	// CeilometerCentral - Spec definition for the CeilometerCentral service of this Telemetry deployment
 	CeilometerCentral CeilometerCentralSpec `json:"ceilometerCentral"`

--- a/config/crd/bases/telemetry.openstack.org_ceilometercentrals.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometercentrals.yaml
@@ -94,9 +94,6 @@ spec:
                 type: string
               sgCoreImage:
                 type: string
-              transportURLSecret:
-                description: The needed values to connect to RabbitMQ
-                type: string
             required:
             - centralImage
             - initImage
@@ -165,6 +162,9 @@ spec:
                 description: ReadyCount of ceilometercentral instances
                 format: int32
                 type: integer
+              transportURLSecret:
+                description: TransportURLSecret - Secret containing RabbitMQ transportURL
+                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/telemetry.openstack.org_ceilometercentrals.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometercentrals.yaml
@@ -87,10 +87,6 @@ spec:
                 description: Secret containing OpenStack password information for
                   ceilometer
                 type: string
-              serviceAccount:
-                description: ServiceAccount - service account name used internally
-                  to provide the default SA name
-                type: string
               serviceUser:
                 default: ceilometer
                 description: ServiceUser - optional username used for this service
@@ -106,7 +102,6 @@ spec:
             - initImage
             - notificationImage
             - secret
-            - serviceAccount
             - sgCoreImage
             type: object
           status:

--- a/config/crd/bases/telemetry.openstack.org_ceilometercentrals.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometercentrals.yaml
@@ -84,7 +84,6 @@ spec:
                   that is created and used in Telemetry
                 type: string
               secret:
-                default: osp-secret
                 description: Secret containing OpenStack password information for
                   ceilometer
                 type: string
@@ -106,6 +105,7 @@ spec:
             - centralImage
             - initImage
             - notificationImage
+            - secret
             - serviceAccount
             - sgCoreImage
             type: object

--- a/config/crd/bases/telemetry.openstack.org_ceilometercentrals.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometercentrals.yaml
@@ -53,9 +53,6 @@ spec:
                   to add additional files. Those get added to the service config dir
                   in /etc/<service> . TODO: -> implement'
                 type: object
-              description:
-                default: A ceilometer agent
-                type: string
               initImage:
                 type: string
               networkAttachmentDefinitions:

--- a/config/crd/bases/telemetry.openstack.org_ceilometercomputes.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometercomputes.yaml
@@ -96,10 +96,6 @@ spec:
                 description: Secret containing OpenStack password information for
                   ceilometer
                 type: string
-              serviceAccount:
-                description: ServiceAccount - service account name used internally
-                  to provide the default SA name
-                type: string
               serviceUser:
                 default: ceilometer
                 description: ServiceUser - optional username used for this service
@@ -116,7 +112,6 @@ spec:
             - initImage
             - ipmiImage
             - secret
-            - serviceAccount
             type: object
           status:
             description: CeilometerComputeStatus defines the observed state of CeilometerCompute

--- a/config/crd/bases/telemetry.openstack.org_ceilometercomputes.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometercomputes.yaml
@@ -101,10 +101,6 @@ spec:
                 description: ServiceUser - optional username used for this service
                   to register in keystone
                 type: string
-              transportURLSecret:
-                description: TransportURLSecret contains the needed values to connect
-                  to RabbitMQ
-                type: string
             required:
             - computeImage
             - dataplaneInventoryConfigMap
@@ -168,6 +164,9 @@ spec:
                 description: ReadyCount of ceilometercompute instances
                 format: int32
                 type: integer
+              transportURLSecret:
+                description: TransportURLSecret - Secret containing RabbitMQ transportURL
+                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/telemetry.openstack.org_ceilometercomputes.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometercomputes.yaml
@@ -61,9 +61,6 @@ spec:
                   be used to add additional files. Those get added to the service
                   config dir in /etc/<service> . TODO: -> implement'
                 type: object
-              description:
-                default: A ceilometer compute agent
-                type: string
               initImage:
                 description: InitImage is the image used for the init container
                 type: string

--- a/config/crd/bases/telemetry.openstack.org_ceilometercomputes.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometercomputes.yaml
@@ -93,7 +93,6 @@ spec:
                   that is created and used in Telemetry
                 type: string
               secret:
-                default: osp-secret
                 description: Secret containing OpenStack password information for
                   ceilometer
                 type: string
@@ -116,6 +115,7 @@ spec:
             - dataplaneSSHSecret
             - initImage
             - ipmiImage
+            - secret
             - serviceAccount
             type: object
           status:

--- a/config/crd/bases/telemetry.openstack.org_infracomputes.yaml
+++ b/config/crd/bases/telemetry.openstack.org_infracomputes.yaml
@@ -56,15 +56,10 @@ spec:
                 default: deploy_infra.yml
                 description: Playbook executed
                 type: string
-              serviceAccount:
-                description: ServiceAccount - service account name used internally
-                  to provide the default SA name
-                type: string
             required:
             - dataplaneInventoryConfigMap
             - dataplaneSSHSecret
             - nodeExporterImage
-            - serviceAccount
             type: object
           status:
             description: InfraComputeStatus defines the observed state of InfraCompute

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -57,9 +57,6 @@ spec:
                       also be used to add additional files. Those get added to the
                       service config dir in /etc/<service> . TODO: -> implement'
                     type: object
-                  description:
-                    default: A ceilometer agent
-                    type: string
                   initImage:
                     type: string
                   networkAttachmentDefinitions:
@@ -135,9 +132,6 @@ spec:
                       But can also be used to add additional files. Those get added
                       to the service config dir in /etc/<service> . TODO: -> implement'
                     type: object
-                  description:
-                    default: A ceilometer compute agent
-                    type: string
                   initImage:
                     description: InitImage is the image used for the init container
                     type: string
@@ -183,9 +177,6 @@ spec:
                 - ipmiImage
                 - secret
                 type: object
-              description:
-                default: A ceilometer agent
-                type: string
               infraCompute:
                 description: InfraCompute - Spec definition for the InfraCompute service
                   of this Telemetry deployment

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -98,9 +98,6 @@ spec:
                     type: string
                   sgCoreImage:
                     type: string
-                  transportURLSecret:
-                    description: The needed values to connect to RabbitMQ
-                    type: string
                 required:
                 - centralImage
                 - initImage
@@ -177,10 +174,6 @@ spec:
                     default: ceilometer
                     description: ServiceUser - optional username used for this service
                       to register in keystone
-                    type: string
-                  transportURLSecret:
-                    description: TransportURLSecret contains the needed values to
-                      connect to RabbitMQ
                     type: string
                 required:
                 - computeImage

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -88,7 +88,6 @@ spec:
                       that is created and used in Telemetry
                     type: string
                   secret:
-                    default: osp-secret
                     description: Secret containing OpenStack password information
                       for ceilometer
                     type: string
@@ -110,6 +109,7 @@ spec:
                 - centralImage
                 - initImage
                 - notificationImage
+                - secret
                 - serviceAccount
                 - sgCoreImage
                 type: object
@@ -175,7 +175,6 @@ spec:
                       that is created and used in Telemetry
                     type: string
                   secret:
-                    default: osp-secret
                     description: Secret containing OpenStack password information
                       for ceilometer
                     type: string
@@ -198,6 +197,7 @@ spec:
                 - dataplaneSSHSecret
                 - initImage
                 - ipmiImage
+                - secret
                 - serviceAccount
                 type: object
               description:

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -91,10 +91,6 @@ spec:
                     description: Secret containing OpenStack password information
                       for ceilometer
                     type: string
-                  serviceAccount:
-                    description: ServiceAccount - service account name used internally
-                      to provide the default SA name
-                    type: string
                   serviceUser:
                     default: ceilometer
                     description: ServiceUser - optional username used for this service
@@ -110,7 +106,6 @@ spec:
                 - initImage
                 - notificationImage
                 - secret
-                - serviceAccount
                 - sgCoreImage
                 type: object
               ceilometerCompute:
@@ -178,10 +173,6 @@ spec:
                     description: Secret containing OpenStack password information
                       for ceilometer
                     type: string
-                  serviceAccount:
-                    description: ServiceAccount - service account name used internally
-                      to provide the default SA name
-                    type: string
                   serviceUser:
                     default: ceilometer
                     description: ServiceUser - optional username used for this service
@@ -198,7 +189,6 @@ spec:
                 - initImage
                 - ipmiImage
                 - secret
-                - serviceAccount
                 type: object
               description:
                 default: A ceilometer agent
@@ -228,15 +218,10 @@ spec:
                     default: deploy_infra.yml
                     description: Playbook executed
                     type: string
-                  serviceAccount:
-                    description: ServiceAccount - service account name used internally
-                      to provide the default SA name
-                    type: string
                 required:
                 - dataplaneInventoryConfigMap
                 - dataplaneSSHSecret
                 - nodeExporterImage
-                - serviceAccount
                 type: object
             required:
             - ceilometerCentral

--- a/config/samples/telemetry_v1beta1_ceilometercentral.yaml
+++ b/config/samples/telemetry_v1beta1_ceilometercentral.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: openstack
 spec:
   secret: osp-secret
-  serviceAccount: telemetry-operator-telemetry
   initImage: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
   centralImage: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
   notificationImage: quay.io/podified-antelope-centos9/openstack-ceilometer-notification:current-podified

--- a/config/samples/telemetry_v1beta1_ceilometercentral.yaml
+++ b/config/samples/telemetry_v1beta1_ceilometercentral.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ceilometercentral
   namespace: openstack
 spec:
+  secret: osp-secret
   serviceAccount: telemetry-operator-telemetry
   initImage: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
   centralImage: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified

--- a/config/samples/telemetry_v1beta1_ceilometercompute.yaml
+++ b/config/samples/telemetry_v1beta1_ceilometercompute.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ceilometercompute
   namespace: openstack
 spec:
+  secret: osp-secret
   serviceAccount: telemetry-operator-telemetry
   dataplaneSSHSecret: dataplane-ansible-ssh-private-key-secret
   dataplaneInventoryConfigMap: dataplanerole-edpm-compute

--- a/config/samples/telemetry_v1beta1_ceilometercompute.yaml
+++ b/config/samples/telemetry_v1beta1_ceilometercompute.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: openstack
 spec:
   secret: osp-secret
-  serviceAccount: telemetry-operator-telemetry
   dataplaneSSHSecret: dataplane-ansible-ssh-private-key-secret
   dataplaneInventoryConfigMap: dataplanerole-edpm-compute
   initImage: quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified

--- a/config/samples/telemetry_v1beta1_infracompute.yaml
+++ b/config/samples/telemetry_v1beta1_infracompute.yaml
@@ -4,7 +4,6 @@ metadata:
   name: infracompute
   namespace: openstack
 spec:
-  serviceAccount: telemetry-operator-telemetry
   dataplaneSSHSecret: dataplane-ansible-ssh-private-key-secret
   dataplaneInventoryConfigMap: dataplanerole-edpm-compute
   nodeExporterImage: quay.io/prometheus/node-exporter:v1.5.0

--- a/config/samples/telemetry_v1beta1_telemetry.yaml
+++ b/config/samples/telemetry_v1beta1_telemetry.yaml
@@ -9,16 +9,13 @@ spec:
     centralImage: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
     notificationImage: quay.io/podified-antelope-centos9/openstack-ceilometer-notification:current-podified
     sgCoreImage: quay.io/infrawatch/sg-core:latest
-    serviceAccount: telemetry-operator-telemetry
   ceilometerCompute:
     initImage: quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified
     computeImage: quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified
     ipmiImage: quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi:current-podified
     dataplaneSSHSecret: dataplane-ansible-ssh-private-key-secret
     dataplaneInventoryConfigMap: dataplanerole-edpm-compute
-    serviceAccount: telemetry-operator-telemetry
   infraCompute:
     nodeExporterImage: quay.io/prometheus/node-exporter:v1.5.0
-    serviceAccount: telemetry-operator-telemetry
     dataplaneSSHSecret: dataplane-ansible-ssh-private-key-secret
     dataplaneInventoryConfigMap: dataplanerole-edpm-compute

--- a/controllers/ceilometercentral_controller.go
+++ b/controllers/ceilometercentral_controller.go
@@ -294,9 +294,9 @@ func (r *CeilometerCentralReconciler) reconcileNormal(ctx context.Context, insta
 		r.Log.Info(fmt.Sprintf("TransportURL %s successfully reconciled - operation: %s", transportURL.Name, string(op)))
 	}
 
-	instance.Spec.TransportURLSecret = transportURL.Status.SecretName
+	instance.Status.TransportURLSecret = transportURL.Status.SecretName
 
-	if instance.Spec.TransportURLSecret == "" {
+	if instance.Status.TransportURLSecret == "" {
 		r.Log.Info(fmt.Sprintf("Waiting for TransportURL %s secret to be created", transportURL.Name))
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.RabbitMqTransportURLReadyCondition,
@@ -324,7 +324,7 @@ func (r *CeilometerCentralReconciler) reconcileNormal(ctx context.Context, insta
 	//
 	// check for required TransportURL secret holding transport URL string
 	//
-	ctrlResult, err = r.getSecret(ctx, helper, instance, instance.Spec.TransportURLSecret, &configMapVars)
+	ctrlResult, err = r.getSecret(ctx, helper, instance, instance.Status.TransportURLSecret, &configMapVars)
 	if err != nil {
 		return ctrlResult, err
 	}

--- a/controllers/ceilometercompute_controller.go
+++ b/controllers/ceilometercompute_controller.go
@@ -241,9 +241,9 @@ func (r *CeilometerComputeReconciler) reconcileNormal(ctx context.Context, insta
 		r.Log.Info(fmt.Sprintf("TransportURL %s successfully reconciled - operation: %s", transportURL.Name, string(op)))
 	}
 
-	instance.Spec.TransportURLSecret = transportURL.Status.SecretName
+	instance.Status.TransportURLSecret = transportURL.Status.SecretName
 
-	if instance.Spec.TransportURLSecret == "" {
+	if instance.Status.TransportURLSecret == "" {
 		r.Log.Info(fmt.Sprintf("Waiting for TransportURL %s secret to be created", transportURL.Name))
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.RabbitMqTransportURLReadyCondition,
@@ -271,7 +271,7 @@ func (r *CeilometerComputeReconciler) reconcileNormal(ctx context.Context, insta
 	//
 	// check for required TransportURL secret holding transport URL string
 	//
-	ctrlResult, err = r.getSecret(ctx, helper, instance, instance.Spec.TransportURLSecret, &configMapVars)
+	ctrlResult, err = r.getSecret(ctx, helper, instance, instance.Status.TransportURLSecret, &configMapVars)
 	if err != nil {
 		return ctrlResult, err
 	}

--- a/pkg/ceilometercentral/deployment.go
+++ b/pkg/ceilometercentral/deployment.go
@@ -164,7 +164,7 @@ func Deployment(
 
 	initContainerDetails := APIDetails{
 		ContainerImage:     instance.Spec.InitImage,
-		TransportURLSecret: instance.Spec.TransportURLSecret,
+		TransportURLSecret: instance.Status.TransportURLSecret,
 		OSPSecret:          instance.Spec.Secret,
 		ServiceSelector:    instance.Spec.PasswordSelectors.Service,
 	}

--- a/pkg/ceilometercompute/ansibleee.go
+++ b/pkg/ceilometercompute/ansibleee.go
@@ -31,7 +31,7 @@ func AnsibleEE(
 
 	initContainerDetails := APIDetails{
 		ContainerImage:     instance.Spec.InitImage,
-		TransportURLSecret: instance.Spec.TransportURLSecret,
+		TransportURLSecret: instance.Status.TransportURLSecret,
 		OSPSecret:          instance.Spec.Secret,
 		ServiceSelector:    instance.Spec.PasswordSelectors.Service,
 	}


### PR DESCRIPTION
In most of our operators the `spec.secret` field is required. Let's follow that instead of adding the default value.

Also currently `spec.transportURLSecret` is updated by the controller but we should not update Spec but should use Status. This fixes it and ensure the value is stored in the new status field.

Finally This removes `spec.serviceAccount` and `spec.Description` which are not used.
