### PR TITLE
[zuul] Update the sg_core_url: ceilometer-internal -> ceilometer

### DIFF
--- a/ci/vars-autoscaling-tempest.yml
+++ b/ci/vars-autoscaling-tempest.yml
@@ -5,6 +5,7 @@ cifmw_test_operator_tempest_container: openstack-tempest-all
 cifmw_test_operator_tempest_image_tag: 'current-podified'
 # This value is used to populate the `tempestconfRun` parameter of the Tempest CR: https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource
 # https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/test_operator/defaults/main.yml
+# TODO: allow some way to select the sg_core URLwithout overriding the whole config
 cifmw_tempest_tempestconf_config:
   overrides: |
       validation.run_validation true
@@ -12,7 +13,7 @@ cifmw_tempest_tempestconf_config:
       service_available.ceilometer true
       service_available.sg_core true
       service_available.aodh true
-      telemetry.sg_core_service_url "ceilometer-internal.openstack.svc.cluster.local:3000"
+      telemetry.sg_core_service_url "ceilometer.openstack.svc.cluster.local:3000"
 cifmw_test_operator_tempest_include_list: |
   telemetry_tempest_plugin.scenario
   telemetry_tempest_plugin.aodh


### PR DESCRIPTION
The ceilometer-internal service is not always created

This is to help debug some downstream issues where ciloemter-internal is not available. This is to confirm the issue, and make sure there isn't some other issues blocking the tempest jobs from passing.
If this is the case, I need to add some way to set the sg_core_url so we can override it downstream without overriding the whole tempest conf
