### PR TITLE
update logging

### DIFF
--- a/controllers/aodh_controller.go
+++ b/controllers/aodh_controller.go
@@ -49,7 +49,8 @@ func (r *AutoscalingReconciler) reconcileDisabledAodh(
 	instance *telemetryv1.Autoscaling,
 	helper *helper.Helper,
 ) (ctrl.Result, error) {
-	r.Log.Info("Reconciling Service Aodh disabled")
+	Log := r.GetLogger(ctx)
+	Log.Info("Reconciling Service Aodh disabled")
 	serviceLabels := map[string]string{
 		common.AppSelector: autoscaling.ServiceName,
 	}
@@ -144,7 +145,7 @@ func (r *AutoscalingReconciler) reconcileDisabledAodh(
 		return ctrl.Result{}, err
 	}
 	instance.Status.Conditions = condition.Conditions{}
-	r.Log.Info(fmt.Sprintf("Reconciled Service Aodh '%s' disable successfully", autoscaling.ServiceName))
+	Log.Info(fmt.Sprintf("Reconciled Service Aodh '%s' disable successfully", autoscaling.ServiceName))
 	return ctrl.Result{}, nil
 }
 
@@ -153,7 +154,8 @@ func (r *AutoscalingReconciler) reconcileDeleteAodh(
 	instance *telemetryv1.Autoscaling,
 	helper *helper.Helper,
 ) (ctrl.Result, error) {
-	r.Log.Info("Reconciling Service Aodh delete")
+	Log := r.GetLogger(ctx)
+	Log.Info("Reconciling Service Aodh delete")
 
 	// remove db finalizer first
 	db, err := mariadbv1.GetDatabaseByName(ctx, helper, autoscaling.ServiceName)
@@ -197,7 +199,7 @@ func (r *AutoscalingReconciler) reconcileDeleteAodh(
 			util.LogForObject(helper, "Removed finalizer from our KeystoneEndpoint", instance)
 		}
 	}
-	r.Log.Info(fmt.Sprintf("Reconciled Service Aodh '%s' delete successfully", autoscaling.ServiceName))
+	Log.Info(fmt.Sprintf("Reconciled Service Aodh '%s' delete successfully", autoscaling.ServiceName))
 
 	return ctrl.Result{}, nil
 }
