### PR TITLE
update clusterserviceversion with missing entries

### DIFF
--- a/config/manifests/bases/telemetry-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/telemetry-operator.clusterserviceversion.yaml
@@ -24,10 +24,28 @@ spec:
       kind: Ceilometer
       name: ceilometers.telemetry.openstack.org
       version: v1beta1
+    - description: Logging is the Schema for the loggings API
+      displayName: Logging
+      kind: Logging
+      name: loggings.telemetry.openstack.org
+      version: v1beta1
     - description: Telemetry is the Schema for the telemetry API
       displayName: Telemetry
       kind: Telemetry
       name: telemetries.telemetry.openstack.org
+      specDescriptors:
+      - description: Enabled - Whether OpenStack autoscaling service should be deployed
+          and managed
+        displayName: Enabled
+        path: autoscaling.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Enabled - Whether OpenStack Ceilometer service should be deployed
+          and managed
+        displayName: Enabled
+        path: ceilometer.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       version: v1beta1
   description: Telemetry Operator
   displayName: Telemetry Operator


### PR DESCRIPTION
First introduced with
Merge pull request #238 from vyzigold/remove_enable_autoscaling

The changes to the telemetry-operator.clusterserviceversion.yaml were left in the repo after running make bundle.

This commit updated the repo with the changes so that after make bundle there are not leftover changes left in local repo.