### PR TITLE
[zuul] Add a job to check operator errors

### DIFF
--- a/ci/check-default-telemetry.yml
+++ b/ci/check-default-telemetry.yml
@@ -49,11 +49,8 @@
             msg: "Errors were found in the telemetry-operator logs"
       when: error_list | length != 0
 
-    - name: "Get telemetry-operator container restart counts"
-      ansible.builtin.command:
-        cmd:
-          oc get pods -n openstack-operators -l "openstack.org/operator-name=telemetry" --output=jsonpath --template='{.items[*].status.containerStatuses[*].restartCount}'
-      register: restart_counts
+    - name: "Get telemetry-operator restart counts"
+      ansible.builtin.import_tasks: "get-operator-restart-counts.yml"
 
     - name: "Fail if telemetry-operator was restarted"
       block:
@@ -70,7 +67,7 @@
         - name: "Fail because telemetry-operator restarted"
           ansible.builtin.fail:
             msg: "Telemetry-operator restarted"
-      when: restart_counts.stdout != "0 0"
+      when: restart_counts != [0, 0]
 
     # Enabling Autoscaling and MetricStorage without COO installed. Expected to see errors.
     - name: "Enable MetricStorage"
@@ -88,11 +85,8 @@
       ansible.builtin.wait_for:
         timeout: 120
 
-    - name: "Get telemetry-operator container restart counts"
-      ansible.builtin.command:
-        cmd:
-          oc get pods -n openstack-operators -l "openstack.org/operator-name=telemetry" --output=jsonpath --template='{.items[*].status.containerStatuses[*].restartCount}'
-      register: restart_counts
+    - name: "Get telemetry-operator restart counts"
+      ansible.builtin.import_tasks: "get-operator-restart-counts.yml"
 
     - name: "Fail if telemetry-operator was restarted"
       block:
@@ -109,7 +103,7 @@
         - name: "Fail because telemetry-operator restarted"
           ansible.builtin.fail:
             msg: "Telemetry-operator restarted"
-      when: restart_counts.stdout != "0 0"
+      when: restart_counts != [0, 0]
 
     - name: "Get telemetry-operator logs"
       ansible.builtin.import_tasks: "get-operator-logs.yml"
@@ -118,7 +112,7 @@
       ansible.builtin.fail:
         msg: "telemetry-operator logs don't include expected log: {{ item }}"
       loop: "{{ expected_logs }}"
-      when: operator_logs.stdout | ansible.builtin.regex_search( "^.*" + item + ".*$" )
+      when: not (operator_logs.stdout | ansible.builtin.regex_search( ".*" + item + ".*" ))
 
     - name: "Check telemetry-operator logs for Errors"
       ansible.builtin.set_fact:
@@ -204,7 +198,7 @@
 
     - name: "Fail if unexpected errors are present"
       ansible.builtin.fail:
-        msg: "telemetry-operator logs include an expected error"
+        msg: "telemetry-operator logs include an unexpected error"
       when: error_list | length != 0
 
     # If we got here, we know that the telemetry status is Ready

