### PR TITLE
[zuul] Add telemetry-operator-multinode-autoscaling-tempest job

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -54,6 +54,7 @@
             identity.v2_admin_endpoint_type: public
             service_available.ceilometer: true
             service_available.sg_core: true
+            telemetry.sg_core_service_url: "ceilometer.openstack.svc.cluster.local:3000"
      # NOTE(efoley): First step is to get ANY tempest jobs running to confirm a working config
       cifmw_tempest_tests_allowed: # need to see ciframwework roles that use these vars, to see how to enable telemetry
         - telemetry_tempest_plugin.scenario

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -43,9 +43,6 @@
     parent: telemetry-operator-multinode-autoscaling
     vars:
       test_fw: test_operator
-      # workaround(gabbi_version)
-      # Using master for now because the sg_core telemetry tests are not compatible with antelope due to an incompatible version of gabbi
-      # The workaround in the telemetry-tempest-plugin patch needs to be incorporated into TCIB
       cifmw_test_operator_tempest_namespace: podified-antelope-centos9
       cifmw_test_operator_tempest_container: openstack-tempest-all
       cifmw_test_operator_tempest_image_tag: 'current-podified'
@@ -56,17 +53,9 @@
       cifmw_test_operator_tempest_external_plugin:
         # workaround(telemetry_tempest_plugin_release)
         # NOTE: Until the telemetry-tempest-plugin repo is tagged and the new version is used in the tempest image, we need to manually install it as an external plugin to use the autoscaling tests.
-        # Once this job runs all the autoscaling tests and passes using telemetry-tempest-plugin/master, the release can be tagged since it works against OSP18 deployments.
-        # - repository: "https://opendev.org/openstack/telemetry-tempest-plugin.git"
-        #   changeRepository: "https://review.opendev.org/openstack/telemetry-tempest-plugin"
-        #   changeRefspec: "master"
-        # workaround(gabbi_version)
-        # NOTE: This review is being used because tempest/antelope container has an incompatible version of gabbi, and it was easier to verify this fix in this patch rather than in TCIB.
-        # TODO: Update the version of gabbi used in TCIB instead of in telemetry-tempest-plugin.
-        # Once that update is made, this patch is not needed, and the podified-antelope-centos9 namespace can be used again to select the antelope version of the tempest image.
         - repository: "https://opendev.org/openstack/telemetry-tempest-plugin.git"
           changeRepository: "https://review.opendev.org/openstack/telemetry-tempest-plugin"
-          changeRefspec: "refs/changes/32/907432/1"
+          changeRefspec: "master"
       # This value is used to populate the `tempestconfRun` parameter of the Tempest CR: https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource
       # https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/test_operator/defaults/main.yml
       cifmw_tempest_tempestconf_config:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -78,6 +78,7 @@
             identity.v3_endpoint_type public
             service_available.ceilometer true
             service_available.sg_core true
+            service_available.aodh true
             telemetry.sg_core_service_url "ceilometer.openstack.svc.cluster.local:3000"
       cifmw_test_operator_tempest_include_list: |
         telemetry_tempest_plugin.scenario

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -42,24 +42,31 @@
     name: telemetry-operator-multinode-autoscaling-tempest
     parent: telemetry-operator-multinode-autoscaling
     vars:
