### PR TITLE
Support disconnected network environments

### DIFF
--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -1,69 +1,13 @@
 #!/bin/bash
 set -e
 
-CLUSTER_BUNDLE_FILE="bundle/manifests/telemetry-operator.clusterserviceversion.yaml"
-
 echo "Creating telemetry operator bundle"
 cd ..
 echo "${GITHUB_SHA}"
 echo "${BASE_IMAGE}"
-skopeo --version
-
-echo "Calculating image digest for docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA}"
-DIGEST=$(skopeo inspect docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} | jq '.Digest' -r)
-# Output:
-# Calculating image digest for docker://quay.io/openstack-k8s-operators/telemetry-operator:d03f2c1c362c04fc5ef819f92a218f9ea59bbd0c
-# Digest: sha256:1d5b578fd212f8dbd03c0235f1913ef738721766f8c94236af5efecc6d8d8cb1
-echo "Digest: ${DIGEST}"
 
 RELEASE_VERSION=$(grep "^VERSION" Makefile | awk -F'?= ' '{ print $2 }')
-OPERATOR_IMG_WITH_DIGEST="${REGISTRY}/${BASE_IMAGE}@${DIGEST}"
-
-echo "New Operator Image with Digest: $OPERATOR_IMG_WITH_DIGEST"
 echo "Release Version: $RELEASE_VERSION"
 
 echo "Creating bundle image..."