--- a/ci/check-default-telemetry.yml
+++ b/ci/check-default-telemetry.yml
@@ -1,0 +1,212 @@
+---
+- name: "Check telemetry-operator logs for errors"
+  hosts: "{{ cifmw_target_hook_host | default('localhost')  }}"
+  gather_facts: false
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  vars:
+    expected_logs:
+      - "INFO	Controllers.MetricStorage	Can't own MonitoringStack resource"
+    expected_metricstorage_conditions: >-
+      {{
+        dict([
+          ["MonitoringStackReady", 'Error occured when trying to own: customresourcedefinitions.apiextensions.k8s.io "monitoringstacks.monitoring.rhobs" not found'],
+          ["Ready", 'Error occured when trying to own: customresourcedefinitions.apiextensions.k8s.io "monitoringstacks.monitoring.rhobs" not found']
+        ])
+      }}
+    expected_autoscaling_conditions: >-
+      {{
+        dict([
+          ["Ready", 'Setup complete']
+        ])
+      }}
+  tasks:
+    - name: "Get telemetry condition"
+      ansible.builtin.command:
+        cmd:
+          oc get telemetry telemetry --output=jsonpath --template={.status.conditions[*].status}
+      register: output
+      retries: 12
+      delay: 10
+      until: output.stdout is ansible.builtin.regex("(True\s?)+$")
+
+    - name: "Get telemetry-operator logs"
+      ansible.builtin.import_tasks: "get-operator-logs.yml"
+
+    - name: "Check telemetry-operator logs for Errors"
+      ansible.builtin.set_fact:
+        error_list: "{{ operator_logs.stdout | ansible.builtin.regex_findall('ERROR.*') }}"
+
+    - name: "Fail if errors were found"
+      block:
+        - name: "Output found errors for debugging purposes"
+          ansible.builtin.debug:
+            var: error_list
+
+        - name: "Fail because errors were found in telemetry-operator logs"
+          ansible.builtin.fail:
+            msg: "Errors were found in the telemetry-operator logs"
+      when: error_list | length != 0
+
+    - name: "Get telemetry-operator container restart counts"
+      ansible.builtin.command:
+        cmd:
+          oc get pods -n openstack-operators -l "openstack.org/operator-name=telemetry" --output=jsonpath --template='{.items[*].status.containerStatuses[*].restartCount}'
+      register: restart_counts
+
+    - name: "Fail if telemetry-operator was restarted"
+      block:
+        - name: "Get telemetry-operator failed pod logs"
+          ansible.builtin.command:
+            cmd:
+              oc logs -n openstack-operators -p -l "openstack.org/operator-name=telemetry" --tail=-1
+          register: operator_logs_previous
+
+        - name: "Output logs for debugging purposes"
+          ansible.builtin.debug:
+            var: operator_logs_previous.stdout_lines
+
+        - name: "Fail because telemetry-operator restarted"
+          ansible.builtin.fail:
+            msg: "Telemetry-operator restarted"
+      when: restart_counts.stdout != "0 0"
+
+    # Enabling Autoscaling and MetricStorage without COO installed. Expected to see errors.
+    - name: "Enable MetricStorage"
+      ansible.builtin.command:
+        cmd: |
+          oc patch oscp/openstack-galera-network-isolation --type='json' -p '[{"op": "replace", "path": "/spec/telemetry/template/metricStorage/enabled", "value":true}]'
+
+    - name: "Enable Autoscaling"
+      ansible.builtin.command:
+        cmd: |
+          oc patch oscp/openstack-galera-network-isolation --type='json' -p '[{"op": "replace", "path": "/spec/telemetry/template/autoscaling/enabled", "value":true}]'
+
+    - name: "Wait until reconciliation finishes"
+      # There isn't a convinient way to know when it finished. The status conditions will never get to a "Ready" state in this situation
+      ansible.builtin.wait_for:
+        timeout: 120
+
+    - name: "Get telemetry-operator container restart counts"
+      ansible.builtin.command:
+        cmd:
+          oc get pods -n openstack-operators -l "openstack.org/operator-name=telemetry" --output=jsonpath --template='{.items[*].status.containerStatuses[*].restartCount}'
+      register: restart_counts
+
+    - name: "Fail if telemetry-operator was restarted"
+      block:
+        - name: "Get telemetry-operator failed pod logs"
+          ansible.builtin.command:
+            cmd:
+              oc logs -n openstack-operators -p -l "openstack.org/operator-name=telemetry" --tail=-1
+          register: operator_logs_previous
+
+        - name: "Output logs for debugging purposes"
+          ansible.builtin.debug:
+            var: operator_logs_previous.stdout_lines
+
+        - name: "Fail because telemetry-operator restarted"
+          ansible.builtin.fail:
+            msg: "Telemetry-operator restarted"
+      when: restart_counts.stdout != "0 0"
+
+    - name: "Get telemetry-operator logs"
+      ansible.builtin.import_tasks: "get-operator-logs.yml"
+
+    - name: "Fail if expected logs are missing"
+      ansible.builtin.fail:
+        msg: "telemetry-operator logs don't include expected log: {{ item }}"
+      loop: "{{ expected_logs }}"
+      when: operator_logs.stdout | ansible.builtin.regex_search( "^.*" + item + ".*$" )
+
+    - name: "Check telemetry-operator logs for Errors"
+      ansible.builtin.set_fact:
+        error_list: "{{ operator_logs.stdout | ansible.builtin.regex_findall('ERROR.*') }}"
+
+    - name: "Fail if unexpected errors are present"
+      ansible.builtin.fail:
+        msg: "telemetry-operator logs include an unexpected error: {{ item }}"
+      loop: "{{ error_list }}"
+      when: item not in expected_logs
+
+    - name: "Check if we have the expected conditions for MetricStorage"
+      block:
+        - name: "Get MetricStorage condition types"
+          ansible.builtin.command:
+            cmd:
+              oc get metricstorage metric-storage -o jsonpath='{.status.conditions[*].type}'
+          register: condition_types
+
+        - name: "Get MetricStorage condition values"
+          ansible.builtin.command:
+            cmd:
+              oc get metricstorage metric-storage -o jsonpath='{.status.conditions[?(@.type == "{{ item }}")].message}'
+          register: output
+          loop: "{{ condition_types.stdout | split(' ') }}"
+
+        - name: "Construct MetricStorage condition dictionary"
+          ansible.builtin.set_fact:
+            conditions: "{{ conditions | default({}) | combine({item.item: item.stdout}) }}"
+          loop: "{{ output.results }}"
+
+        - name: "Fail if an expected condition wasn't found"
+          ansible.builtin.fail:
+            msg: "Expected {{ item.key }} condition field to be {{ item.value }}, not {{ output }}"
+          when: conditions[item.key] != item.value
+          loop: "{{ expected_metricstorage_conditions | dict2items }}"
+
+    - name: "Check that we have the expected conditions for Autoscaling"
+      block:
+        - name: "Get Autoscaling condition types"
+          ansible.builtin.command:
+            cmd:
+              oc get autoscaling autoscaling -o jsonpath='{.status.conditions[*].type}'
+          register: condition_types
+
+        - name: "Get Autoscaling condition values"
+          ansible.builtin.command:
+            cmd:
+              oc get autoscaling autoscaling -o jsonpath='{.status.conditions[?(@.type == "{{ item }}")].message}'
+          register: output
+          loop: "{{ condition_types.stdout | split(' ') }}"
+
+        - name: "Construct Autoscaling condition dictionary"
+          ansible.builtin.set_fact:
+            conditions: "{{ conditions | default({}) | combine({item.item: item.stdout}) }}"
+          loop: "{{ output.results }}"
+
+        - name: "Fail if an expected condition wasn't found"
+          ansible.builtin.fail:
+            msg: "Expected {{ item.key }} condition field to be {{ item.value }}, not {{ output }}"
+          when: conditions[item.key] != item.value
+          loop: "{{ expected_autoscaling_conditions | dict2items }}"
+
+    # Installing COO and restarting the operators. Expecting everything to run without errors.
+    - name: Install COO
+      ansible.builtin.include_tasks: "create-coo-subscription.yaml"
+
+    - name: "Wait until Autoscaling and MetricStorage are ready"
+      ansible.builtin.command:
+        cmd:
+          oc get telemetry telemetry --output=jsonpath --template={.status.conditions[*].status}
+      register: output
+      retries: 12
+      delay: 10
+      until: output.stdout is ansible.builtin.regex("(True\s?)+$")
+
+    - name: "Get telemetry-operator logs"
+      ansible.builtin.import_tasks: "get-operator-logs.yml"
+
+    - name: "Check telemetry-operator logs for Errors"
+      ansible.builtin.set_fact:
+        error_list: "{{ operator_logs.stdout | ansible.builtin.regex_findall('ERROR.*') }}"
+
+    - name: "Fail if unexpected errors are present"
+      ansible.builtin.fail:
+        msg: "telemetry-operator logs include an expected error"
+      when: error_list | length != 0
+
+    # If we got here, we know that the telemetry status is Ready
+    # and there aren't any new error. Everything should be correctly
+    # deployed.

