### PR TITLE
Set default image url for node exporter image

### DIFF
--- a/api/v1beta1/ceilometer_types.go
+++ b/api/v1beta1/ceilometer_types.go
@@ -164,6 +164,7 @@ func SetupDefaultsCeilometer() {
 		NotificationContainerImageURL: util.GetEnvVar("RELATED_IMAGE_CEILOMETER_NOTIFICATION_IMAGE_URL_DEFAULT", CeilometerNotificationContainerImage),
 		ComputeContainerImageURL:      util.GetEnvVar("RELATED_IMAGE_CEILOMETER_COMPUTE_IMAGE_URL_DEFAULT", CeilometerComputeContainerImage),
 		IpmiContainerImageURL:         util.GetEnvVar("RELATED_IMAGE_CEILOMETER_IPMI_IMAGE_URL_DEFAULT", CeilometerIpmiContainerImage),
+		NodeExporterContainerImageURL: util.GetEnvVar("RELATED_IMAGE_TELEMETRY_NODE_EXPORTER_IMAGE_URL_DEFAULT", NodeExporterContainerImage),
 	}
 
 	SetupCeilometerDefaults(ceilometerDefaults)


### PR DESCRIPTION
Without this change when telemetry services are initialized with default values, "nodeExporterImage" holds no value.