### PR TITLE
Move metricstorage consts to api

### DIFF
--- a/api/v1beta1/metricstorage_consts.go
+++ b/api/v1beta1/metricstorage_consts.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package metricstorage
+package v1beta1
 
 import "time"
 

--- a/controllers/autoscaling_controller.go
+++ b/controllers/autoscaling_controller.go
@@ -55,7 +55,6 @@ import (
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
 	autoscaling "github.com/openstack-k8s-operators/telemetry-operator/pkg/autoscaling"
-	metricstorage "github.com/openstack-k8s-operators/telemetry-operator/pkg/metricstorage"
 )
 
 // AutoscalingReconciler reconciles a Autoscaling object
@@ -403,12 +402,12 @@ func (r *AutoscalingReconciler) reconcileNormal(
 	// NOTE: Always do this before calling the generateServiceConfig to get the newest values in the ServiceConfig
 	//
 	if instance.Spec.PrometheusHost == "" {
-		instance.Status.PrometheusHost = fmt.Sprintf("%s-prometheus.%s.svc", metricstorage.DefaultServiceName, instance.Namespace)
+		instance.Status.PrometheusHost = fmt.Sprintf("%s-prometheus.%s.svc", telemetryv1.DefaultServiceName, instance.Namespace)
 	} else {
 		instance.Status.PrometheusHost = instance.Spec.PrometheusHost
 	}
 	if instance.Spec.PrometheusPort == 0 {
-		instance.Status.PrometheusPort = metricstorage.DefaultPrometheusPort
+		instance.Status.PrometheusPort = telemetryv1.DefaultPrometheusPort
 	} else {
 		instance.Status.PrometheusPort = instance.Spec.PrometheusPort
 	}

--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -216,7 +216,7 @@ func (r *MetricStorageReconciler) reconcileNormal(
 			condition.SeverityError,
 			telemetryv1.MonitoringStackUnableToOwnMessage, err)
 		Log.Info("Can't own MonitoringStack resource")
-		return ctrl.Result{RequeueAfter: metricstorage.PauseBetweenWatchAttempts}, nil
+		return ctrl.Result{RequeueAfter: telemetryv1.PauseBetweenWatchAttempts}, nil
 	}
 
 	monitoringStack := &obov1.MonitoringStack{
@@ -274,7 +274,7 @@ func (r *MetricStorageReconciler) reconcileNormal(
 			condition.SeverityError,
 			telemetryv1.ServiceMonitorUnableToOwnMessage, err)
 		Log.Info("Can't own ServiceMonitor resource")
-		return ctrl.Result{RequeueAfter: metricstorage.PauseBetweenWatchAttempts}, nil
+		return ctrl.Result{RequeueAfter: telemetryv1.PauseBetweenWatchAttempts}, nil
 	}
 	ceilometerMonitor := &monv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
@@ -332,7 +332,7 @@ func (r *MetricStorageReconciler) reconcileNormal(
 			condition.SeverityError,
 			telemetryv1.NodeSetUnableToWatchMessage, err)
 		Log.Info("Can't watch OpenStackDataPlaneNodeSet resource")
-		return ctrl.Result{RequeueAfter: metricstorage.PauseBetweenWatchAttempts}, nil
+		return ctrl.Result{RequeueAfter: telemetryv1.PauseBetweenWatchAttempts}, nil
 	}
 	instance.Status.Conditions.MarkTrue(telemetryv1.NodeSetReadyCondition, condition.ReadyMessage)
 
@@ -354,7 +354,7 @@ func (r *MetricStorageReconciler) reconcileNormal(
 			condition.SeverityError,
 			telemetryv1.ScrapeConfigUnableToOwnMessage, err)
 		Log.Info("Can't own ScrapeConfig resource")
-		return ctrl.Result{RequeueAfter: metricstorage.PauseBetweenWatchAttempts}, nil
+		return ctrl.Result{RequeueAfter: telemetryv1.PauseBetweenWatchAttempts}, nil
 	}
 	op, err = controllerutil.CreateOrPatch(ctx, r.Client, scrapeConfig, func() error {
 		endpoints, err := getNodeExporterTargets(instance, helper)
@@ -463,7 +463,7 @@ func getNodeExporterTargets(
 				// we were unable to find an IP or HostName for a node, so we do not go further
 				return addresses, nil
 			}
-			addresses = append(addresses, fmt.Sprintf("%s:%d", address, metricstorage.DefaultNodeExporterPort))
+			addresses = append(addresses, fmt.Sprintf("%s:%d", address, telemetryv1.DefaultNodeExporterPort))
 		}
 	}
 	return addresses, nil

--- a/controllers/telemetry_controller.go
+++ b/controllers/telemetry_controller.go
@@ -37,7 +37,6 @@ import (
 	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
 	ceilometer "github.com/openstack-k8s-operators/telemetry-operator/pkg/ceilometer"
 	logging "github.com/openstack-k8s-operators/telemetry-operator/pkg/logging"
-	metricstorage "github.com/openstack-k8s-operators/telemetry-operator/pkg/metricstorage"
 	telemetry "github.com/openstack-k8s-operators/telemetry-operator/pkg/telemetry"
 	obov1 "github.com/rhobs/observability-operator/pkg/apis/monitoring/v1alpha1"
 )
