### PR TITLE
Use COO instead of OBO in kuttl tests

### DIFF
--- a/tests/kuttl/suites/default/deps/rhobs.yaml
+++ b/tests/kuttl/suites/default/deps/rhobs.yaml
@@ -1,33 +1,11 @@
 apiVersion: operators.coreos.com/v1alpha1
-kind: CatalogSource
-metadata:
-  annotations:
-  name: observability-operator
-  namespace: openshift-marketplace
-spec:
-  displayName: Observability Operator - Test
-  icon:
-    base64data: ""
-    mediatype: ""
-  image: quay.io/rhobs/observability-operator-catalog:latest
-  publisher: Sunil Thaha
-  sourceType: grpc
-  grpcPodConfig:
-    securityContextConfig: restricted
-  updateStrategy:
-    registryPoll:
-      interval: 1m0s
----
-apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  labels:
-    operators.coreos.com/observability-operator.openshift-operators: ""
-  name: observability-operator
+  name: cluster-observability-operator
   namespace: openshift-operators
 spec:
   channel: development
   installPlanApproval: Automatic
-  name: observability-operator
-  source: observability-operator
+  name: cluster-observability-operator
+  source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/tests/kuttl/suites/default/tests/01-assert.yaml
+++ b/tests/kuttl/suites/default/tests/01-assert.yaml
@@ -156,7 +156,6 @@ metadata:
   - kind: MetricStorage
     name: metric-storage
 spec:
-  scrapeInterval: 30s
   staticConfigs:
   - targets: []
 ---

--- a/tests/kuttl/suites/metricstorage/deps/rhobs.yaml
+++ b/tests/kuttl/suites/metricstorage/deps/rhobs.yaml
@@ -1,33 +1,11 @@
 apiVersion: operators.coreos.com/v1alpha1
-kind: CatalogSource
-metadata:
-  annotations:
-  name: observability-operator
-  namespace: openshift-marketplace
-spec:
-  displayName: Observability Operator - Test
-  icon:
-    base64data: ""
-    mediatype: ""
-  image: quay.io/rhobs/observability-operator-catalog:latest
-  publisher: Sunil Thaha
-  sourceType: grpc
-  grpcPodConfig:
-    securityContextConfig: restricted
-  updateStrategy:
-    registryPoll:
-      interval: 1m0s
----
-apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  labels:
-    operators.coreos.com/observability-operator.openshift-operators: ""
-  name: observability-operator
+  name: cluster-observability-operator
   namespace: openshift-operators
 spec:
   channel: development
   installPlanApproval: Automatic
-  name: observability-operator
-  source: observability-operator
+  name: cluster-observability-operator
+  source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/tests/kuttl/suites/metricstorage/tests/01-assert.yaml
+++ b/tests/kuttl/suites/metricstorage/tests/01-assert.yaml
@@ -68,6 +68,5 @@ metadata:
   - kind: MetricStorage
     name: telemetry-kuttl
 spec:
-  scrapeInterval: 30s
   staticConfigs:
   - targets: []


### PR DESCRIPTION
* kuttl tests are subscribing to a very old pre-release of OBO
* It has since been replaced by a (tech preview) release of COO
* This worked for me during auto-scaling tests