--- a/ci/create-coo-subscription-playbook.yaml
+++ b/ci/create-coo-subscription-playbook.yaml
@@ -1,0 +1,10 @@
+---
+- name: "Create the cluster-observability-operator subscription"
+  hosts: "{{ cifmw_target_hook_host | default('localhost')  }}"
+  gather_facts: false
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  tasks:
+    - name: Import tasks for creating COO subscription
+      ansible.builtin.include_tasks: "create-coo-subscription.yaml"

--- a/ci/create-coo-subscription.yaml
+++ b/ci/create-coo-subscription.yaml
@@ -1,40 +1,33 @@
 ---
-- name: "Create the cluster-observability-operator subscription"
-  hosts: "{{ cifmw_target_hook_host | default('localhost')  }}"
-  gather_facts: false
-  environment:
-    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
-    PATH: "{{ cifmw_path }}"
-  tasks:
-    - name: Create the COO subscription
-      ansible.builtin.shell:
-        cmd: |
-          oc create -f - <<EOF
-          apiVersion: operators.coreos.com/v1alpha1
-          kind: Subscription
-          metadata:
-            name: cluster-observability-operator
-            namespace: openshift-operators
-          spec:
-            channel: development
-            installPlanApproval: Automatic
-            name: cluster-observability-operator
-            source: redhat-operators
-            sourceNamespace: openshift-marketplace
-          EOF
-      register: output
+- name: Create the COO subscription
+  ansible.builtin.shell:
+    cmd: |
+      oc create -f - <<EOF
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: cluster-observability-operator
+        namespace: openshift-operators
+      spec:
+        channel: development
+        installPlanApproval: Automatic
+        name: cluster-observability-operator
+        source: redhat-operators
+        sourceNamespace: openshift-marketplace
+      EOF
+  register: output
 
