### PR TITLE
Logging controller updates status instead of failing when cloNamespac…

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -51,6 +51,9 @@ const (
 	// LoggingReadyCondition Status=True condition which indicates if the Logging is configured and operational
 	LoggingReadyCondition condition.Type = "LoggingReady"
 
+	// LoggingCLONamespaceReadyCondition Status=True condition which indicates if the cluster-logging-operator namespace is created
+	LoggingCLONamespaceReadyCondition condition.Type = "LoggingCLONamespaceReady"
+
 	DashboardPrometheusRuleReadyCondition condition.Type = "DashboardPrometheusRuleReady"
 
 	DashboardDatasourceReadyCondition condition.Type = "DashboardDatasourceReady"
@@ -192,6 +195,9 @@ const (
 	// LoggingReadyRunningMessage
 	LoggingReadyRunningMessage = "Logging in progress"
 
+	// LoggingCLONamespaceFailedMessage
+	LoggingCLONamespaceFailedMessage = "CLO Namespace %s does not exist"
+
 	DashboardsNotEnabledMessage = "Dashboarding was not enabled, so no actions required"
 
 	DashboardPrometheusRuleReadyInitMessage = "Dashboard PrometheusRule not started"
@@ -202,5 +208,4 @@ const (
 
 	DashboardDefinitionReadyInitMessage = "Dashboard Definition not started"
 	DashboardDefinitionFailedMessage = "Error occured when trying to install the dashboard definitions: %s"
-
 )

--- a/api/v1beta1/metricstorage_consts.go
+++ b/api/v1beta1/metricstorage_consts.go
@@ -29,7 +29,7 @@ const (
 	// DefaultScrapeInterval -
 	DefaultScrapeInterval = "30s"
 	// PauseBetweenWatchAttempts -
-	PauseBetweenWatchAttempts = time.Duration(10) * time.Second
+	PauseBetweenWatchAttempts = time.Duration(60) * time.Second
 )
 
 // PrometheusReplicas -


### PR DESCRIPTION
…e does not exist

Also, this raises the waiting time for triggering a new reconcile to 1 minute, 10 seconds does create a lot of spam in the logs and the user cannot really fix things in so little time.

Maybe the time could even be raised further to something like 5 minutes.