### PR TITLE
 migrate from databaseUsername to databaseAccount and fully use MariaDBAccount

### DIFF
--- a/api/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/api/bases/telemetry.openstack.org_autoscalings.yaml
@@ -48,15 +48,15 @@ spec:
                       content gets added to to /etc/<service>/<service>.conf.d directory
                       as custom.conf file.
                     type: string
+                  databaseAccount:
+                    default: aodh
+                    description: DatabaseAccount - optional MariaDBAccount CR name
+                      used for aodh DB, defaults to aodh
+                    type: string
                   databaseInstance:
                     description: MariaDB instance name Right now required by the maridb-operator
                       to get the credentials from the instance to create the DB Might
                       not be required in future
-                    type: string
-                  databaseUser:
-                    default: aodh
-                    description: Database user name Needed to connect to a database
-                      used by aodh
                     type: string
                   defaultConfigOverwrite:
                     additionalProperties:
@@ -255,7 +255,6 @@ spec:
                   passwordSelector:
                     default:
                       aodhService: AodhPassword
-                      database: AodhDatabasePassword
                     description: PasswordSelectors - Selectors to identify the service
                       from the Secret
                     properties:
@@ -263,11 +262,6 @@ spec:
                         default: AodhPassword
                         description: AodhService - Selector to get the aodh service
                           password from the Secret
-                        type: string
-                      database:
-                        default: AodhDatabasePassword
-                        description: Database - Selector to get the aodh database
-                          user password from the Secret
                         type: string
                       service:
                         default: CeilometerPassword

--- a/api/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometers.yaml
@@ -76,11 +76,6 @@ spec:
                     description: AodhService - Selector to get the aodh service password
                       from the Secret
                     type: string
-                  database:
-                    default: AodhDatabasePassword
-                    description: Database - Selector to get the aodh database user
-                      password from the Secret
-                    type: string
                   service:
                     default: CeilometerPassword
                     description: Service - Selector to get the ceilometer service

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -51,15 +51,15 @@ spec:
                           The content gets added to to /etc/<service>/<service>.conf.d
                           directory as custom.conf file.
                         type: string
+                      databaseAccount:
+                        default: aodh
+                        description: DatabaseAccount - optional MariaDBAccount CR
+                          name used for aodh DB, defaults to aodh
+                        type: string
                       databaseInstance:
                         description: MariaDB instance name Right now required by the
                           maridb-operator to get the credentials from the instance
                           to create the DB Might not be required in future
-                        type: string
-                      databaseUser:
-                        default: aodh
-                        description: Database user name Needed to connect to a database
-                          used by aodh
                         type: string
                       defaultConfigOverwrite:
                         additionalProperties:
@@ -269,7 +269,6 @@ spec:
                       passwordSelector:
                         default:
                           aodhService: AodhPassword
-                          database: AodhDatabasePassword
                         description: PasswordSelectors - Selectors to identify the
                           service from the Secret
                         properties:
@@ -277,11 +276,6 @@ spec:
                             default: AodhPassword
                             description: AodhService - Selector to get the aodh service
                               password from the Secret
-                            type: string
-                          database:
-                            default: AodhDatabasePassword
-                            description: Database - Selector to get the aodh database
-                              user password from the Secret
                             type: string
                           service:
                             default: CeilometerPassword
@@ -416,11 +410,6 @@ spec:
                         default: AodhPassword
                         description: AodhService - Selector to get the aodh service
                           password from the Secret
-                        type: string
-                      database:
-                        default: AodhDatabasePassword
-                        description: Database - Selector to get the aodh database
-                          user password from the Secret
                         type: string
                       service:
                         default: CeilometerPassword