-      cifmw_tempest_container: openstack-tempest-all
-      cifmw_tempest_tempestconf_profile:
-        overrides:
-            compute-feature-enabled.vnc_console: true
-            validation.run_validation: true
-            # NOTE(gibi): This is a WA to force the publicURL as otherwise
-            # tempest gets configured with adminURL and that causes test
-            # instability.
-            identity.v3_endpoint_type: public
-            identity.v2_admin_endpoint_type: public
-            service_available.ceilometer: true
-            service_available.sg_core: true
-            telemetry.sg_core_service_url: "ceilometer.openstack.svc.cluster.local:3000"
-     # NOTE(efoley): First step is to get ANY tempest jobs running to confirm a working config
-      cifmw_tempest_tests_allowed: # need to see ciframwework roles that use these vars, to see how to enable telemetry
-        - telemetry_tempest_plugin.scenario
-        - telemetry_tempest_plugin.aodh
-      cifmw_tempest_tests_skipped: []
+      test_fw: test_operator
+      cifmw_test_operator_tempest_container: openstack-tempest-all
+      cifmw_test_operator_tempest_image_tag: 'current-podified'
+      cifmw_test_operator_tempest_external_plugin:
+        - repository: "https://opendev.org/openstack/telemetry-tempest-plugin.git"
+          changeRepository: "https://review.opendev.org/openstack/telemetry-tempest-plugin"
+          changeRefspec: "master"
+      # This value is used to populate the `tempestconfRun` parameter of the Tempest CR: https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource
+      # https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/test_operator/defaults/main.yml
+      cifmw_tempest_tempestconf_config:
+        # NOTE(gibi): This is a WA to force the publicURL as otherwise
+        # tempest gets configured with adminURL and that causes test
+        # instability.
+        overrides: |
+            compute-feature-enabled.vnc_console true
+            validation.run_validation true
+            identity.v3_endpoint_type public
+            identity.v2_admin_endpoint_type public
+            service_available.ceilometer true
+            service_available.sg_core true
+            telemetry.sg_core_service_url "ceilometer.openstack.svc.cluster.local:3000"
+      cifmw_test_operator_tempest_include_list: |
+        telemetry_tempest_plugin.scenario
+        telemetry_tempest_plugin.aodh
+      cifmw_test_operator_tempest_exclude_list: ''
 
 - project:
     name: openstack-k8s-operators/telemetry-operator

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -43,6 +43,8 @@
     parent: telemetry-operator-multinode-autoscaling
     vars:
       test_fw: test_operator
+      # Using master for now because the sg_core telemetry tests are not compatible with antelope
+      cifmw_test_operator_tempest_namespace: podified-master-centos9
       cifmw_test_operator_tempest_container: openstack-tempest-all
       cifmw_test_operator_tempest_image_tag: 'current-podified'
       cifmw_test_operator_tempest_external_plugin:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -44,21 +44,15 @@
       cifmw_test_operator_tempest_namespace: podified-antelope-centos9
       cifmw_test_operator_tempest_container: openstack-tempest-all
       cifmw_test_operator_tempest_image_tag: 'current-podified'
-      # TODO: Remove the externalPlugin before merging since we want the tests running from the antelope container.
-      # This requires a release of telemetry-tempest-plugin that gets included in packages installed int he openstack-tempest-all containers built by TCIB.
-      # Once that is being built, the external_plugin won't be needed
       cifmw_test_operator_tempest_external_plugin:
         # workaround(telemetry_tempest_plugin_release)
         # NOTE: Until the telemetry-tempest-plugin repo is tagged and the new version is used in the tempest image, we need to manually install it as an external plugin to use the autoscaling tests.
         - repository: "https://opendev.org/openstack/telemetry-tempest-plugin.git"
           changeRepository: "https://review.opendev.org/openstack/telemetry-tempest-plugin"
-          changeRefspec: "refs/changes/59/909459/4"
+          changeRefspec: "master"
       # This value is used to populate the `tempestconfRun` parameter of the Tempest CR: https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource
       # https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/test_operator/defaults/main.yml
       cifmw_tempest_tempestconf_config:
-        # NOTE(gibi): This is a WA to force the publicURL as otherwise
-        # tempest gets configured with adminURL and that causes test
-        # instability.
         overrides: |
             validation.run_validation true
             identity.v3_endpoint_type public

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -55,7 +55,7 @@
         # NOTE: Until the telemetry-tempest-plugin repo is tagged and the new version is used in the tempest image, we need to manually install it as an external plugin to use the autoscaling tests.
         - repository: "https://opendev.org/openstack/telemetry-tempest-plugin.git"
           changeRepository: "https://review.opendev.org/openstack/telemetry-tempest-plugin"
-          changeRefspec: "refs/changes/59/909459/1"
+          changeRefspec: "refs/changes/59/909459/3"
       # This value is used to populate the `tempestconfRun` parameter of the Tempest CR: https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource
       # https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/test_operator/defaults/main.yml
       cifmw_tempest_tempestconf_config:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -42,13 +42,7 @@
     name: telemetry-operator-multinode-autoscaling-tempest
     parent: telemetry-operator-multinode-autoscaling
     vars:
-      # May need to add telemetry to this.
-      # * `cifmw_tempest_container`: (String) Name of the tempest container. Default to `openstack-tempest`
-      # https://github.com/openstack-k8s-operators/ci-framework/blob/a32669366a32b494b692d5dc73de044fd089a38a/roles/tempest/README.md?plain=1#L14
       cifmw_tempest_container: openstack-tempest-all
-      #* `cifmw_tempest_tempestconf_profile`: (Dictionary) List of settings to be overwritten in tempest.conf.
-      # https://github.com/openstack-k8s-operators/ci-framework/blob/a32669366a32b494b692d5dc73de044fd089a38a/roles/tempest/README.md?plain=1#L21C4-L21C37
-      # Assumption: the config vars passed here are from tempest, and I can follow the tempest configs from upstream/devstack-based deployments to populate this for telemetry
       cifmw_tempest_tempestconf_profile:
         overrides:
             compute-feature-enabled.vnc_console: true
@@ -58,22 +52,11 @@
             # instability.
             identity.v3_endpoint_type: public
             identity.v2_admin_endpoint_type: public
+            service_available.ceilometer: true
      # NOTE(efoley): First step is to get ANY tempest jobs running to confirm a working config
       cifmw_tempest_tests_allowed: # need to see ciframwework roles that use these vars, to see how to enable telemetry
-        - neutron_tempest_plugin.api
-        - neutron_tempest_plugin.scenario
-        # To check metadata with and without config drive
-        - tempest.scenario.test_server_basic_ops.TestServerBasicOps.test_server_basic_ops
-      cifmw_tempest_tests_skipped:
-        # https://issues.redhat.com/browse/OSPRH-3099
-        - test_list_pagination_page_reverse_with_href_links
-        - test_list_pagination_with_href_links
-        # https://review.opendev.org/892839
-        - neutron_tempest_plugin.scenario.test_mtu.NetworkWritableMtuTest
-        # missing https://review.opendev.org/882818 in antelope
-        - test_qos_dscp_create_and_update
-        # Limit job runtime
-        - NetworkSecGroupTest
+        - telemetry_tempest_plugin.scenario
+      cifmw_tempest_tests_skipped: []
 
 - project:
     name: openstack-k8s-operators/telemetry-operator

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -63,7 +63,8 @@
       cifmw_test_operator_tempest_include_list: |
         telemetry_tempest_plugin.scenario
         telemetry_tempest_plugin.aodh
-      cifmw_test_operator_tempest_exclude_list: ''
+      cifmw_test_operator_tempest_exclude_list: |
+        telemetry_tempest_plugin.scenario.test_telemetry_integration_prometheus.PrometheusGabbiTest.test_ceilometer_sg_core_integration
 
 - project:
     name: openstack-k8s-operators/telemetry-operator

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -55,7 +55,7 @@
         # NOTE: Until the telemetry-tempest-plugin repo is tagged and the new version is used in the tempest image, we need to manually install it as an external plugin to use the autoscaling tests.
         - repository: "https://opendev.org/openstack/telemetry-tempest-plugin.git"
           changeRepository: "https://review.opendev.org/openstack/telemetry-tempest-plugin"
-          changeRefspec: "master"
+          changeRefspec: "refs/changes/59/909459/1"
       # This value is used to populate the `tempestconfRun` parameter of the Tempest CR: https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource
       # https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/test_operator/defaults/main.yml
       cifmw_tempest_tempestconf_config:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -48,9 +48,12 @@
       cifmw_test_operator_tempest_container: openstack-tempest-all
       cifmw_test_operator_tempest_image_tag: 'current-podified'
       cifmw_test_operator_tempest_external_plugin:
+        # - repository: "https://opendev.org/openstack/telemetry-tempest-plugin.git"
+        #   changeRepository: "https://review.opendev.org/openstack/telemetry-tempest-plugin"
+        #   changeRefspec: "master"
         - repository: "https://opendev.org/openstack/telemetry-tempest-plugin.git"
           changeRepository: "https://review.opendev.org/openstack/telemetry-tempest-plugin"
-          changeRefspec: "master"
+          changeRefspec: "refs/changes/32/907432/1"
       # This value is used to populate the `tempestconfRun` parameter of the Tempest CR: https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource
       # https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/test_operator/defaults/main.yml
       cifmw_tempest_tempestconf_config:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -11,8 +11,6 @@
         - name: Create COO subscription
           source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/create-coo-subscription.yaml"
           type: playbook
