### PR TITLE
[tlse] TLS database connection

### DIFF
--- a/controllers/autoscaling_controller.go
+++ b/controllers/autoscaling_controller.go
@@ -50,6 +50,7 @@ import (
 	common_rbac "github.com/openstack-k8s-operators/lib-common/modules/common/rbac"
 	secret "github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	service "github.com/openstack-k8s-operators/lib-common/modules/common/service"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 
 	heatv1 "github.com/openstack-k8s-operators/heat-operator/api/v1beta1"
@@ -528,7 +529,16 @@ func (r *AutoscalingReconciler) generateServiceConfig(
 	db *mariadbv1.Database,
 ) error {
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(autoscaling.ServiceName), map[string]string{})
-	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.Aodh.CustomServiceConfig}
+
+	var tlsCfg *tls.Service
+	if instance.Spec.Aodh.TLS.CaBundleSecretName != "" {
+		tlsCfg = &tls.Service{}
+	}
+
+	customData := map[string]string{
+		common.CustomServiceConfigFileName: instance.Spec.Aodh.CustomServiceConfig,
+		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
+	}
 	for key, data := range instance.Spec.Aodh.DefaultConfigOverwrite {
 		customData[key] = data
 	}
@@ -565,7 +575,7 @@ func (r *AutoscalingReconciler) generateServiceConfig(
 		"PrometheusPort":           instance.Status.PrometheusPort,
 		"MemcachedServers":         strings.Join(mc.Status.ServerList, ","),
 		"MemcachedServersWithInet": strings.Join(mc.Status.ServerListWithInet, ","),
-		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s",
+		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
 			databaseAccount.Spec.UserName,
 			string(databaseSecret.Data[mariadbv1.DatabasePasswordSelector]),
 			instance.Status.DatabaseHostname,

--- a/templates/autoscaling/config/aodh-api-config.json
+++ b/templates/autoscaling/config/aodh-api-config.json
@@ -47,6 +47,12 @@
         "perm": "0400",
         "optional": true,
         "merge": true
+    },
+    {
+        "source": "/var/lib/openstack//config/my.cnf",
+        "dest": "/etc/my.cnf",
+        "owner": "aodh",
+        "perm": "0644"
     }
     ]
 }

--- a/templates/autoscaling/config/aodh-dbsync-config.json
+++ b/templates/autoscaling/config/aodh-dbsync-config.json
@@ -13,6 +13,12 @@
                         "owner": "aodh",
                         "perm": "0600",
                         "optional": true
+                },
+                {
+                        "source": "/var/lib/openstack//config/my.cnf",
+                        "dest": "/etc/my.cnf",
+                        "owner": "aodh",
+                        "perm": "0644"
                 }
         ]
 }

--- a/templates/autoscaling/config/aodh-evaluator-config.json
+++ b/templates/autoscaling/config/aodh-evaluator-config.json
@@ -19,6 +19,12 @@
         "dest": "/etc/openstack/prometheus.yaml",
         "owner": "aodh",
         "perm": "0600"
+      },
+      {
+        "source": "/var/lib/openstack//config/my.cnf",
+        "dest": "/etc/my.cnf",
+        "owner": "aodh",
+        "perm": "0644"
       }
     ]
   }

--- a/templates/autoscaling/config/aodh-listener-config.json
+++ b/templates/autoscaling/config/aodh-listener-config.json
@@ -13,6 +13,12 @@
         "owner": "aodh",
         "perm": "0600",
         "optional": true
+      },
+      {
+        "source": "/var/lib/openstack//config/my.cnf",
+        "dest": "/etc/my.cnf",
+        "owner": "aodh",
+        "perm": "0644"
       }
     ]
   }

--- a/templates/autoscaling/config/aodh-notifier-config.json
+++ b/templates/autoscaling/config/aodh-notifier-config.json
@@ -13,6 +13,12 @@
         "owner": "aodh",
         "perm": "0600",
         "optional": true
+      },
+      {
+        "source": "/var/lib/openstack//config/my.cnf",
+        "dest": "/etc/my.cnf",
+        "owner": "aodh",
+        "perm": "0644"
       }
     ]
   }


### PR DESCRIPTION
The my.cnf file gets added to the secret holding the service configs. The content of my.cnf is centrally managed in the mariadb-operator and retrieved calling db.GetDatabaseClientConfig(tlsCfg)

Depends-On: https://github.com/openstack-k8s-operators/mariadb-operator/pull/190
Depends-On: https://github.com/openstack-k8s-operators/mariadb-operator/pull/191

Jira: [OSPRH-4547](https://issues.redhat.com//browse/OSPRH-4547)