### PR TITLE
Move ceilometer to use StatefulSet

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -35,6 +35,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - batch
   resources:
   - jobs

--- a/pkg/ceilometer/statefulset.go
+++ b/pkg/ceilometer/statefulset.go
@@ -35,12 +35,12 @@ const (
 	ServiceCommand = "/usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
 )
 
-// Deployment func
-func Deployment(
+// StatefulSet func
+func StatefulSet(
 	instance *telemetryv1.Ceilometer,
 	configHash string,
 	labels map[string]string,
-) (*appsv1.Deployment, error) {
+) (*appsv1.StatefulSet, error) {
 	runAsUser := int64(0)
 
 	// TO-DO Probes
@@ -135,13 +135,13 @@ func Deployment(
 		},
 	}
 
-	deployment := &appsv1.Deployment{
+	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ServiceName,
 			Namespace: instance.Namespace,
 			Labels:    labels,
 		},
-		Spec: appsv1.DeploymentSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
@@ -150,7 +150,7 @@ func Deployment(
 		},
 	}
 
-	deployment.Spec.Template.Spec.Volumes = getVolumes(ServiceName)
+	statefulset.Spec.Template.Spec.Volumes = getVolumes(ServiceName)
 
 	// networks to attach to
 	nwAnnotation, err := annotations.GetNADAnnotation(instance.Namespace, instance.Spec.NetworkAttachmentDefinitions)
@@ -158,7 +158,7 @@ func Deployment(
 		return nil, fmt.Errorf("failed create network annotation from %s: %w",
 			instance.Spec.NetworkAttachmentDefinitions, err)
 	}
-	deployment.Spec.Template.Annotations = util.MergeStringMaps(deployment.Spec.Template.Annotations, nwAnnotation)
+	statefulset.Spec.Template.Annotations = util.MergeStringMaps(statefulset.Spec.Template.Annotations, nwAnnotation)
 
-	return deployment, nil
+	return statefulset, nil
 }

--- a/tests/kuttl/suites/ceilometer/tests/00-assert.yaml
+++ b/tests/kuttl/suites/ceilometer/tests/00-assert.yaml
@@ -1,4 +1,77 @@
 apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: ceilometer
+  name: ceilometer-0
+  ownerReferences:
+  - kind: StatefulSet
+    name: ceilometer
+spec:
+  containers:
+  - args:
+    - -c
+    - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+    command:
+    - /bin/bash
+    name: ceilometer-central-agent
+  - args:
+    - -c
+    - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+    command:
+    - /bin/bash
+    name: ceilometer-notification-agent
+  - name: sg-core
+  hostname: ceilometer-0
+status:
+  containerStatuses:
+  - name: ceilometer-central-agent
+    ready: true
+    started: true
+  - name: ceilometer-notification-agent
+    ready: true
+    started: true
+  - name: sg-core
+    ready: true
+    started: true
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    service: ceilometer
+  name: ceilometer
+  ownerReferences:
+  - kind: Ceilometer
+    name: telemetry-kuttl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: ceilometer
+  template:
+    spec:
+      containers:
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        name: ceilometer-central-agent
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        name: ceilometer-notification-agent
+      - name: sg-core
+status:
+  availableReplicas: 1
+  currentReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -12,36 +85,3 @@ spec:
   - port: 3000
     protocol: TCP
     targetPort: 3000
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    service: ceilometer
-  name: ceilometer
-  ownerReferences:
-  - kind: Ceilometer
-    name: telemetry-kuttl
-spec:
-  template:
-    spec:
-      containers:
-      - name: ceilometer-central-agent
-      - name: ceilometer-notification-agent
-      - name: sg-core
-      volumes:
-      - name: scripts
-        secret:
-          defaultMode: 480
-          secretName: ceilometer-scripts
-      - name: config-data
-        secret:
-          defaultMode: 416
-          secretName: ceilometer-config-data
-      - name: sg-core-conf-yaml
-        secret:
-          defaultMode: 416
-          items:
-          - key: sg-core.conf.yaml
-            path: sg-core.conf.yaml
-          secretName: ceilometer-config-data

--- a/tests/kuttl/suites/default/tests/01-assert.yaml
+++ b/tests/kuttl/suites/default/tests/01-assert.yaml
@@ -13,8 +13,45 @@ spec:
     protocol: TCP
     targetPort: 3000
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: ceilometer
+  name: ceilometer-0
+  ownerReferences:
+  - kind: StatefulSet
+    name: ceilometer
+spec:
+  containers:
+  - args:
+    - -c
+    - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+    command:
+    - /bin/bash
+    name: ceilometer-central-agent
+  - args:
+    - -c
+    - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+    command:
+    - /bin/bash
+    name: ceilometer-notification-agent
+  - name: sg-core
+  hostname: ceilometer-0
+status:
+  containerStatuses:
+  - name: ceilometer-central-agent
+    ready: true
+    started: true
+  - name: ceilometer-notification-agent
+    ready: true
+    started: true
+  - name: sg-core
+    ready: true
+    started: true
+---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   labels:
     service: ceilometer
@@ -23,28 +60,31 @@ metadata:
   - kind: Ceilometer
     name: ceilometer
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: ceilometer
   template:
     spec:
       containers:
-      - name: ceilometer-central-agent
-      - name: ceilometer-notification-agent
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        name: ceilometer-central-agent
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        name: ceilometer-notification-agent
       - name: sg-core
-      volumes:
-      - name: scripts
-        secret:
-          defaultMode: 480
-          secretName: ceilometer-scripts
-      - name: config-data
-        secret:
-          defaultMode: 416
-          secretName: ceilometer-config-data
-      - name: sg-core-conf-yaml
-        secret:
-          defaultMode: 416
-          items:
-          - key: sg-core.conf.yaml
-            path: sg-core.conf.yaml
-          secretName: ceilometer-config-data
+status:
+  availableReplicas: 1
+  currentReplicas: 1
+  readyReplicas: 1
+  replicas: 1
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
This moves ceilometer to use StatefulSet instead of deployment. This aligns us to the rest of the operators and also allows us to check for ceilometer pod in kuttl tests (the tests to check for the pod is included in this PR)