### PR TITLE
Add the customServiceConfig functionality

### DIFF
--- a/templates/autoscaling/config/aodh-api-config.json
+++ b/templates/autoscaling/config/aodh-api-config.json
@@ -8,6 +8,13 @@
         "perm": "0600"
       },
       {
+        "source": "/var/lib/openstack/config/custom.conf",
+        "dest": "/etc/aodh/aodh.conf.d/01-aodh-custom.conf",
+        "owner": "aodh",
+        "perm": "0600",
+        "optional": true
+      },
+      {
         "source": "/var/lib/openstack/config/wsgi-aodh.conf",
         "dest": "/etc/httpd/conf.d/00wsgi-aodh.conf",
         "owner": "root",

--- a/templates/autoscaling/config/aodh-dbsync-config.json
+++ b/templates/autoscaling/config/aodh-dbsync-config.json
@@ -6,6 +6,13 @@
                         "dest": "/etc/aodh/aodh.conf",
                         "owner": "aodh",
                         "perm": "0600"
+                },
+                {
+                        "source": "/var/lib/openstack/config/custom.conf",
+                        "dest": "/etc/aodh/aodh.conf.d/01-aodh-custom.conf",
+                        "owner": "aodh",
+                        "perm": "0600",
+                        "optional": true
                 }
         ]
 }

--- a/templates/autoscaling/config/aodh-evaluator-config.json
+++ b/templates/autoscaling/config/aodh-evaluator-config.json
@@ -8,6 +8,13 @@
         "perm": "0600"
       },
       {
+        "source": "/var/lib/openstack/config/custom.conf",
+        "dest": "/etc/aodh/aodh.conf.d/01-aodh-custom.conf",
+        "owner": "aodh",
+        "perm": "0600",
+        "optional": true
+      },
+      {
         "source": "/var/lib/openstack/config/prometheus.yaml",
         "dest": "/etc/openstack/prometheus.yaml",
         "owner": "aodh",

--- a/templates/autoscaling/config/aodh-listener-config.json
+++ b/templates/autoscaling/config/aodh-listener-config.json
@@ -6,6 +6,13 @@
         "dest": "/etc/aodh/aodh.conf",
         "owner": "aodh",
         "perm": "0600"
+      },
+      {
+        "source": "/var/lib/openstack/config/custom.conf",
+        "dest": "/etc/aodh/aodh.conf.d/01-aodh-custom.conf",
+        "owner": "aodh",
+        "perm": "0600",
+        "optional": true
       }
     ]
   }

--- a/templates/autoscaling/config/aodh-notifier-config.json
+++ b/templates/autoscaling/config/aodh-notifier-config.json
@@ -6,6 +6,13 @@
         "dest": "/etc/aodh/aodh.conf",
         "owner": "aodh",
         "perm": "0600"
+      },
+      {
+        "source": "/var/lib/openstack/config/custom.conf",
+        "dest": "/etc/aodh/aodh.conf.d/01-aodh-custom.conf",
+        "owner": "aodh",
+        "perm": "0600",
+        "optional": true
       }
     ]
   }

--- a/templates/ceilometercentral/config/ceilometer-central-config.json
+++ b/templates/ceilometercentral/config/ceilometer-central-config.json
@@ -12,6 +12,13 @@
         "dest": "/etc/ceilometer/polling.yaml",
         "owner": "ceilometer",
         "perm": "0600"
+      },
+      {
+        "source": "/var/lib/openstack/config/custom.conf",
+        "dest": "/etc/ceilometer/ceilometer.conf.d/01-ceilometer-custom.conf",
+        "owner": "ceilometer",
+        "perm": "0600",
+        "optional": true
       }
     ]
   }

--- a/templates/ceilometercentral/config/ceilometer-notification-config.json
+++ b/templates/ceilometercentral/config/ceilometer-notification-config.json
@@ -12,6 +12,13 @@
         "dest": "/etc/ceilometer/pipeline.yaml",
         "owner": "ceilometer",
         "perm": "0600"
+      },
+      {
+        "source": "/var/lib/openstack/config/custom.conf",
+        "dest": "/etc/ceilometer/ceilometer.conf.d/01-ceilometer-custom.conf",
+        "owner": "ceilometer",
+        "perm": "0600",
+        "optional": true
       }
     ]
   }

--- a/templates/ceilometercompute/config/ceilometer-agent-compute.json
+++ b/templates/ceilometercompute/config/ceilometer-agent-compute.json
@@ -12,6 +12,13 @@
         "dest": "/etc/ceilometer/polling.yaml",
         "owner": "ceilometer",
         "perm": "0600"
+      },
+      {
+        "source": "/var/lib/openstack/config/custom.conf",
+        "dest": "/etc/ceilometer/ceilometer.conf.d/01-ceilometer-custom.conf",
+        "owner": "ceilometer",
+        "perm": "0600",
+        "optional": true
       }
     ]
   }

--- a/templates/ceilometercompute/config/ceilometer-agent-ipmi.json
+++ b/templates/ceilometercompute/config/ceilometer-agent-ipmi.json
@@ -12,6 +12,13 @@
         "dest": "/etc/ceilometer/polling.yaml",
         "owner": "ceilometer",
         "perm": "0600"
+      },
+      {
+        "source": "/var/lib/openstack/config/custom.conf",
+        "dest": "/etc/ceilometer/ceilometer.conf.d/01-ceilometer-custom.conf",
+        "owner": "ceilometer",
+        "perm": "0600",
+        "optional": true
       }
     ]
   }


### PR DESCRIPTION
This lets us use the "customServiceConfig" field in the CR to customize ceilometer.conf and aodh.conf.