-VERSION=$RELEASE_VERSION IMG=$OPERATOR_IMG_WITH_DIGEST make bundle
-
-echo "Bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
-
-# We do not want to exit here. Some images are in different registries, so
-# error will be reported to the console.
-set +e
-for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep "image:" | sed -e "s|.*image:||" | sort -u); do
-    digest_image=""
-    echo "CSV line: ${csv_image}"
-
-    # case where @ is in the csv_image image
-    if [[ "$csv_image" =~ .*"@".* ]]; then
-        delimeter='@'
-    else
-        delimeter=':'
-    fi
-
-    base_image=$(echo $csv_image | cut -f 1 -d${delimeter})
-    tag_image=$(echo $csv_image | cut -f 2 -d${delimeter})
-
-    if [[ "$base_image:$tag_image" == "controller:latest" ]]; then
-        echo "$base_image:$tag_image becomes $OPERATOR_IMG_WITH_DIGEST"
-        sed -e "s|$base_image:$tag_image|$OPERATOR_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
-    else
-        digest_image=$(skopeo inspect docker://${base_image}${delimeter}${tag_image} | jq '.Digest' -r)
-        echo "Base image: $base_image"
-        if [ -n "$digest_image" ]; then
-            echo "$base_image${delimeter}$tag_image becomes $base_image@$digest_image"
-            sed -i "s|$base_image$delimeter$tag_image|$base_image@$digest_image|g" "${CLUSTER_BUNDLE_FILE}"
-        else
-            echo "$base_image${delimeter}$tag_image not changed"
-        fi
-    fi
-done
-
-echo "Resulting bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
+USE_IMAGE_DIGESTS=true VERSION=$RELEASE_VERSION IMG=${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} make bundle

--- a/api/v1beta1/ceilometercentral_types.go
+++ b/api/v1beta1/ceilometercentral_types.go
@@ -148,10 +148,10 @@ func (instance CeilometerCentral) RbacResourceName() string {
 func SetupDefaultsCeilometerCentral() {
 	// Acquire environmental defaults and initialize Telemetry defaults with them
 	ceilometercentralDefaults := CeilometerCentralDefaults{
-		CentralContainerImageURL:      util.GetEnvVar("CEILOMETER_CENTRAL_IMAGE_URL_DEFAULT", CeilometerCentralContainerImage),
-		CentralInitContainerImageURL:  util.GetEnvVar("CEILOMETER_CENTRAL_INIT_IMAGE_URL_DEFAULT", CeilometerCentralInitContainerImage),
-		SgCoreContainerImageURL:       util.GetEnvVar("CEILOMETER_SGCORE_IMAGE_URL_DEFAULT", CeilometerSgCoreContainerImage),
-		NotificationContainerImageURL: util.GetEnvVar("CEILOMETER_NOTIFICATION_IMAGE_URL_DEFAULT", CeilometerNotificationContainerImage),
+		CentralContainerImageURL:      util.GetEnvVar("RELATED_IMAGE_CEILOMETER_CENTRAL_IMAGE_URL_DEFAULT", CeilometerCentralContainerImage),
+		CentralInitContainerImageURL:  util.GetEnvVar("RELATED_IMAGE_CEILOMETER_CENTRAL_INIT_IMAGE_URL_DEFAULT", CeilometerCentralInitContainerImage),
+		SgCoreContainerImageURL:       util.GetEnvVar("RELATED_IMAGE_CEILOMETER_SGCORE_IMAGE_URL_DEFAULT", CeilometerSgCoreContainerImage),
+		NotificationContainerImageURL: util.GetEnvVar("RELATED_IMAGE_CEILOMETER_NOTIFICATION_IMAGE_URL_DEFAULT", CeilometerNotificationContainerImage),
 	}
 
 	SetupCeilometerCentralDefaults(ceilometercentralDefaults)

--- a/api/v1beta1/ceilometercompute_types.go
+++ b/api/v1beta1/ceilometercompute_types.go
@@ -152,9 +152,9 @@ func (instance CeilometerCompute) RbacResourceName() string {
 func SetupDefaultsCeilometerCompute() {
 	// Acquire environmental defaults and initialize Telemetry defaults with them
 	ceilometercomputeDefaults := CeilometerComputeDefaults{
-		ComputeContainerImageURL:      util.GetEnvVar("CEILOMETER_COMPUTE_IMAGE_URL_DEFAULT", CeilometerComputeContainerImage),
-		ComputeInitContainerImageURL:  util.GetEnvVar("CEILOMETER_COMPUTE_INIT_IMAGE_URL_DEFAULT", CeilometerComputeInitContainerImage),
-		IpmiContainerImageURL:         util.GetEnvVar("CEILOMETER_IPMI_IMAGE_URL_DEFAULT", CeilometerIpmiContainerImage),
+		ComputeContainerImageURL:      util.GetEnvVar("RELATED_IMAGE_CEILOMETER_COMPUTE_IMAGE_URL_DEFAULT", CeilometerComputeContainerImage),
+		ComputeInitContainerImageURL:  util.GetEnvVar("RELATED_IMAGE_CEILOMETER_COMPUTE_INIT_IMAGE_URL_DEFAULT", CeilometerComputeInitContainerImage),
+		IpmiContainerImageURL:         util.GetEnvVar("RELATED_IMAGE_CEILOMETER_IPMI_IMAGE_URL_DEFAULT", CeilometerIpmiContainerImage),
 	}
 
 	SetupCeilometerComputeDefaults(ceilometercomputeDefaults)

--- a/api/v1beta1/infracompute_types.go
+++ b/api/v1beta1/infracompute_types.go
@@ -119,7 +119,7 @@ func (instance InfraCompute) RbacResourceName() string {
 func SetupDefaultsInfraCompute() {
 	// Acquire environmental defaults and initialize Telemetry defaults with them
 	infracomputeDefaults := InfraComputeDefaults{
-		NodeExporterContainerImageURL: util.GetEnvVar("TELEMETRY_NODE_EXPORTER_IMAGE_URL_DEFAULT", NodeExporterContainerImage),
+		NodeExporterContainerImageURL: util.GetEnvVar("RELATED_IMAGE_TELEMETRY_NODE_EXPORTER_IMAGE_URL_DEFAULT", NodeExporterContainerImage),
 	}
 
 	SetupInfraComputeDefaults(infracomputeDefaults)

--- a/api/v1beta1/telemetry_types.go
+++ b/api/v1beta1/telemetry_types.go
@@ -98,14 +98,14 @@ func init() {
 func SetupDefaultsTelemetry() {
 	// Acquire environmental defaults and initialize Telemetry defaults with them
 	telemetryDefaults := TelemetryDefaults{
-		CentralContainerImageURL:      util.GetEnvVar("CEILOMETER_CENTRAL_IMAGE_URL_DEFAULT", CeilometerCentralContainerImage),
-		CentralInitContainerImageURL:  util.GetEnvVar("CEILOMETER_CENTRAL_INIT_IMAGE_URL_DEFAULT", CeilometerCentralInitContainerImage),
-		ComputeContainerImageURL:      util.GetEnvVar("CEILOMETER_COMPUTE_IMAGE_URL_DEFAULT", CeilometerComputeContainerImage),
-		ComputeInitContainerImageURL:  util.GetEnvVar("CEILOMETER_COMPUTE_INIT_IMAGE_URL_DEFAULT", CeilometerComputeInitContainerImage),
-		IpmiContainerImageURL:         util.GetEnvVar("CEILOMETER_IPMI_IMAGE_URL_DEFAULT", CeilometerIpmiContainerImage),
-		NotificationContainerImageURL: util.GetEnvVar("CEILOMETER_NOTIFICATION_IMAGE_URL_DEFAULT", CeilometerNotificationContainerImage),
-		NodeExporterContainerImageURL: util.GetEnvVar("TELEMETRY_NODE_EXPORTER_IMAGE_URL_DEFAULT", NodeExporterContainerImage),
-		SgCoreContainerImageURL:       util.GetEnvVar("CEILOMETER_SGCORE_IMAGE_URL_DEFAULT", CeilometerSgCoreContainerImage),
+		CentralContainerImageURL:      util.GetEnvVar("RELATED_IMAGE_CEILOMETER_CENTRAL_IMAGE_URL_DEFAULT", CeilometerCentralContainerImage),
+		CentralInitContainerImageURL:  util.GetEnvVar("RELATED_IMAGE_CEILOMETER_CENTRAL_INIT_IMAGE_URL_DEFAULT", CeilometerCentralInitContainerImage),
+		ComputeContainerImageURL:      util.GetEnvVar("RELATED_IMAGE_CEILOMETER_COMPUTE_IMAGE_URL_DEFAULT", CeilometerComputeContainerImage),
+		ComputeInitContainerImageURL:  util.GetEnvVar("RELATED_IMAGE_CEILOMETER_COMPUTE_INIT_IMAGE_URL_DEFAULT", CeilometerComputeInitContainerImage),
+		IpmiContainerImageURL:         util.GetEnvVar("RELATED_IMAGE_CEILOMETER_IPMI_IMAGE_URL_DEFAULT", CeilometerIpmiContainerImage),
+		NotificationContainerImageURL: util.GetEnvVar("RELATED_IMAGE_CEILOMETER_NOTIFICATION_IMAGE_URL_DEFAULT", CeilometerNotificationContainerImage),
+		NodeExporterContainerImageURL: util.GetEnvVar("RELATED_IMAGE_TELEMETRY_NODE_EXPORTER_IMAGE_URL_DEFAULT", NodeExporterContainerImage),
+		SgCoreContainerImageURL:       util.GetEnvVar("RELATED_IMAGE_CEILOMETER_SGCORE_IMAGE_URL_DEFAULT", CeilometerSgCoreContainerImage),
 	}
 
 	SetupTelemetryDefaults(telemetryDefaults)

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,19 +11,19 @@ spec:
       containers:
       - name: manager
         env:
-        - name: CEILOMETER_CENTRAL_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_CEILOMETER_CENTRAL_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
-        - name: CEILOMETER_CENTRAL_INIT_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_CEILOMETER_CENTRAL_INIT_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ceilometer-central:current-podified
-        - name: CEILOMETER_COMPUTE_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_CEILOMETER_COMPUTE_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified
-        - name: CEILOMETER_COMPUTE_INIT_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_CEILOMETER_COMPUTE_INIT_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified
-        - name: CEILOMETER_NOTIFICATION_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_CEILOMETER_NOTIFICATION_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ceilometer-notification:current-podified
-        - name: CEILOMETER_IPMI_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_CEILOMETER_IPMI_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi:current-podified
-        - name: CEILOMETER_SGCORE_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_CEILOMETER_SGCORE_IMAGE_URL_DEFAULT
           value: quay.io/infrawatch/sg-core:latest
-        - name: TELEMETRY_NODE_EXPORTER_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_TELEMETRY_NODE_EXPORTER_IMAGE_URL_DEFAULT
           value: quay.io/prometheus/node-exporter:v1.5.0

--- a/config/manifests/bases/telemetry-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/telemetry-operator.clusterserviceversion.yaml
@@ -5,6 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     operatorframework.io/suggested-namespace: openstack
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/operator-type: non-standalone
   name: telemetry-operator.v0.0.0
   namespace: placeholder


### PR DESCRIPTION
This PR adds support for installing the operator in disconnected network environments. To build with image-digests set USE_IMAGE_DIGESTS=true before running make bundle.

For Prow jobs we are enabling this via .prow-ci.env

This drops the old logic from create_bundle.sh which has been broken with operator-sdk's make bundle for some time.

(NOTE: this currently requires a secure registry)

Jira: [OSP-26486](https://issues.redhat.com//browse/OSP-26486)