### PR TITLE
DNM testing addmetricsstorage

### DIFF
--- a/ci/create-coo-subscription.yaml
+++ b/ci/create-coo-subscription.yaml
@@ -1,0 +1,40 @@
+---
+- name: "Create the cluster-observability-operator subscription"
+  hosts: "{{ cifmw_target_hook_host | default('localhost')  }}"
+  gather_facts: false
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  tasks:
+    - name: Create the COO subscription
+      ansible.builtin.shell:
+        cmd: |
+          oc create -f - <<EOF
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: cluster-observability-operator
+            namespace: openshift-operators
+          spec:
+            channel: development
+            installPlanApproval: Automatic
+            name: cluster-observability-operator
+            source: redhat-operators
+            sourceNamespace: openshift-marketplace
+          EOF
+      register: output
+
+      # need to have a wait here, since the csv is not created immediately. There is a slight delay, during which time, the oc wait command would fail, since there's no resource to watch
+    - name: Wait for the required resource to be created
+      ansible.builtin.command:
+        cmd:
+          oc get csv --namespace=openshift-operators -l operators.coreos.com/cluster-observability-operator.openshift-operators
+      delay: 2
+      retries: 10
+      register: output
+      until: output.stdout_lines | length != 0
+
+    - name: Wait for the resources to be available
+      ansible.builtin.command:
+        cmd: |
+          oc wait --for jsonpath="{.status.phase}"=Succeeded csv --namespace=openshift-operators -l operators.coreos.com/cluster-observability-operator.openshift-operators

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -35,9 +35,8 @@
 
 - project:
     name: openstack-k8s-operators/telemetry-operator
-    #templates:
-    #  - podified-multinode-edpm-pipeline
+    templates:
+      - podified-multinode-edpm-pipeline
     github-check:
       jobs:
-        - openstack-k8s-operators-content-provider
         - telemetry-operator-multinode-autoscaling

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -6,6 +6,7 @@
     description: |
       Deploy OpenStack with Autoscaling features enabled
     vars:
+      cifmw_edpm_prepare_timeout: 60
       pre_deploy:
         - name: Create COO subscription
           source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/create-coo-subscription.yaml"

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -35,8 +35,9 @@
 
 - project:
     name: openstack-k8s-operators/telemetry-operator
-    templates:
-      - podified-multinode-edpm-pipeline
+    #templates:
+    #  - podified-multinode-edpm-pipeline
     github-check:
       jobs:
+        - openstack-k8s-operators-content-provider
         - telemetry-operator-multinode-autoscaling

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -29,7 +29,7 @@
                   enabled: true
                   template:
                     metricStorage:
-                      enabled: true
+                      enabled: false
                     autoscaling:
                       enabled: true
             target:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -30,7 +30,9 @@
                   enabled: true
                   template:
                     metricStorage:
-                      enabled: false
+                      enabled: true
+                      monitoringStack:
+                        alertingEnabled: false
                     autoscaling:
                       enabled: true
             target:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,5 +1,42 @@
 ---
+- job:
+    name: telemetry-operator-multinode-autoscaling
+    parent: podified-multinode-edpm-deployment-crc
+    dependencies: ["openstack-k8s-operators-content-provider"]
+    description: |
+      Deploy OpenStack with Autoscaling features enabled
+    vars:
+      pre_deploy:
+        - name: Create COO subscription
+          source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/create-coo-subscription.yaml"
+          type: playbook
+      cifmw_edpm_prepare_kustomizations:
+        - apiVersion: kustomize.config.k8s.io/v1beta1
+          kind: Kustomization
+          namespace: openstack
+          patches:
+          - patch: |-
+              apiVersion: core.openstack.org/v1beta1
+              kind: OpenStackControlPlane
+              metadata:
+                name: unused
+              spec:
+                heat:
+                  enabled: true
+                telemetry:
+                  enabled: true
+                  template:
+                    metricStorage:
+                      enabled: true
+                    autoscaling:
+                      enabled: true
+            target:
+              kind: OpenStackControlPlane
+
 - project:
     name: openstack-k8s-operators/telemetry-operator
     templates:
       - podified-multinode-edpm-pipeline
+    github-check:
+      jobs:
+        - telemetry-operator-multinode-autoscaling

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -10,6 +10,8 @@
         - name: Create COO subscription
           source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/create-coo-subscription.yaml"
           type: playbook
+      cifmw_install_yamls_vars:
+        BMO_SETUP: false
       cifmw_edpm_prepare_kustomizations:
         - apiVersion: kustomize.config.k8s.io/v1beta1
           kind: Kustomization


### PR DESCRIPTION
This is a temporary PR to test re-anabling metrics storage with alertmanage disabled. It is being tested separate so I can test that the alertmanager was the issue and move with some other update to the main PR #301 

Depends-On: https://github.com/openstack-k8s-operators/telemetry-operator/pull/301 