--- a/api/v1beta1/autoscaling_types.go
+++ b/api/v1beta1/autoscaling_types.go
@@ -68,13 +68,13 @@ type AodhCore struct {
 	// Might not be required in future
 	DatabaseInstance string `json:"databaseInstance"`
 
-	// Database user name
-	// Needed to connect to a database used by aodh
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=aodh
-	DatabaseUser string `json:"databaseUser,omitempty"`
+	// DatabaseAccount - optional MariaDBAccount CR name used for aodh DB, defaults to aodh
+	DatabaseAccount string `json:"databaseAccount"`
 
 	// PasswordSelectors - Selectors to identify the service from the Secret
-	// +kubebuilder:default:={aodhService: AodhPassword, database: AodhDatabasePassword}
+	// +kubebuilder:default:={aodhService: AodhPassword}
 	PasswordSelectors PasswordsSelector `json:"passwordSelector,omitempty"`
 
 	// ServiceUser - optional username used for this service to register in keystone

--- a/api/v1beta1/telemetry_types.go
+++ b/api/v1beta1/telemetry_types.go
@@ -36,11 +36,6 @@ type PasswordsSelector struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:=AodhPassword
 	AodhService string `json:"aodhService"`
-
-	// Database - Selector to get the aodh database user password from the Secret
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:=AodhDatabasePassword
-	Database string `json:"database"`
 }
 
 // TelemetrySpec defines the desired state of Telemetry

--- a/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
@@ -48,15 +48,15 @@ spec:
                       content gets added to to /etc/<service>/<service>.conf.d directory
                       as custom.conf file.
                     type: string
+                  databaseAccount:
+                    default: aodh
+                    description: DatabaseAccount - optional MariaDBAccount CR name
+                      used for aodh DB, defaults to aodh
+                    type: string
                   databaseInstance:
                     description: MariaDB instance name Right now required by the maridb-operator
                       to get the credentials from the instance to create the DB Might
                       not be required in future
-                    type: string
-                  databaseUser:
-                    default: aodh
-                    description: Database user name Needed to connect to a database
-                      used by aodh
                     type: string
                   defaultConfigOverwrite:
                     additionalProperties:
@@ -255,7 +255,6 @@ spec:
                   passwordSelector:
                     default:
                       aodhService: AodhPassword
-                      database: AodhDatabasePassword
                     description: PasswordSelectors - Selectors to identify the service
                       from the Secret
                     properties:
@@ -263,11 +262,6 @@ spec:
                         default: AodhPassword
                         description: AodhService - Selector to get the aodh service
                           password from the Secret
-                        type: string
-                      database:
-                        default: AodhDatabasePassword
-                        description: Database - Selector to get the aodh database
-                          user password from the Secret
                         type: string
                       service:
                         default: CeilometerPassword

--- a/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
@@ -76,11 +76,6 @@ spec:
                     description: AodhService - Selector to get the aodh service password
                       from the Secret
                     type: string
-                  database:
-                    default: AodhDatabasePassword
-                    description: Database - Selector to get the aodh database user
-                      password from the Secret
-                    type: string
                   service:
                     default: CeilometerPassword
                     description: Service - Selector to get the ceilometer service

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -51,15 +51,15 @@ spec:
                           The content gets added to to /etc/<service>/<service>.conf.d
                           directory as custom.conf file.
                         type: string
+                      databaseAccount:
+                        default: aodh
+                        description: DatabaseAccount - optional MariaDBAccount CR
+                          name used for aodh DB, defaults to aodh
+                        type: string
                       databaseInstance:
                         description: MariaDB instance name Right now required by the
                           maridb-operator to get the credentials from the instance
                           to create the DB Might not be required in future
-                        type: string
-                      databaseUser:
-                        default: aodh
-                        description: Database user name Needed to connect to a database
-                          used by aodh
                         type: string
                       defaultConfigOverwrite:
                         additionalProperties:
@@ -269,7 +269,6 @@ spec:
                       passwordSelector:
                         default:
                           aodhService: AodhPassword
-                          database: AodhDatabasePassword
                         description: PasswordSelectors - Selectors to identify the
                           service from the Secret
                         properties:
@@ -277,11 +276,6 @@ spec:
                             default: AodhPassword
                             description: AodhService - Selector to get the aodh service
                               password from the Secret
