### PR TITLE
Add missing aodh httpd config

### DIFF
--- a/templates/autoscaling/config/wsgi-aodh.conf
+++ b/templates/autoscaling/config/wsgi-aodh.conf
@@ -1,19 +1,38 @@
-
+{{ range $endpt, $vhost := .VHosts }}
+# {{ $endpt }} vhost {{ $vhost.ServerName }} configuration
 <VirtualHost *:8042>
+  ServerName {{ $vhost.ServerName }}
+
+  ## Vhost docroot
+  DocumentRoot "/var/www/cgi-bin/aodh"
+
+  ## Directories, there should at least be a declaration for /var/www/cgi-bin/aodh
+
   <Directory "/var/www/cgi-bin/aodh">
-      <FilesMatch "^aodh-api$">
-        Options Indexes FollowSymLinks MultiViews
-        AllowOverride None
-        Require all granted
-      </FilesMatch>
+    Options -Indexes +FollowSymLinks +MultiViews
+    AllowOverride None
+    Require all granted
   </Directory>
+
   ## Logging
-  ErrorLog "/dev/stdout"
+  ErrorLog /dev/stdout
   ServerSignature Off
-  LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b %D \"%{Referer}i\" \"%{User-Agent}i\"" logformat
-  CustomLog "/dev/stdout" logformat
+  CustomLog /dev/stdout combined
+
+{{- if $vhost.TLS }}
+  SetEnvIf X-Forwarded-Proto https HTTPS=1
+
+  ## SSL directives
+  SSLEngine on
+  SSLCertificateFile      "{{ $vhost.SSLCertificateFile }}"
+  SSLCertificateKeyFile   "{{ $vhost.SSLCertificateKeyFile }}"
+{{- end }}
+
+  ## WSGI configuration
   WSGIApplicationGroup %{GLOBAL}
-  WSGIDaemonProcess aodh group=aodh processes=3 threads=1 user=aodh
-  WSGIProcessGroup aodh
+  WSGIDaemonProcess {{ $endpt }} display-name={{ $endpt }} group=aodh processes=3 threads=1 user=aodh
+  WSGIProcessGroup {{ $endpt }}
   WSGIScriptAlias / "/var/www/cgi-bin/aodh/aodh-api"
+  WSGIPassAuthorization On
 </VirtualHost>
+{{ end }}


### PR DESCRIPTION
There was configuration missing to enable TLS on aodh api endpoints. The httpd and wsgi files are taken from the cinder-operator. I was able to verify this works
by executing curl from openstackclient pod against the https://aodh-internal.openstack.svc and
https://aodh-public.openstack.svc endpoints.
The "openstack alarm list" command started working as well after this change when TLS was enabled in the control plane.

I also renamed the field index variables in preparation for https://github.com/openstack-k8s-operators/telemetry-operator/pull/320. The reason is, that all of the controllers are in the same package. Each controller needs these variables defined slightly different, so we need a unique name for the variables across each controller.