-      cifmw_install_yamls_vars:
-        BMO_SETUP: false
       cifmw_edpm_prepare_kustomizations:
         - apiVersion: kustomize.config.k8s.io/v1beta1
           kind: Kustomization
@@ -49,13 +47,12 @@
       # TODO: Remove the externalPlugin before merging since we want the tests running from the antelope container.
       # This requires a release of telemetry-tempest-plugin that gets included in packages installed int he openstack-tempest-all containers built by TCIB.
       # Once that is being built, the external_plugin won't be needed
-      # TODO: merge the change that allows external_plugin to be passed to the CR: https://github.com/openstack-k8s-operators/ci-framework/pull/1065
       cifmw_test_operator_tempest_external_plugin:
         # workaround(telemetry_tempest_plugin_release)
         # NOTE: Until the telemetry-tempest-plugin repo is tagged and the new version is used in the tempest image, we need to manually install it as an external plugin to use the autoscaling tests.
         - repository: "https://opendev.org/openstack/telemetry-tempest-plugin.git"
           changeRepository: "https://review.opendev.org/openstack/telemetry-tempest-plugin"
-          changeRefspec: "refs/changes/59/909459/3"
+          changeRefspec: "refs/changes/59/909459/4"
       # This value is used to populate the `tempestconfRun` parameter of the Tempest CR: https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource
       # https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/test_operator/defaults/main.yml
       cifmw_tempest_tempestconf_config:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -53,9 +53,11 @@
             identity.v3_endpoint_type: public
             identity.v2_admin_endpoint_type: public
             service_available.ceilometer: true
+            service_available.sg_core: true
      # NOTE(efoley): First step is to get ANY tempest jobs running to confirm a working config
       cifmw_tempest_tests_allowed: # need to see ciframwework roles that use these vars, to see how to enable telemetry
         - telemetry_tempest_plugin.scenario
+        - telemetry_tempest_plugin.aodh
       cifmw_tempest_tests_skipped: []
 
 - project:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -46,7 +46,7 @@
       # workaround(gabbi_version)
       # Using master for now because the sg_core telemetry tests are not compatible with antelope due to an incompatible version of gabbi
       # The workaround in the telemetry-tempest-plugin patch needs to be incorporated into TCIB
-      cifmw_test_operator_tempest_namespace: podified-master-centos9
+      cifmw_test_operator_tempest_namespace: podified-antelope-centos9
       cifmw_test_operator_tempest_container: openstack-tempest-all
       cifmw_test_operator_tempest_image_tag: 'current-podified'
       # TODO: Remove the externalPlugin before merging since we want the tests running from the antelope container.

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -38,10 +38,47 @@
             target:
               kind: OpenStackControlPlane
 
+- job:
+    name: telemetry-operator-multinode-autoscaling-tempest
+    parent: telemetry-operator-multinode-autoscaling
+    vars:
+      # May need to add telemetry to this.
+      # * `cifmw_tempest_container`: (String) Name of the tempest container. Default to `openstack-tempest`
+      # https://github.com/openstack-k8s-operators/ci-framework/blob/a32669366a32b494b692d5dc73de044fd089a38a/roles/tempest/README.md?plain=1#L14
+      cifmw_tempest_container: openstack-tempest-all
+      #* `cifmw_tempest_tempestconf_profile`: (Dictionary) List of settings to be overwritten in tempest.conf.
+      # https://github.com/openstack-k8s-operators/ci-framework/blob/a32669366a32b494b692d5dc73de044fd089a38a/roles/tempest/README.md?plain=1#L21C4-L21C37
+      # Assumption: the config vars passed here are from tempest, and I can follow the tempest configs from upstream/devstack-based deployments to populate this for telemetry
+      cifmw_tempest_tempestconf_profile:
+        overrides:
+            compute-feature-enabled.vnc_console: true
+            validation.run_validation: true
+            # NOTE(gibi): This is a WA to force the publicURL as otherwise
+            # tempest gets configured with adminURL and that causes test
+            # instability.
+            identity.v3_endpoint_type: public
+            identity.v2_admin_endpoint_type: public
+     # NOTE(efoley): First step is to get ANY tempest jobs running to confirm a working config
+      cifmw_tempest_tests_allowed: # need to see ciframwework roles that use these vars, to see how to enable telemetry
+        - neutron_tempest_plugin.api
+        - neutron_tempest_plugin.scenario
+        # To check metadata with and without config drive
+        - tempest.scenario.test_server_basic_ops.TestServerBasicOps.test_server_basic_ops
+      cifmw_tempest_tests_skipped:
+        # https://issues.redhat.com/browse/OSPRH-3099
+        - test_list_pagination_page_reverse_with_href_links
+        - test_list_pagination_with_href_links
+        # https://review.opendev.org/892839
+        - neutron_tempest_plugin.scenario.test_mtu.NetworkWritableMtuTest
+        # missing https://review.opendev.org/882818 in antelope
+        - test_qos_dscp_create_and_update
+        # Limit job runtime
+        - NetworkSecGroupTest
+
 - project:
     name: openstack-k8s-operators/telemetry-operator
     templates:
       - podified-multinode-edpm-pipeline
     github-check:
       jobs:
-        - telemetry-operator-multinode-autoscaling
+        - telemetry-operator-multinode-autoscaling-tempest

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -43,14 +43,27 @@
     parent: telemetry-operator-multinode-autoscaling
     vars:
       test_fw: test_operator
-      # Using master for now because the sg_core telemetry tests are not compatible with antelope
+      # workaround(gabbi_version)
+      # Using master for now because the sg_core telemetry tests are not compatible with antelope due to an incompatible version of gabbi
+      # The workaround in the telemetry-tempest-plugin patch needs to be incorporated into TCIB
       cifmw_test_operator_tempest_namespace: podified-master-centos9
       cifmw_test_operator_tempest_container: openstack-tempest-all
       cifmw_test_operator_tempest_image_tag: 'current-podified'
+      # TODO: Remove the externalPlugin before merging since we want the tests running from the antelope container.
+      # This requires a release of telemetry-tempest-plugin that gets included in packages installed int he openstack-tempest-all containers built by TCIB.
+      # Once that is being built, the external_plugin won't be needed
+      # TODO: merge the change that allows external_plugin to be passed to the CR: https://github.com/openstack-k8s-operators/ci-framework/pull/1065
       cifmw_test_operator_tempest_external_plugin:
+        # workaround(telemetry_tempest_plugin_release)
+        # NOTE: Until the telemetry-tempest-plugin repo is tagged and the new version is used in the tempest image, we need to manually install it as an external plugin to use the autoscaling tests.
+        # Once this job runs all the autoscaling tests and passes using telemetry-tempest-plugin/master, the release can be tagged since it works against OSP18 deployments.
         # - repository: "https://opendev.org/openstack/telemetry-tempest-plugin.git"
         #   changeRepository: "https://review.opendev.org/openstack/telemetry-tempest-plugin"
         #   changeRefspec: "master"
+        # workaround(gabbi_version)
+        # NOTE: This review is being used because tempest/antelope container has an incompatible version of gabbi, and it was easier to verify this fix in this patch rather than in TCIB.
+        # TODO: Update the version of gabbi used in TCIB instead of in telemetry-tempest-plugin.
+        # Once that update is made, this patch is not needed, and the podified-antelope-centos9 namespace can be used again to select the antelope version of the tempest image.
         - repository: "https://opendev.org/openstack/telemetry-tempest-plugin.git"
           changeRepository: "https://review.opendev.org/openstack/telemetry-tempest-plugin"
           changeRefspec: "refs/changes/32/907432/1"
@@ -61,10 +74,8 @@
         # tempest gets configured with adminURL and that causes test
         # instability.
         overrides: |
-            compute-feature-enabled.vnc_console true
             validation.run_validation true
             identity.v3_endpoint_type public
-            identity.v2_admin_endpoint_type public
             service_available.ceilometer true
             service_available.sg_core true
             telemetry.sg_core_service_url "ceilometer.openstack.svc.cluster.local:3000"


### PR DESCRIPTION
This is a first pass, creating a tempest job based on neutron-operator. This change runs the neutron tempest tests to establish that the environment is configured correctly for tempest tests.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1110
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1116
Depends-On: https://github.com/openstack-k8s-operators/tcib/pull/132
Depends-On: https://github.com/openstack-k8s-operators/telemetry-operator/pull/301
Depends-On: https://review.opendev.org/c/openstack/releases/+/907406
Depends-On: https://review.rdoproject.org/r/c/rdoinfo/+/51721
