### PR TITLE
Use database helpers from mariadb-operator/api

### DIFF
--- a/controllers/aodh_controller.go
+++ b/controllers/aodh_controller.go
@@ -36,7 +36,7 @@ import (
 	secret "github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	service "github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
-	database "github.com/openstack-k8s-operators/lib-common/modules/database"
+	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 
 	routev1 "github.com/openshift/api/route/v1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
@@ -78,7 +78,7 @@ func (r *AutoscalingReconciler) reconcileDisabledAodh(
 	}
 
 	// Delete db
-	db, err := database.GetDatabaseByName(ctx, helper, autoscaling.ServiceName)
+	db, err := mariadbv1.GetDatabaseByName(ctx, helper, autoscaling.ServiceName)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
@@ -156,7 +156,7 @@ func (r *AutoscalingReconciler) reconcileDeleteAodh(
 	r.Log.Info("Reconciling Service Aodh delete")
 
 	// remove db finalizer first
-	db, err := database.GetDatabaseByName(ctx, helper, autoscaling.ServiceName)
+	db, err := mariadbv1.GetDatabaseByName(ctx, helper, autoscaling.ServiceName)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
@@ -250,7 +250,7 @@ func (r *AutoscalingReconciler) reconcileInitAodh(
 	//
 	// create service DB instance
 	//
-	db := database.NewDatabaseWithNamespace(
+	db := mariadbv1.NewDatabaseWithNamespace(
 		// instance.Name
 		// TODO: We might want to change the db name.
 		// The mariadb-operator is currently implemented

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,7 @@ require (
 	github.com/openstack-k8s-operators/infra-operator/apis v0.1.1-0.20230905074428-c6aefc16dd01
 	github.com/openstack-k8s-operators/keystone-operator/api v0.1.1-0.20230830083045-d73d07cca617
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.1.1-0.20230927082538-4f614f333d17
-	github.com/openstack-k8s-operators/lib-common/modules/database v0.1.0
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.0
 	github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.1.1-0.20230904091032-d53c9286b6a4
 	github.com/openstack-k8s-operators/telemetry-operator/api v0.1.1-0.20230904141420-35a75e39495a
 	github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring v0.64.1-rhobs3

--- a/go.sum
+++ b/go.sum
@@ -147,14 +147,12 @@ github.com/openstack-k8s-operators/keystone-operator/api v0.1.1-0.20230830083045
 github.com/openstack-k8s-operators/keystone-operator/api v0.1.1-0.20230830083045-d73d07cca617/go.mod h1:CmUe4tHh990eRUj6Ou8gD9JE0PQ38LGnUu3kaaP8K50=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.1.1-0.20230927082538-4f614f333d17 h1:n5QmZLJfPtKbNnPVqqSQkLU1X/NMmW3CbML3yjBUjyY=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.1.1-0.20230927082538-4f614f333d17/go.mod h1:kZS5rqVWBZeCyYor2PeQB9IEZ19mGaeL/to3x8F9OJg=
-github.com/openstack-k8s-operators/lib-common/modules/database v0.1.0 h1:JWLX0pyQXANEULDbjv4rWcYQ8y4OSqnQl0L6O/gIv7U=
-github.com/openstack-k8s-operators/lib-common/modules/database v0.1.0/go.mod h1:bbauLidBocb/iigxC0D4fIbqjkvR80o6fsKpOGyVk00=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.20230824094610-976b18ca2875 h1:aUlwELsLYWQ3FL+/nRG/1uGVNW86c3MhtLrHNVDd57k=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.20230824094610-976b18ca2875/go.mod h1:Vng+vqdTJUuZ+AEzSAaU0I7bn3qwYMMFEUHHhiH0440=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.1.1-0.20230824094610-976b18ca2875 h1:lC8Nw4PF2Lcqc7BJAdlBvYPyLqyaKa9R1e15dM9b3BY=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.1.1-0.20230824094610-976b18ca2875/go.mod h1:lazDTPD8BYde2yyzZ3HbOfG51Sf87vSr4KXwpF57hDs=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0 h1:oM0ZzFHHj+ioCc7NXHIO6+sy7I2yiN29DI9/jh4fe54=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.0/go.mod h1:m5XuZSa5Zt5uAw3WbJYOIkFAGXy01mybVekcKOq1qHI=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.0 h1:FB0xB6whYM6W4XIncYo2mPiOJWkFsIOWtCT+UOtvOaQ=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.0/go.mod h1:xhiz5wFdKWwVM7BF/VYon4TT3NuUPXp/Pyn2hWcp0CE=
 github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.1.1-0.20230904091032-d53c9286b6a4 h1:lzEcJf9tyzBtVdL889++2NqyqGI34RX87u/fsQWstHw=
 github.com/openstack-k8s-operators/openstack-ansibleee-operator/api v0.1.1-0.20230904091032-d53c9286b6a4/go.mod h1:gCsHjYsZWdF8DOd4MH++2RZ+tF/VOuhhaVXWB7HrLCg=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
The database helpers got moved from lib-common to mariadb-operator to deal with circular dependencies: https://github.com/openstack-k8s-operators/lib-common/pull/352