-                            type: string
-                          database:
-                            default: AodhDatabasePassword
-                            description: Database - Selector to get the aodh database
-                              user password from the Secret
                             type: string
                           service:
                             default: CeilometerPassword
@@ -416,11 +410,6 @@ spec:
                         default: AodhPassword
                         description: AodhService - Selector to get the aodh service
                           password from the Secret
-                        type: string
-                      database:
-                        default: AodhDatabasePassword
-                        description: Database - Selector to get the aodh database
-                          user password from the Secret
                         type: string
                       service:
                         default: CeilometerPassword

--- a/config/samples/telemetry_v1beta1_autoscaling.yaml
+++ b/config/samples/telemetry_v1beta1_autoscaling.yaml
@@ -12,6 +12,6 @@ spec:
   aodh:
     secret: osp-secret
     passwordSelectors:
-    databaseUser: aodh
+    databaseAccount: aodh
     databaseInstance: openstack
     memcachedInstance: memcached

--- a/config/samples/telemetry_v1beta1_autoscaling_tls.yaml
+++ b/config/samples/telemetry_v1beta1_autoscaling_tls.yaml
@@ -12,7 +12,7 @@ spec:
   aodh:
     secret: osp-secret
     passwordSelectors:
-    databaseUser: aodh
+    databaseAccount: aodh
     databaseInstance: openstack
     memcachedInstance: memcached
     tls:

--- a/config/samples/telemetry_v1beta1_telemetry.yaml
+++ b/config/samples/telemetry_v1beta1_telemetry.yaml
@@ -17,7 +17,7 @@ spec:
     enabled: false
     aodh:
       passwordSelectors:
-      databaseUser: aodh
+      databaseAccount: aodh
       databaseInstance: openstack
       memcachedInstance: memcached
       secret: osp-secret

--- a/controllers/aodh_controller.go
+++ b/controllers/aodh_controller.go
@@ -55,7 +55,7 @@ func (r *AutoscalingReconciler) reconcileDeleteAodh(
 	Log.Info("Reconciling Service Aodh delete")
 
 	// remove db finalizer first
-	db, err := mariadbv1.GetDatabaseByName(ctx, helper, autoscaling.DatabaseName)
+	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, helper, autoscaling.DatabaseCRName, instance.Spec.Aodh.DatabaseAccount, instance.Namespace)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
@@ -147,70 +147,13 @@ func (r *AutoscalingReconciler) reconcileInitAodh(
 	if instance.Status.Hash == nil {
 		instance.Status.Hash = map[string]string{}
 	}
-	//
-	// create service DB instance
-	//
-	db := mariadbv1.NewDatabaseWithNamespace(
-		// instance.Name
-		// TODO: We might want to change the db name.
-		// The mariadb-operator is currently implemented
-		// in a way, that the db name needs to be the
-		// same as the user
-		instance.Spec.Aodh.DatabaseUser,
-		instance.Spec.Aodh.DatabaseUser,
-		instance.Spec.Aodh.Secret,
-		map[string]string{
-			"dbName": instance.Spec.Aodh.DatabaseInstance,
-		},
-		autoscaling.ServiceName,
-		instance.Namespace,
-	)
-	// create or patch the DB
-	ctrlResult, err = db.CreateOrPatchDBByName(
-		ctx,
-		helper,
-		instance.Spec.Aodh.DatabaseInstance,
-	)
+
+	_, result, err := r.ensureDB(ctx, helper, instance)
 	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DBReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.DBReadyErrorMessage,
-			err.Error()))
 		return ctrl.Result{}, err
+	} else if (result != ctrl.Result{}) {
+		return result, nil
 	}
-	if (ctrlResult != ctrl.Result{}) {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DBReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			condition.DBReadyRunningMessage))
-		return ctrlResult, nil
-	}
-	// wait for the DB to be setup
-	ctrlResult, err = db.WaitForDBCreated(ctx, helper)
-	if err != nil {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DBReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.DBReadyErrorMessage,
-			err.Error()))
-		return ctrlResult, err
-	}
-	if (ctrlResult != ctrl.Result{}) {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.DBReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			condition.DBReadyRunningMessage))
-		return ctrlResult, nil
-	}
-	// update Status.DatabaseHostname, used to config the service
-	instance.Status.DatabaseHostname = db.GetDatabaseHostname()
-	instance.Status.Conditions.MarkTrue(condition.DBReadyCondition, condition.DBReadyMessage)
-	// create service DB - end
 
 	//
 	// run Aodh db sync
