### PR TITLE
Observability-operator dependency fix

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -123,6 +123,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - monitoring.rhobs
+  resources:
+  - monitoringstacks
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - rabbitmq.openstack.org
   resources:
   - transporturls

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -40,6 +40,13 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/controllers/autoscaling_controller.go
+++ b/controllers/autoscaling_controller.go
@@ -56,6 +56,7 @@ type AutoscalingReconciler struct {
 // +kubebuilder:rbac:groups=telemetry.openstack.org,resources=autoscalings/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=telemetry.openstack.org,resources=autoscalings/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list
+// +kubebuilder:rbac:groups=monitoring.rhobs,resources=monitoringstacks,verbs=get;list;watch
 
 // Reconcile reconciles an Autoscaling
 func (r *AutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/autoscaling_controller.go
+++ b/controllers/autoscaling_controller.go
@@ -21,7 +21,9 @@ import (
 	"fmt"
 
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,6 +55,7 @@ type AutoscalingReconciler struct {
 // +kubebuilder:rbac:groups=telemetry.openstack.org,resources=autoscalings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=telemetry.openstack.org,resources=autoscalings/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=telemetry.openstack.org,resources=autoscalings/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list
 
 // Reconcile reconciles an Autoscaling
 func (r *AutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -390,6 +393,21 @@ func (r *AutoscalingReconciler) reconcilePrometheus(ctx context.Context,
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AutoscalingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Kind:    "CustomResourceDefinition",
+		Version: "v1",
+	})
+	err := r.Client.Get(context.Background(), client.ObjectKey{
+		Name: "monitoringstacks.monitoring.rhobs",
+	}, u)
+	if err != nil {
+		return ctrl.NewControllerManagedBy(mgr).
+			For(&telemetryv1.Autoscaling{}).
+			Complete(r)
+	}
+	// There is OBO installed and we can own MonitoringStack
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&telemetryv1.Autoscaling{}).
 		Owns(&obov1.MonitoringStack{}).


### PR DESCRIPTION
There was an issue, when the telemetry-operator was trying to own a MonitoringStack even if the observability-operator wasn't installed and because of that there was no MonitoringStack CRD. This pull request adds a check if the MonitoringStack CRD exists before trying to own it.