### PR TITLE
[zuul] Add a project template for telemetry-tempest jobs

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -29,15 +29,12 @@
     name: rdo-telemetry-tempest-plugin-jobs
     openstack-experimental:
       jobs:
-        - noop:
-            required-projects:
-              - openstack/telemetry-tempest-plugin
-              - openstack-k8s-operators/telemetry-operator
+        - noop
 
-#- project:
-#    name: openstack-k8s-operators/telemetry-operator
-#    templates:
-#      - podified-multinode-edpm-pipeline
-#    github-check:
-#      jobs:
-#        - telemetry-operator-multinode-autoscaling-tempest
+- project:
+    name: openstack-k8s-operators/telemetry-operator
+    templates:
+      - podified-multinode-edpm-pipeline
+    github-check:
+      jobs:
+        - telemetry-operator-multinode-autoscaling-tempest

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -25,6 +25,12 @@
           changeRepository: "https://review.opendev.org/openstack/telemetry-tempest-plugin"
           changeRefspec: "master"
 
+- project-template:
+    name: rdo-telemetry-tempest-plugin-jobs
+    openstack-experimental:
+      jobs:
+        - noop
+
 - project:
     name: openstack-k8s-operators/telemetry-operator
     templates:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -31,10 +31,10 @@
       jobs:
         - noop
 
-- project:
-    name: openstack-k8s-operators/telemetry-operator
-    templates:
-      - podified-multinode-edpm-pipeline
-    github-check:
-      jobs:
-        - telemetry-operator-multinode-autoscaling-tempest
+#- project:
+#    name: openstack-k8s-operators/telemetry-operator
+#    templates:
+#      - podified-multinode-edpm-pipeline
+#    github-check:
+#      jobs:
+#        - telemetry-operator-multinode-autoscaling-tempest

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -29,7 +29,10 @@
     name: rdo-telemetry-tempest-plugin-jobs
     openstack-experimental:
       jobs:
-        - noop
+        - noop:
+            required-projects:
+              - openstack/telemetry-tempest-plugin
+              - openstack-k8s-operators/telemetry-operator
 
 #- project:
 #    name: openstack-k8s-operators/telemetry-operator


### PR DESCRIPTION
This will run jobs against changes to telemetry-tempest-plugins The jobs can be triggered with "check rdo experimental" comment

The template will be added to the project in: https://review.rdoproject.org/r/c/config/+/51769
