### PR TITLE
Rename test_fw to cifmw_run_test_role

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -40,7 +40,7 @@
     name: telemetry-operator-multinode-autoscaling-tempest
     parent: telemetry-operator-multinode-autoscaling
     vars:
-      test_fw: test_operator
+      cifmw_run_test_role: test_operator
       cifmw_test_operator_tempest_namespace: podified-antelope-centos9
       cifmw_test_operator_tempest_container: openstack-tempest-all
       cifmw_test_operator_tempest_image_tag: 'current-podified'


### PR DESCRIPTION
Once [1] has been approved, the parameter test_fw has been renamed to cifmw_run_test_role.
This patch fixes it for the jobs that use that parameter.

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/1171