### PR TITLE
[zuul][tempest] Re-enable the sg_core integration test

### DIFF
--- a/ci/vars-autoscaling-tempest.yml
+++ b/ci/vars-autoscaling-tempest.yml
@@ -16,5 +16,4 @@ cifmw_tempest_tempestconf_config:
 cifmw_test_operator_tempest_include_list: |
   telemetry_tempest_plugin.scenario
   telemetry_tempest_plugin.aodh
-cifmw_test_operator_tempest_exclude_list: |
-  telemetry_tempest_plugin.scenario.test_telemetry_integration_prometheus.PrometheusGabbiTest.test_ceilometer_sg_core_integration
+cifmw_test_operator_tempest_exclude_list: ''


### PR DESCRIPTION

Depends-On: https://review.opendev.org/c/openstack/telemetry-tempest-plugin/+/909459
Depends-On: https://github.com/openstack-k8s-operators/telemetry-operator/pull/284