-      # need to have a wait here, since the csv is not created immediately. There is a slight delay, during which time, the oc wait command would fail, since there's no resource to watch
-    - name: Wait for the required resource to be created
-      ansible.builtin.command:
-        cmd:
-          oc get csv --namespace=openshift-operators -l operators.coreos.com/cluster-observability-operator.openshift-operators
-      delay: 10
-      retries: 20
-      register: output
-      until: output.stdout_lines | length != 0
+  # need to have a wait here, since the csv is not created immediately. There is a slight delay, during which time, the oc wait command would fail, since there's no resource to watch
+- name: Wait for the required resource to be created
+  ansible.builtin.command:
+    cmd:
+      oc get csv --namespace=openshift-operators -l operators.coreos.com/cluster-observability-operator.openshift-operators
+  delay: 10
+  retries: 20
+  register: output
+  until: output.stdout_lines | length != 0
 
-    - name: Wait for the resources to be available
-      ansible.builtin.command:
-        cmd: |
-          oc wait --timeout=300s --for jsonpath="{.status.phase}"=Succeeded csv --namespace=openshift-operators -l operators.coreos.com/cluster-observability-operator.openshift-operators
+- name: Wait for the resources to be available
+  ansible.builtin.command:
+    cmd: |
+      oc wait --timeout=300s --for jsonpath="{.status.phase}"=Succeeded csv --namespace=openshift-operators -l operators.coreos.com/cluster-observability-operator.openshift-operators

--- a/ci/get-operator-logs.yml
+++ b/ci/get-operator-logs.yml
@@ -1,0 +1,14 @@
+---
+- name: "Get current time"
+  ansible.builtin.set_fact:
+    operator_reconciled_timestamp: "{{ now(utc=true,fmt='%Y-%m-%dT%H:%M:%SZ') }}"
+
+- name: "Wait for new logs to be generated"
+  ansible.builtin.wait_for:
+    timeout: 120
+
+- name: "Get new telemetry-operator logs"
+  ansible.builtin.command:
+    cmd:
+      oc logs -n openstack-operators -l "openstack.org/operator-name=telemetry" --tail=-1 --since-time "{{ operator_reconciled_timestamp }}"
+  register: operator_logs

--- a/ci/get-operator-restart-counts.yml
+++ b/ci/get-operator-restart-counts.yml
@@ -1,0 +1,14 @@
+---
+- name: "Get telemetry-operator pod data"
+  ansible.builtin.command:
+    cmd:
+      oc get pods -n openstack-operators -l "openstack.org/operator-name=telemetry" --output=jsonpath --template='{.items[0]}'
+  register: output
+
+- name: "Get telemetry-operator container statuses"
+  ansible.builtin.set_fact:
+    container_statuses: "{{ (output.stdout | from_json).status.containerStatuses }}"
+
+- name: "Get telemetry-operator restart counts"
+  ansible.builtin.set_fact:
+    restart_counts: "{{ range(container_statuses | length) | map('extract', container_statuses) | map(attribute='restartCount') }}"

--- a/ci/vars-default-telemetry.yml
+++ b/ci/vars-default-telemetry.yml
@@ -1,7 +1,7 @@
 ---
-cifmw_edpm_prepare_timeout: 60
-pre_deploy_create_coo_subscription:
-    source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/create-coo-subscription-playbook.yaml"
+post_ctlplane_deploy:
+  - name: Check default telemetry
+    source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/check-default-telemetry.yml"
     type: playbook
 cifmw_edpm_prepare_kustomizations:
   - apiVersion: kustomize.config.k8s.io/v1beta1
@@ -18,12 +18,5 @@ cifmw_edpm_prepare_kustomizations:
             enabled: true
           telemetry:
             enabled: true
-            template:
-              metricStorage:
-                enabled: true
-                monitoringStack:
-                  alertingEnabled: false
-              autoscaling:
-                enabled: true
       target:
         kind: OpenStackControlPlane

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -18,6 +18,17 @@
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-autoscaling.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-autoscaling-tempest.yml"
 
+- job:
+    name: telemetry-operator-multinode-default-telemetry
+    parent: podified-multinode-edpm-deployment-crc
+    dependencies: ["openstack-k8s-operators-content-provider"]
+    description: |
+      Deploy a default OpenStack with telemetry enabled, but without COO installed. Check that the telemetry-operator logs don't have any errors.
+    vars:
+      cifmw_extras:
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir  }}/scenarios/centos-9/multinode-ci.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-default-telemetry.yml"
+
 - project-template:
     name: rdo-telemetry-tempest-plugin-jobs
     openstack-experimental:
@@ -54,3 +65,4 @@
     github-check:
       jobs:
         - telemetry-operator-multinode-autoscaling-tempest
+        - telemetry-operator-multinode-default-telemetry


### PR DESCRIPTION
This checks for errors in the operator logs.

For testing purposes I introduced an error in the metricstorage controller, so the job should fail right now.