### PR TITLE
Improve defaulting

### DIFF
--- a/api/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/api/bases/telemetry.openstack.org_autoscalings.yaml
@@ -36,6 +36,18 @@ spec:
             description: AutoscalingSpec defines the desired state of Autoscaling
             properties:
               aodh:
+                default:
+                  apiImage: ""
+                  databaseAccount: aodh
+                  databaseInstance: openstack
+                  evaluatorImage: ""
+                  listenerImage: ""
+                  notifierImage: ""
+                  passwordSelector:
+                    aodhService: AodhPassword
+                  rabbitMqClusterName: rabbitmq
+                  secret: osp-secret
+                  serviceUser: aodh
                 description: Aodh spec
                 properties:
                   apiImage:
@@ -54,6 +66,7 @@ spec:
                       used for aodh DB, defaults to aodh
                     type: string
                   databaseInstance:
+                    default: openstack
                     description: MariaDB instance name Right now required by the maridb-operator
                       to get the credentials from the instance to create the DB Might
                       not be required in future
@@ -288,6 +301,7 @@ spec:
                       that is created and used in Aodh
                     type: string
                   secret:
+                    default: osp-secret
                     description: Secret containing OpenStack password information
                       for aodh
                     type: string

--- a/api/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometers.yaml
@@ -90,6 +90,7 @@ spec:
                   that is created and used in Telemetry
                 type: string
               secret:
+                default: osp-secret
                 description: Secret containing OpenStack password information for
                   ceilometer
                 type: string

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -39,6 +39,18 @@ spec:
                 description: Autoscaling - Parameters related to the autoscaling service
                 properties:
                   aodh:
+                    default:
+                      apiImage: ""
+                      databaseAccount: aodh
+                      databaseInstance: openstack
+                      evaluatorImage: ""
+                      listenerImage: ""
+                      notifierImage: ""
+                      passwordSelector:
+                        aodhService: AodhPassword
+                      rabbitMqClusterName: rabbitmq
+                      secret: osp-secret
+                      serviceUser: aodh
                     description: Aodh spec
                     properties:
                       apiImage:
@@ -57,6 +69,7 @@ spec:
                           name used for aodh DB, defaults to aodh
                         type: string
                       databaseInstance:
+                        default: openstack
                         description: MariaDB instance name Right now required by the
                           maridb-operator to get the credentials from the instance
                           to create the DB Might not be required in future
@@ -301,6 +314,7 @@ spec:
                           that is created and used in Aodh
                         type: string
                       secret:
+                        default: osp-secret
                         description: Secret containing OpenStack password information
                           for aodh
                         type: string
@@ -434,6 +448,7 @@ spec:
                       that is created and used in Telemetry
                     type: string
                   secret:
+                    default: osp-secret
                     description: Secret containing OpenStack password information
                       for ceilometer
                     type: string

