### PR TITLE
Increase KUTTL timeout

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -17,7 +17,7 @@ kind: TestSuite
 reportFormat: JSON
 reportName: kuttl-test-telemetry
 namespace: telemetry-kuttl-tests
-timeout: 180
+timeout: 300
 parallel: 1
 testDirs:
   - tests/kuttl/suites/autoscaling/


### PR DESCRIPTION
The current 180s which is used in other operators is not enough and tests fail during Prometheus pod initialization.