### PR TITLE
use upstream kube-rbac-proxy instead of downstream

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
         # capabilities:
         #   drop:
         #     - "ALL"
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.11
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/samples/deploy.yaml
+++ b/config/samples/deploy.yaml
@@ -449,7 +449,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.11
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
should fix

```
time="2023-09-04T10:37:10Z" level=fatal msg="Error generating bundle manifests: error resolving image: GET https://registry.redhat.io/auth/realms/rhcc/protocol/redhat-docker-v2/auth?scope=repository%3Aopenshift4%2Fose-kube-rbac-proxy%3Apull&service=docker-registry: UNAUTHORIZED: Please login to the Red Hat Registry using your Customer Portal credentials. Further instructions can be found here: https://access.redhat.com/RegistryAuthentication"
```