### PR TITLE
Fix creation of CRD manifests via kustomize during build

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -4,6 +4,7 @@
 resources:
 - bases/telemetry.openstack.org_telemetries.yaml
 - bases/telemetry.openstack.org_autoscalings.yaml
+- bases/telemetry.openstack.org_ceilometers.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/manifests/bases/telemetry-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/telemetry-operator.clusterserviceversion.yaml
@@ -13,6 +13,11 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: Autoscaling is the Schema for the autoscalings API
+      displayName: Autoscaling
+      kind: Autoscaling
+      name: autoscalings.telemetry.openstack.org
+      version: v1beta1
     - description: Ceilometer is the Schema for the ceilometers API
       displayName: Ceilometer
       kind: Ceilometer


### PR DESCRIPTION
Fixes this issue:

```
{"level":"error","ts":"2023-09-13T14:34:20.192Z","logger":"controller-runtime.source","msg":"if kind is a CRD, it should be installed before calling Start","kind":"Ceilometer.telemetry.openstack.org","error":"no matches for kind \"Ceilometer\" in version \"telemetry.openstack.org/v1beta1\""...
```