@@ -254,6 +197,94 @@ func (r *AutoscalingReconciler) reconcileInitAodh(
 	// run Aodh db sync - end
 	Log.Info("Reconciled Service Aodh init successfully")
 	return ctrl.Result{}, nil
+}
+
+// ensureDB - create aodh DB instance
+func (r *AutoscalingReconciler) ensureDB(
+	ctx context.Context,
+	h *helper.Helper,
+	instance *telemetryv1.Autoscaling,
+) (*mariadbv1.Database, ctrl.Result, error) {
+	// ensure MariaDBAccount exists.  This account record may be created by
+	// openstack-operator or the cloud operator up front without a specific
+	// MariaDBDatabase configured yet.   Otherwise, a MariaDBAccount CR is
+	// created here with a generated username as well as a secret with
+	// generated password.   The MariaDBAccount is created without being
+	// yet associated with any MariaDBDatabase.
+	_, _, err := mariadbv1.EnsureMariaDBAccount(
+		ctx, h, instance.Spec.Aodh.DatabaseAccount,
+		instance.Namespace, false, autoscaling.DatabaseUsernamePrefix,
+	)
+
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			mariadbv1.MariaDBAccountReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			mariadbv1.MariaDBAccountNotReadyMessage,
+			err.Error()))
+
+		return nil, ctrl.Result{}, err
+	}
+	instance.Status.Conditions.MarkTrue(
+		mariadbv1.MariaDBAccountReadyCondition,
+		mariadbv1.MariaDBAccountReadyMessage)
+
+	// create aodh DB instance
+	//
+	db := mariadbv1.NewDatabaseForAccount(
+		instance.Spec.Aodh.DatabaseInstance, // mariadb/galera service to target
+		autoscaling.DatabaseName,            // name used in CREATE DATABASE in mariadb
+		autoscaling.DatabaseCRName,          // CR name for MariaDBDatabase
+		instance.Spec.Aodh.DatabaseAccount,  // CR name for MariaDBAccount
+		instance.Namespace,                  // namespace
+	)
+
+	// create or patch the DB
+	ctrlResult, err := db.CreateOrPatchAll(ctx, h)
+
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.DBReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.DBReadyErrorMessage,
+			err.Error()))
+		return db, ctrl.Result{}, err
+	}
+	if (ctrlResult != ctrl.Result{}) {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.DBReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.DBReadyRunningMessage))
+		return db, ctrlResult, nil
+	}
+	// wait for the DB to be setup
+	ctrlResult, err = db.WaitForDBCreated(ctx, h)
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.DBReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.DBReadyErrorMessage,
+			err.Error()))
+		return db, ctrlResult, err
+	}
+	if (ctrlResult != ctrl.Result{}) {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.DBReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.DBReadyRunningMessage))
+		return db, ctrlResult, nil
+	}
+	// update Status.DatabaseHostname, used to config the service
+	instance.Status.DatabaseHostname = db.GetDatabaseHostname()
+	instance.Status.Conditions.MarkTrue(condition.DBReadyCondition, condition.DBReadyMessage)
+	// create service DB - end
+
+	return db, ctrlResult, nil
 }
 
 func (r *AutoscalingReconciler) reconcileNormalAodh(
@@ -502,6 +533,14 @@ func (r *AutoscalingReconciler) reconcileNormalAodh(
 		}
 
 		configVars[tls.TLSHashName] = env.SetValue(certsHash)
+	}
+
+	// remove finalizers from unused MariaDBAccount records
+	err = mariadbv1.DeleteUnusedMariaDBAccountFinalizers(
+		ctx, helper, autoscaling.DatabaseCRName,
+		instance.Spec.Aodh.DatabaseAccount, instance.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// all cert input checks out so report InputReady

--- a/pkg/autoscaling/const.go
+++ b/pkg/autoscaling/const.go
@@ -26,8 +26,15 @@ const (
 	// PrometheusRetention -
 	PrometheusRetention = "5h"
 
-	// DatabaseName -
+	// DatabaseName - Name of the database used in CREATE DATABASE statement
 	DatabaseName = "aodh"
+
+	// DatabaseCRName - Name of the MariaDBDatabase CR
+	DatabaseCRName = "aodh"
+
+	// DatabaseUsernamePrefix - used by EnsureMariaDBAccount when a new username
+	// is to be generated, e.g. "aodh_e5a4", "aodh_78bc", etc
+	DatabaseUsernamePrefix = "aodh"
 
 	// AodhAPIPort -
 	AodhAPIPort = 8042

--- a/tests/kuttl/suites/autoscaling/tests/01-deploy.yaml
+++ b/tests/kuttl/suites/autoscaling/tests/01-deploy.yaml
@@ -10,7 +10,7 @@ spec:
     notifierImage: "quay.io/mmagr/openstack-aodh-notifier:current-podified"
     listenerImage: "quay.io/mmagr/openstack-aodh-listener:current-podified"
     passwordSelectors:
-    databaseUser: aodh
+    databaseAccount: aodh
     databaseInstance: openstack
     memcachedInstance: memcached
   heatInstance: heat

--- a/tests/kuttl/suites/default/tests/01-deploy.yaml
+++ b/tests/kuttl/suites/default/tests/01-deploy.yaml
@@ -22,7 +22,7 @@ spec:
       notifierImage: "quay.io/mmagr/openstack-aodh-notifier:current-podified"
       listenerImage: "quay.io/mmagr/openstack-aodh-listener:current-podified"
       passwordSelectors:
-      databaseUser: aodh
+      databaseAccount: aodh
       databaseInstance: openstack
       memcachedInstance: memcached
     heatInstance: heat

--- a/tests/kuttl/suites/tls/tests/02-deploy.yaml
+++ b/tests/kuttl/suites/tls/tests/02-deploy.yaml
@@ -10,7 +10,7 @@ spec:
     notifierImage: "quay.io/mmagr/openstack-aodh-notifier:current-podified"
     listenerImage: "quay.io/mmagr/openstack-aodh-listener:current-podified"
     passwordSelectors:
-    databaseUser: aodh
+    databaseAccount: aodh
     databaseInstance: openstack
     memcachedInstance: memcached
     tls:


### PR DESCRIPTION
Lead Jira: [OSPRH-4095](https://issues.redhat.com/browse/OSPRH-4095)

1. [x] controller calls EnsureMariaDBAccount up front to make sure MariaDBAccount is present
2. [x] error code from EnsureMariaDBAccount is handled, Conditions are amended when error is returned
3. [x] controller calls NewDatabaseForAccount instead of NewDatabase
4. [x]  GetAccountAndSecret is used to retrieve account /secret to populate template
5. [x]  GetDatabaseByName() , normally used for delete finalizers, replaced with GetDatabaseByNameAndAccount
6. [x]  CreateOrPatchAll() used to patch the Database, replacing CreateOrPatchDB / CreateOrPatchDBByName
7. [x]  controller calls DeleteUnusedMariaDBAccountFinalizers when launched pods are definitely running on a new MariaDBAccount, returns error code if present
8. [x]  PasswordSelectors that refer to database are removed
9. [x]  all databaseUser replaced with databaseAccount inside of all XYZ_types.go
10. [x] all databaseUser replaced with databaseAccount inside of all `kuttl/*.yaml`
11. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all XYZ_types.go
12. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all `kuttl/*.yaml`
13. [x] MariaDBAccountSuiteTests are used in controller ginkgo tests if it has them
14. [x] [184](https://github.com/openstack-k8s-operators/mariadb-operator/pull/184) is merged and replaces from go.mod are removed