--- a/api/v1beta1/autoscaling_types.go
+++ b/api/v1beta1/autoscaling_types.go
@@ -63,6 +63,7 @@ type AodhCore struct {
 	RabbitMqClusterName string `json:"rabbitMqClusterName,omitempty"`
 
 	// +kubebuilder:validation:Required
+	// +kubebuilder:default=openstack
 	// MariaDB instance name
 	// Right now required by the maridb-operator to get the credentials from the instance to create the DB
 	// Might not be required in future
@@ -84,6 +85,7 @@ type AodhCore struct {
 
 	// Secret containing OpenStack password information for aodh
 	// +kubebuilder:validation:Required
+	// +kubebuilder:default=osp-secret
 	Secret string `json:"secret"`
 
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,
@@ -128,6 +130,7 @@ type AutoscalingSpec struct {
 	AutoscalingSpecBase `json:",inline"`
 
 	// Aodh spec
+	// +kubebuilder:default={rabbitMqClusterName: rabbitmq, databaseAccount: aodh, passwordSelector: {aodhService: AodhPassword}, serviceUser: aodh, apiImage: "", evaluatorImage: "", notifierImage: "", listenerImage: "", databaseInstance: "openstack", secret: "osp-secret"}
 	Aodh Aodh `json:"aodh,omitempty"`
 }
 
@@ -136,6 +139,7 @@ type AutoscalingSpecCore struct {
 	AutoscalingSpecBase `json:",inline"`
 
 	// Aodh spec
+	// +kubebuilder:default={rabbitMqClusterName: rabbitmq, databaseAccount: aodh, passwordSelector: {aodhService: AodhPassword}, serviceUser: aodh, databaseInstance: "openstack", secret: "osp-secret"}
 	Aodh AodhCore `json:"aodh,omitempty"`
 }
 

--- a/api/v1beta1/ceilometer_types.go
+++ b/api/v1beta1/ceilometer_types.go
@@ -81,6 +81,7 @@ type CeilometerSpecCore struct {
 
 	// Secret containing OpenStack password information for ceilometer
 	// +kubebuilder:validation:Required
+	// +kubebuilder:default=osp-secret
 	Secret string `json:"secret"`
 
 	// CustomServiceConfig - customize the service config using this parameter to change service defaults,

--- a/api/v1beta1/metricstorage_webhook.go
+++ b/api/v1beta1/metricstorage_webhook.go
@@ -51,6 +51,9 @@ func (spec *MetricStorageSpec) Default() {
 		// and we don't have a way of distinguishing if the value was left
 		// empty or set to false by the user in the spec.MonitoringStack.Default()
 		spec.MonitoringStack.AlertingEnabled = true
+
+		// NOTE: If we want to enable dashboards in the future by default, set
+		//       it here like Alerting above
 	}
 	if spec.MonitoringStack != nil {
 		spec.MonitoringStack.Default()
@@ -61,6 +64,9 @@ func (spec *MetricStorageSpec) Default() {
 func (ms *MonitoringStack) Default() {
 	if ms.ScrapeInterval == "" {
 		ms.ScrapeInterval = "30s"
+	}
+	if ms.DataplaneNetwork == "" {
+		ms.DataplaneNetwork = "ctlplane"
 	}
 	ms.Storage.Default()
 }

--- a/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
@@ -36,6 +36,18 @@ spec:
             description: AutoscalingSpec defines the desired state of Autoscaling
             properties:
               aodh:
+                default:
+                  apiImage: ""
+                  databaseAccount: aodh
+                  databaseInstance: openstack
+                  evaluatorImage: ""
+                  listenerImage: ""
+                  notifierImage: ""
+                  passwordSelector:
+                    aodhService: AodhPassword
+                  rabbitMqClusterName: rabbitmq
+                  secret: osp-secret
+                  serviceUser: aodh
                 description: Aodh spec
                 properties:
                   apiImage:
@@ -54,6 +66,7 @@ spec:
                       used for aodh DB, defaults to aodh
                     type: string
                   databaseInstance:
+                    default: openstack
                     description: MariaDB instance name Right now required by the maridb-operator
                       to get the credentials from the instance to create the DB Might
                       not be required in future
@@ -288,6 +301,7 @@ spec:
                       that is created and used in Aodh
                     type: string
                   secret:
+                    default: osp-secret
                     description: Secret containing OpenStack password information
                       for aodh
                     type: string

--- a/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
@@ -90,6 +90,7 @@ spec:
                   that is created and used in Telemetry
                 type: string
               secret:
+                default: osp-secret
                 description: Secret containing OpenStack password information for
                   ceilometer
                 type: string

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -39,6 +39,18 @@ spec:
                 description: Autoscaling - Parameters related to the autoscaling service
                 properties:
                   aodh:
+                    default:
+                      apiImage: ""
+                      databaseAccount: aodh
+                      databaseInstance: openstack
+                      evaluatorImage: ""
+                      listenerImage: ""
+                      notifierImage: ""
+                      passwordSelector:
+                        aodhService: AodhPassword
+                      rabbitMqClusterName: rabbitmq
+                      secret: osp-secret
+                      serviceUser: aodh
                     description: Aodh spec
                     properties:
                       apiImage:
@@ -57,6 +69,7 @@ spec:
                           name used for aodh DB, defaults to aodh
                         type: string
                       databaseInstance:
+                        default: openstack
                         description: MariaDB instance name Right now required by the
                           maridb-operator to get the credentials from the instance
                           to create the DB Might not be required in future
@@ -301,6 +314,7 @@ spec:
                           that is created and used in Aodh
                         type: string
                       secret:
+                        default: osp-secret
                         description: Secret containing OpenStack password information
                           for aodh
                         type: string
@@ -434,6 +448,7 @@ spec:
                       that is created and used in Telemetry
                     type: string
                   secret:
+                    default: osp-secret
                     description: Secret containing OpenStack password information
                       for ceilometer
                     type: string


### PR DESCRIPTION
This makes enables us to deploy a working telemetry with default values with minimal CR:

```
telemetry:
  enabled: true
  autoscaling:
    enabled: true
  ceilometer:
    enabled: true
  metricStorage:
    enabled: true
```
    
Depends-On: https://github.com/openstack-k8s-operators/heat-operator/pull/344