### PR TITLE
Remove *ReadyCount from telemetry status

### DIFF
--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -1550,14 +1550,6 @@ spec:
           status:
             description: TelemetryStatus defines the observed state of Telemetry
             properties:
-              autoscalingReadyCount:
-                description: ReadyCount of Autoscaling instance
-                format: int32
-                type: integer
-              ceilometerReadyCount:
-                description: ReadyCount of Ceilometer instance
-                format: int32
-                type: integer
               conditions:
                 description: Conditions
                 items:

--- a/api/v1beta1/telemetry_types.go
+++ b/api/v1beta1/telemetry_types.go
@@ -107,12 +107,6 @@ type TelemetryStatus struct {
 
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
-
-	// ReadyCount of Ceilometer instance
-	CeilometerReadyCount int32 `json:"ceilometerReadyCount,omitempty"`
-
-	// ReadyCount of Autoscaling instance
-	AutoscalingReadyCount int32 `json:"autoscalingReadyCount,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -1550,14 +1550,6 @@ spec:
           status:
             description: TelemetryStatus defines the observed state of Telemetry
             properties:
-              autoscalingReadyCount:
-                description: ReadyCount of Autoscaling instance
-                format: int32
-                type: integer
-              ceilometerReadyCount:
-                description: ReadyCount of Ceilometer instance
-                format: int32
-                type: integer
               conditions:
                 description: Conditions
                 items:


### PR DESCRIPTION
This removes "autoscalingReadyCount" and "ceilometerReadyCount" as discussed in https://github.com/openstack-k8s-operators/telemetry-operator/pull/256#discussion_r1434162340

Telemetry is able to deploy only one of each resource, therefore the count can only be either 0 or 1. In this case the Ready contitions with values True or False give us the same information.