### PR TITLE
Move autoscaling to use StatefulSet

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -25,18 +25,6 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - deployments
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
   - statefulsets
   verbs:
   - create

--- a/controllers/autoscaling_controller.go
+++ b/controllers/autoscaling_controller.go
@@ -78,7 +78,7 @@ func (r *AutoscalingReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete;
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete;
+// +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;create;update;patch;delete;watch
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list
 // +kubebuilder:rbac:groups=keystone.openstack.org,resources=keystoneservices,verbs=get;list;watch;create;update;patch;delete;
@@ -722,7 +722,7 @@ func (r *AutoscalingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&telemetryv1.Autoscaling{}).
-		Owns(&appsv1.Deployment{}).
+		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.Secret{}).

--- a/pkg/autoscaling/aodh_statefulset.go
+++ b/pkg/autoscaling/aodh_statefulset.go
@@ -36,12 +36,12 @@ const (
 	ServiceCommand = "/usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start"
 )
 
-// AodhDeployment func
-func AodhDeployment(
+// AodhStatefulSet func
+func AodhStatefulSet(
 	instance *telemetryv1.Autoscaling,
 	configHash string,
 	labels map[string]string,
-) (*appsv1.Deployment, error) {
+) (*appsv1.StatefulSet, error) {
 	runAsUser := int64(0)
 
 	livenessProbe := &corev1.Probe{
@@ -152,13 +152,13 @@ func AodhDeployment(
 		},
 	}
 
-	deployment := &appsv1.Deployment{
+	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ServiceName,
 			Namespace: instance.Namespace,
 			Labels:    labels,
 		},
-		Spec: appsv1.DeploymentSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
@@ -167,7 +167,7 @@ func AodhDeployment(
 		},
 	}
 
-	deployment.Spec.Template.Spec.Volumes = getVolumes(ServiceName)
+	statefulset.Spec.Template.Spec.Volumes = getVolumes(ServiceName)
 
 	// networks to attach to
 	nwAnnotation, err := annotations.GetNADAnnotation(instance.Namespace, instance.Spec.Aodh.NetworkAttachmentDefinitions)
@@ -175,7 +175,7 @@ func AodhDeployment(
 		return nil, fmt.Errorf("failed create network annotation from %s: %w",
 			instance.Spec.Aodh.NetworkAttachmentDefinitions, err)
 	}
-	deployment.Spec.Template.Annotations = util.MergeStringMaps(deployment.Spec.Template.Annotations, nwAnnotation)
+	statefulset.Spec.Template.Annotations = util.MergeStringMaps(statefulset.Spec.Template.Annotations, nwAnnotation)
 
-	return deployment, nil
+	return statefulset, nil
 }

--- a/tests/kuttl/suites/autoscaling/tests/01-assert.yaml
+++ b/tests/kuttl/suites/autoscaling/tests/01-assert.yaml
@@ -1,4 +1,102 @@
 apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: aodh
+  name: aodh-0
+  ownerReferences:
+  - kind: StatefulSet
+    name: aodh
+spec:
+  containers:
+  - args:
+    - -c
+    - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+    command:
+    - /bin/bash
+    name: aodh-api
+  - args:
+    - -c
+    - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+    command:
+    - /bin/bash
+    name: aodh-evaluator
+  - args:
+    - -c
+    - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+    command:
+    - /bin/bash
+    name: aodh-notifier
+  - args:
+    - -c
+    - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+    command:
+    - /bin/bash
+    name: aodh-listener
+  hostname: aodh-0
+status:
+  containerStatuses:
+  - name: aodh-api
+    ready: true
+    started: true
+  - name: aodh-evaluator
+    ready: true
+    started: true
+  - name: aodh-listener
+    ready: true
+    started: true
+  - name: aodh-notifier
+    ready: true
+    started: true
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    service: aodh
+  name: aodh
+  ownerReferences:
+  - kind: Autoscaling
+    name: telemetry-kuttl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: aodh
+  template:
+    spec:
+      containers:
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        name: aodh-api
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        name: aodh-evaluator
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        name: aodh-notifier
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        name: aodh-listener
+status:
+  availableReplicas: 1
+  currentReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -31,28 +129,3 @@ spec:
     port: 8042
     protocol: TCP
     targetPort: 8042
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    service: aodh
-  name: aodh
-  ownerReferences:
-  - kind: Autoscaling
-    name: telemetry-kuttl
-spec:
-  template:
-    spec:
-      containers:
-      - name: aodh-api
-      - name: aodh-evaluator
-      - name: aodh-notifier
-      - name: aodh-listener
-      volumes:
-      - name: scripts
-        secret:
-          secretName: aodh-scripts
-      - name: config-data
-        secret:
-          secretName: aodh-config-data

--- a/tests/kuttl/suites/default/tests/01-assert.yaml
+++ b/tests/kuttl/suites/default/tests/01-assert.yaml
@@ -194,8 +194,59 @@ spec:
     protocol: TCP
     targetPort: 8042
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: aodh
+  name: aodh-0
+  ownerReferences:
+  - kind: StatefulSet
+    name: aodh
+spec:
+  containers:
+  - args:
+    - -c
+    - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+    command:
+    - /bin/bash
+    name: aodh-api
+  - args:
+    - -c
+    - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+    command:
+    - /bin/bash
+    name: aodh-evaluator
+  - args:
+    - -c
+    - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+    command:
+    - /bin/bash
+    name: aodh-notifier
+  - args:
+    - -c
+    - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+    command:
+    - /bin/bash
+    name: aodh-listener
+  hostname: aodh-0
+status:
+  containerStatuses:
+  - name: aodh-api
+    ready: true
+    started: true
+  - name: aodh-evaluator
+    ready: true
+    started: true
+  - name: aodh-listener
+    ready: true
+    started: true
+  - name: aodh-notifier
+    ready: true
+    started: true
+---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   labels:
     service: aodh
@@ -204,17 +255,39 @@ metadata:
   - kind: Autoscaling
     name: autoscaling
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: aodh
   template:
     spec:
       containers:
-      - name: aodh-api
-      - name: aodh-evaluator
-      - name: aodh-notifier
-      - name: aodh-listener
-      volumes:
-      - name: scripts
-        secret:
-          secretName: aodh-scripts
-      - name: config-data
-        secret:
-          secretName: aodh-config-data
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        name: aodh-api
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        name: aodh-evaluator
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        name: aodh-notifier
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        name: aodh-listener
+status:
+  availableReplicas: 1
+  currentReplicas: 1
+  readyReplicas: 1
+  replicas: 1


### PR DESCRIPTION
Similarly to https://github.com/openstack-k8s-operators/telemetry-operator/pull/260 this moves autoscaling to use statefulset for aodh instead of deployment. This aligns us to the rest of the operators and also allows us to check for aodh pod in kuttl tests