### PR TITLE
Restoring code for reconcilliation on hash change

### DIFF
--- a/controllers/ceilometercentral_controller.go
+++ b/controllers/ceilometercentral_controller.go
@@ -356,18 +356,14 @@ func (r *CeilometerCentralReconciler) reconcileNormal(ctx context.Context, insta
 	// and a restart/recreate is required.
 	//
 	inputHash, hashChanged, err := r.createHashOfInputHashes(ctx, instance, configMapVars)
-	fmt.Printf("hashChanged: %v\n", hashChanged)
+	r.Log.Info("hashChanged: %v\n", hashChanged)
 	if err != nil {
-		return ctrl.Result{}, err
-	}
-	/*if err != nil {
 		return ctrl.Result{}, err
 	} else if hashChanged {
 		// Hash changed and instance status should be updated (which will be done by main defer func),
 		// so we need to return and reconcile again
 		return ctrl.Result{}, nil
 	}
-	fmt.Printf("MarkTrue\n")*/
 	instance.Status.Conditions.MarkTrue(condition.ServiceConfigReadyCondition, condition.ServiceConfigReadyMessage)
 
 	serviceLabels := map[string]string{


### PR DESCRIPTION
I'm not sure why was this removed in the first place, but it has been commented out since the file was added. 

Depending on the reason we may want to remove it entirely, replace it, or restore it like here.