@@ -208,7 +210,8 @@ func (r *AutoscalingReconciler) reconcileInitAodh(
 	helper *helper.Helper,
 	serviceLabels map[string]string,
 ) (ctrl.Result, error) {
-	r.Log.Info("Reconciling Service Aodh init")
+	Log := r.GetLogger(ctx)
+	Log.Info("Reconciling Service Aodh init")
 	_, _, err := secret.GetSecret(ctx, helper, instance.Spec.Aodh.Secret, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
@@ -347,12 +350,12 @@ func (r *AutoscalingReconciler) reconcileInitAodh(
 	}
 	if dbSyncjob.HasChanged() {
 		instance.Status.Hash[telemetryv1.DbSyncHash] = dbSyncjob.GetHash()
-		r.Log.Info(fmt.Sprintf("Service '%s' - Job %s hash added - %s", instance.Name, jobDef.Name, instance.Status.Hash[telemetryv1.DbSyncHash]))
+		Log.Info(fmt.Sprintf("Service '%s' - Job %s hash added - %s", instance.Name, jobDef.Name, instance.Status.Hash[telemetryv1.DbSyncHash]))
 	}
 	instance.Status.Conditions.MarkTrue(condition.DBSyncReadyCondition, condition.DBSyncReadyMessage)
 
 	// run Aodh db sync - end
-	r.Log.Info("Reconciled Service Aodh init successfully")
+	Log.Info("Reconciled Service Aodh init successfully")
 	return ctrl.Result{}, nil
 }
 
@@ -362,7 +365,8 @@ func (r *AutoscalingReconciler) reconcileNormalAodh(
 	helper *helper.Helper,
 	inputHash string,
 ) (ctrl.Result, error) {
-	r.Log.Info(fmt.Sprintf("Reconciling Service Aodh '%s'", autoscaling.ServiceName))
+	Log := r.GetLogger(ctx)
+	Log.Info(fmt.Sprintf("Reconciling Service Aodh '%s'", autoscaling.ServiceName))
 	serviceLabels := map[string]string{
 		common.AppSelector: autoscaling.ServiceName,
 	}
@@ -543,6 +547,6 @@ func (r *AutoscalingReconciler) reconcileNormalAodh(
 		return ctrlResult, nil
 	}
 
-	r.Log.Info("Reconciled Service Aodh successfully")
+	Log.Info("Reconciled Service Aodh successfully")
 	return ctrl.Result{}, nil
 }

--- a/controllers/prometheus_controller.go
+++ b/controllers/prometheus_controller.go
@@ -39,7 +39,8 @@ func (r *AutoscalingReconciler) reconcileDisabledPrometheus(
 	instance *telemetryv1.Autoscaling,
 	helper *helper.Helper,
 ) (ctrl.Result, error) {
-	r.Log.Info("Reconciling Service Prometheus disabled")
+	Log := r.GetLogger(ctx)
+	Log.Info("Reconciling Service Prometheus disabled")
 	serviceLabels := map[string]string{
 		common.AppSelector: autoscaling.ServiceName,
 	}
@@ -56,7 +57,7 @@ func (r *AutoscalingReconciler) reconcileDisabledPrometheus(
 	for _, c := range instance.Status.Conditions {
 		instance.Status.Conditions.MarkTrue(c.Type, telemetryv1.AutoscalingReadyDisabledMessage)
 	}
-	r.Log.Info(fmt.Sprintf("Reconciled Service '%s' disable successfully", autoscaling.ServiceName))
+	Log.Info(fmt.Sprintf("Reconciled Service '%s' disable successfully", autoscaling.ServiceName))
 	return ctrl.Result{}, nil
 }
 
@@ -65,9 +66,10 @@ func (r *AutoscalingReconciler) reconcileDeletePrometheus(
 	instance *telemetryv1.Autoscaling,
 	helper *helper.Helper,
 ) (ctrl.Result, error) {
-	r.Log.Info("Reconciling Service Prometheus delete")
+	Log := r.GetLogger(ctx)
+	Log.Info("Reconciling Service Prometheus delete")
 	// TODO: finalizer prometheus
-	r.Log.Info(fmt.Sprintf("Reconciled Service '%s' delete successfully", autoscaling.ServiceName))
+	Log.Info(fmt.Sprintf("Reconciled Service '%s' delete successfully", autoscaling.ServiceName))
 
 	return ctrl.Result{}, nil
 }
@@ -87,11 +89,12 @@ func (r *AutoscalingReconciler) reconcileNormalPrometheus(
 	instance *telemetryv1.Autoscaling,
 	helper *helper.Helper,
 ) (ctrl.Result, error) {
+	Log := r.GetLogger(ctx)
 	serviceLabels := map[string]string{
 		common.AppSelector: autoscaling.ServiceName,
 	}
 	prom := autoscaling.Prometheus(instance, serviceLabels)
-	r.Log.Info(fmt.Sprintf("Reconciling Service Aodh '%s'", prom.Name))
+	Log.Info(fmt.Sprintf("Reconciling Service Aodh '%s'", prom.Name))
 
 	var promHost string
 	var promPort int32
@@ -105,7 +108,7 @@ func (r *AutoscalingReconciler) reconcileNormalPrometheus(
 			return ctrl.Result{}, err
 		}
 		if op != controllerutil.OperationResultNone {
-			r.Log.Info(fmt.Sprintf("Prometheus %s successfully reconciled - operation: %s", prom.Name, string(op)))
+			Log.Info(fmt.Sprintf("Prometheus %s successfully reconciled - operation: %s", prom.Name, string(op)))
 		}
 		promReady := true
 		for _, c := range prom.Status.Conditions {
@@ -155,6 +158,6 @@ func (r *AutoscalingReconciler) reconcileNormalPrometheus(
 	instance.Status.PrometheusHost = promHost
 	instance.Status.PrometheusPort = promPort
 
-	r.Log.Info(fmt.Sprintf("Reconciled Service Aodh '%s' successfully", prom.Name))
+	Log.Info(fmt.Sprintf("Reconciled Service Aodh '%s' successfully", prom.Name))
 	return ctrl.Result{}, nil
 }

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 	"strings"
@@ -124,7 +125,6 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("Telemetry"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create Telemetry controller")
 		os.Exit(1)
@@ -134,8 +134,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("Ceilometer"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(context.Background(), mgr); err != nil {
 		setupLog.Error(err, "unable to create Ceilometer controller")
 		os.Exit(1)
 	}
@@ -144,8 +143,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("Autoscaling"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(context.Background(), mgr); err != nil {
 		setupLog.Error(err, "unable to create Autoscaling controller")
 		os.Exit(1)
 	}


### PR DESCRIPTION
This automatically adds additional fields like reconcile_id etc.. from the controller context.
and standardize the logging implementation 

example logging after patch: 
 
`2023-10-24T16:50:13+03:00       INFO    Controllers.Ceilometer  Reconciling Service 'ceilometer'        {"controller": "ceilometer", "co
ntrollerGroup": "telemetry.openstack.org", "controllerKind": "Ceilometer", "Ceilometer": {"name":"ceilometer","namespace":"openstack"}, 
"namespace": "openstack", "name": "ceilometer", "reconcileID": "520c6ff7-633c-418b-8096-740fba15aece"}`

*by using per reconcile function respective logger objects, the intention is to lay the ground for parallel reconciliation in future and avoid race conditions as ctx objects are reconcile run specific.