### PR TITLE
Rename ceilometer password selector

### DIFF
--- a/api/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/api/bases/telemetry.openstack.org_autoscalings.yaml
@@ -275,10 +275,10 @@ spec:
                         description: AodhService - Selector to get the aodh service
                           password from the Secret
                         type: string
-                      service:
+                      ceilometerService:
                         default: CeilometerPassword
-                        description: Service - Selector to get the ceilometer service
-                          password from the Secret
+                        description: CeilometerService - Selector to get the ceilometer
+                          service password from the Secret
                         type: string
                     type: object
                   preserveJobs:

--- a/api/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometers.yaml
@@ -67,7 +67,7 @@ spec:
                 type: string
               passwordSelector:
                 default:
-                  service: CeilometerPassword
+                  ceilometerService: CeilometerPassword
                 description: PasswordSelectors - Selectors to identify the service
                   from the Secret
                 properties:
@@ -76,10 +76,10 @@ spec:
                     description: AodhService - Selector to get the aodh service password
                       from the Secret
                     type: string
-                  service:
+                  ceilometerService:
                     default: CeilometerPassword
-                    description: Service - Selector to get the ceilometer service
-                      password from the Secret
+                    description: CeilometerService - Selector to get the ceilometer
+                      service password from the Secret
                     type: string
                 type: object
               proxyImage:

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -288,9 +288,9 @@ spec:
                             description: AodhService - Selector to get the aodh service
                               password from the Secret
                             type: string
-                          service:
+                          ceilometerService:
                             default: CeilometerPassword
-                            description: Service - Selector to get the ceilometer
+                            description: CeilometerService - Selector to get the ceilometer
                               service password from the Secret
                             type: string
                         type: object
@@ -416,7 +416,7 @@ spec:
                     type: string
                   passwordSelector:
                     default:
-                      service: CeilometerPassword
+                      ceilometerService: CeilometerPassword
                     description: PasswordSelectors - Selectors to identify the service
                       from the Secret
                     properties:
@@ -425,10 +425,10 @@ spec:
                         description: AodhService - Selector to get the aodh service
                           password from the Secret
                         type: string
-                      service:
+                      ceilometerService:
                         default: CeilometerPassword
-                        description: Service - Selector to get the ceilometer service
-                          password from the Secret
+                        description: CeilometerService - Selector to get the ceilometer
+                          service password from the Secret
                         type: string
                     type: object
                   proxyImage:

--- a/api/v1beta1/ceilometer_types.go
+++ b/api/v1beta1/ceilometer_types.go
@@ -71,7 +71,7 @@ type CeilometerSpecCore struct {
 	RabbitMqClusterName string `json:"rabbitMqClusterName,omitempty"`
 
 	// PasswordSelectors - Selectors to identify the service from the Secret
-	// +kubebuilder:default:={service: CeilometerPassword}
+	// +kubebuilder:default:={ceilometerService: CeilometerPassword}
 	PasswordSelectors PasswordsSelector `json:"passwordSelector,omitempty"`
 
 	// ServiceUser - optional username used for this service to register in keystone

--- a/api/v1beta1/telemetry_types.go
+++ b/api/v1beta1/telemetry_types.go
@@ -23,14 +23,12 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 )
 
-// TODO: We might want to split this to aodh and ceilometer and move it to appropriate files
-
 // PasswordsSelector to identify the Service password from the Secret
 type PasswordsSelector struct {
-	// Service - Selector to get the ceilometer service password from the Secret
+	// CeilometerService - Selector to get the ceilometer service password from the Secret
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:=CeilometerPassword
-	Service string `json:"service"`
+	CeilometerService string `json:"ceilometerService"`
 
 	// AodhService - Selector to get the aodh service password from the Secret
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
@@ -275,10 +275,10 @@ spec:
                         description: AodhService - Selector to get the aodh service
                           password from the Secret
                         type: string
-                      service:
+                      ceilometerService:
                         default: CeilometerPassword
-                        description: Service - Selector to get the ceilometer service
-                          password from the Secret
+                        description: CeilometerService - Selector to get the ceilometer
+                          service password from the Secret
                         type: string
                     type: object
                   preserveJobs:

--- a/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
@@ -67,7 +67,7 @@ spec:
                 type: string
               passwordSelector:
                 default:
-                  service: CeilometerPassword
+                  ceilometerService: CeilometerPassword
                 description: PasswordSelectors - Selectors to identify the service
                   from the Secret
                 properties:
@@ -76,10 +76,10 @@ spec:
                     description: AodhService - Selector to get the aodh service password
                       from the Secret
                     type: string
-                  service:
+                  ceilometerService:
                     default: CeilometerPassword
-                    description: Service - Selector to get the ceilometer service
-                      password from the Secret
+                    description: CeilometerService - Selector to get the ceilometer
+                      service password from the Secret
                     type: string
                 type: object
               proxyImage:

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -288,9 +288,9 @@ spec:
                             description: AodhService - Selector to get the aodh service
                               password from the Secret
                             type: string
-                          service:
+                          ceilometerService:
                             default: CeilometerPassword
-                            description: Service - Selector to get the ceilometer
+                            description: CeilometerService - Selector to get the ceilometer
                               service password from the Secret
                             type: string
                         type: object
@@ -416,7 +416,7 @@ spec:
                     type: string
                   passwordSelector:
                     default:
-                      service: CeilometerPassword
+                      ceilometerService: CeilometerPassword
                     description: PasswordSelectors - Selectors to identify the service
                       from the Secret
                     properties:
@@ -425,10 +425,10 @@ spec:
                         description: AodhService - Selector to get the aodh service
                           password from the Secret
                         type: string
-                      service:
+                      ceilometerService:
                         default: CeilometerPassword
-                        description: Service - Selector to get the ceilometer service
-                          password from the Secret
+                        description: CeilometerService - Selector to get the ceilometer
+                          service password from the Secret
                         type: string
                     type: object
                   proxyImage:

--- a/controllers/ceilometer_controller.go
+++ b/controllers/ceilometer_controller.go
@@ -250,7 +250,7 @@ func (r *CeilometerReconciler) reconcileInit(
 		Enabled:            true,
 		ServiceUser:        instance.Spec.ServiceUser,
 		Secret:             instance.Spec.Secret,
-		PasswordSelector:   instance.Spec.PasswordSelectors.Service,
+		PasswordSelector:   instance.Spec.PasswordSelectors.CeilometerService,
 	}
 
 	ksSvc := keystonev1.NewKeystoneService(ksSvcSpec, instance.Namespace, serviceLabels, 10)

--- a/pkg/autoscaling/dbsync.go
+++ b/pkg/autoscaling/dbsync.go
@@ -54,7 +54,7 @@ func DbSyncJob(instance *autoscalingv1beta1.Autoscaling, labels map[string]strin
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: instance.Spec.Aodh.Secret,
 					},
-					Key: instance.Spec.Aodh.PasswordSelectors.Service,
+					Key: instance.Spec.Aodh.PasswordSelectors.AodhService,
 				},
 			},
 		},


### PR DESCRIPTION
This is less confusing for the users. I also fixed a passwordSelector in the pkg/autoscaling/dbsync.go. Which wrongly used the ceilometer passwordSelector instead of aodh.

Depends-On: https://github.com/openstack-k8s-operators/heat-operator/pull/344