@@ -371,11 +370,11 @@ func reconcileMetricStorage(ctx context.Context, instance *telemetryv1.Telemetry
 	const (
 		metricStorageNamespaceLabel = "MetricStorage.Namespace"
 		metricStorageNameLabel      = "MetricStorage.Name"
-		metricStorageName           = metricstorage.DefaultServiceName
+		metricStorageName           = telemetryv1.DefaultServiceName
 	)
 	metricStorageInstance := &telemetryv1.MetricStorage{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      metricstorage.DefaultServiceName,
+			Name:      telemetryv1.DefaultServiceName,
 			Namespace: instance.Namespace,
 		},
 	}
@@ -388,7 +387,7 @@ func reconcileMetricStorage(ctx context.Context, instance *telemetryv1.Telemetry
 		return ctrl.Result{}, nil
 	}
 
-	helper.GetLogger().Info("Reconciling MetricStorage", metricStorageNamespaceLabel, instance.Namespace, metricStorageNameLabel, metricstorage.DefaultServiceName)
+	helper.GetLogger().Info("Reconciling MetricStorage", metricStorageNamespaceLabel, instance.Namespace, metricStorageNameLabel, telemetryv1.DefaultServiceName)
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), metricStorageInstance, func() error {
 		if instance.Spec.MetricStorage.MetricStorageSpec.CustomMonitoringStack != nil {
 			metricStorageInstance.Spec.CustomMonitoringStack = &obov1.MonitoringStackSpec{}
@@ -416,7 +415,7 @@ func reconcileMetricStorage(ctx context.Context, instance *telemetryv1.Telemetry
 		return ctrl.Result{}, err
 	}
 	if op != controllerutil.OperationResultNone {
-		helper.GetLogger().Info(fmt.Sprintf("%s %s - %s", metricstorage.DefaultServiceName, metricStorageInstance.Name, op))
+		helper.GetLogger().Info(fmt.Sprintf("%s %s - %s", telemetryv1.DefaultServiceName, metricStorageInstance.Name, op))
 	}
 
 	if metricStorageInstance.IsReady() {

--- a/pkg/metricstorage/monitoring_stack.go
+++ b/pkg/metricstorage/monitoring_stack.go
@@ -51,7 +51,7 @@ func MonitoringStack(
 				Disabled: !instance.Spec.MonitoringStack.AlertingEnabled,
 			},
 			PrometheusConfig: &obov1.PrometheusConfig{
-				Replicas: &PrometheusReplicas,
+				Replicas: &telemetryv1.PrometheusReplicas,
 				// NOTE: unsupported before OBOv0.0.21, but we can set the value
 				//       in the ServiceMonitor, so this isn't a big deal.
 				//ScrapeInterval: instance.Spec.MonitoringStack.ScrapeInterval,
@@ -84,7 +84,7 @@ func getPVCSpec(instance *telemetryv1.MetricStorage) (*corev1.PersistentVolumeCl
 			// the persistent field is omited, we won't have anything in
 			// persistentSpec.PvcStorageRequest and we need to set the default
 			// value like this here.
-			quantity, err = resource.ParseQuantity(DefaultPvcStorageRequest)
+			quantity, err = resource.ParseQuantity(telemetryv1.DefaultPvcStorageRequest)
 		} else {
 			quantity, err = resource.ParseQuantity(persistentSpec.PvcStorageRequest)
 		}

--- a/pkg/metricstorage/scrape_config.go
+++ b/pkg/metricstorage/scrape_config.go
@@ -40,7 +40,7 @@ func ScrapeConfig(
 		//} else if instance.Spec.CustomMonitoringStack.PrometheusConfig.ScrapeInterval {
 		//	scrapeInterval = instance.Spec.CustomMonitoringStack.PrometheusConfig.ScrapeInterval
 	} else {
-		scrapeInterval = DefaultScrapeInterval
+		scrapeInterval = telemetryv1.DefaultScrapeInterval
 	}
 	scrapeConfig := &unstructured.Unstructured{}
 	scrapeConfig.SetUnstructuredContent(map[string]interface{}{

--- a/pkg/metricstorage/service_monitor.go
+++ b/pkg/metricstorage/service_monitor.go
@@ -35,7 +35,7 @@ func ServiceMonitor(
 		//} else if instance.Spec.CustomMonitoringStack.PrometheusConfig.ScrapeInterval {
 		//	scrapeInterval = instance.Spec.CustomMonitoringStack.PrometheusConfig.ScrapeInterval
 	} else {
-		scrapeInterval = DefaultScrapeInterval
+		scrapeInterval = telemetryv1.DefaultScrapeInterval
 	}
 
 	serviceMonitor := &monv1.ServiceMonitor{


### PR DESCRIPTION
This is needed if we want to use the constants in other operators without the need to add telemetry-operator as a dependency. It'll be useful for this PR: https://github.com/openstack-k8s-operators/openstack-operator/pull/643