### PR TITLE
[zuul] Remove content-provider dependency for tempest template

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -34,6 +34,7 @@
     openstack-experimental:
       jobs:
         - telemetry-operator-multinode-autoscaling-tempest:
+            dependencies: []
             pre-run:
               - ci/debug-get-branch-for-telemetry-tempest-plugin.yml
             vars:


### PR DESCRIPTION
The openstack containers don't need to be rebuilt when testing the telemetry-tempest-plugin, so the dependency on the content provider can be overwritten in the job varient used for testing the plugin. Images will be used from quay instead.