### PR TITLE
[OSPRH-6312] Remove memcached from autoscaling

### DIFF
--- a/api/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/api/bases/telemetry.openstack.org_autoscalings.yaml
@@ -70,10 +70,6 @@ spec:
                     type: string
                   listenerImage:
                     type: string
-                  memcachedInstance:
-                    default: memcached
-                    description: Memcached instance name.
-                    type: string
                   networkAttachmentDefinitions:
                     description: NetworkAttachmentDefinitions list of network attachment
                       definitions the service pod gets attached to
@@ -335,7 +331,6 @@ spec:
                 - databaseInstance
                 - evaluatorImage
                 - listenerImage
-                - memcachedInstance
                 - notifierImage
                 - secret
                 type: object

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -73,10 +73,6 @@ spec:
                         type: string
                       listenerImage:
                         type: string
-                      memcachedInstance:
-                        default: memcached
-                        description: Memcached instance name.
-                        type: string
                       networkAttachmentDefinitions:
                         description: NetworkAttachmentDefinitions list of network
                           attachment definitions the service pod gets attached to
@@ -348,7 +344,6 @@ spec:
                     - databaseInstance
                     - evaluatorImage
                     - listenerImage
-                    - memcachedInstance
                     - notifierImage
                     - secret
                     type: object

--- a/api/v1beta1/autoscaling_types.go
+++ b/api/v1beta1/autoscaling_types.go
@@ -110,11 +110,6 @@ type AodhCore struct {
 	// PreserveJobs - do not delete jobs after they finished e.g. to check logs
 	PreserveJobs bool `json:"preserveJobs"`
 
-	// +kubebuilder:validation:Required
-	// +kubebuilder:default=memcached
-	// Memcached instance name.
-	MemcachedInstance string `json:"memcachedInstance"`
-
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// TLS - Parameters related to the TLS

--- a/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
@@ -70,10 +70,6 @@ spec:
                     type: string
                   listenerImage:
                     type: string
-                  memcachedInstance:
-                    default: memcached
-                    description: Memcached instance name.
-                    type: string
                   networkAttachmentDefinitions:
                     description: NetworkAttachmentDefinitions list of network attachment
                       definitions the service pod gets attached to
@@ -335,7 +331,6 @@ spec:
                 - databaseInstance
                 - evaluatorImage
                 - listenerImage
-                - memcachedInstance
                 - notifierImage
                 - secret
                 type: object

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -73,10 +73,6 @@ spec:
                         type: string
                       listenerImage:
                         type: string
-                      memcachedInstance:
-                        default: memcached
-                        description: Memcached instance name.
-                        type: string
                       networkAttachmentDefinitions:
                         description: NetworkAttachmentDefinitions list of network
                           attachment definitions the service pod gets attached to
@@ -348,7 +344,6 @@ spec:
                     - databaseInstance
                     - evaluatorImage
                     - listenerImage
-                    - memcachedInstance
                     - notifierImage
                     - secret
                     type: object

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -187,14 +187,6 @@ rules:
   verbs:
   - update
 - apiGroups:
-  - memcached.openstack.org
-  resources:
-  - memcacheds
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - monitoring.rhobs
   resources:
   - alertmanagers

--- a/config/samples/telemetry_v1beta1_autoscaling.yaml
+++ b/config/samples/telemetry_v1beta1_autoscaling.yaml
@@ -14,4 +14,3 @@ spec:
     passwordSelectors:
     databaseAccount: aodh
     databaseInstance: openstack
-    memcachedInstance: memcached

--- a/config/samples/telemetry_v1beta1_autoscaling_tls.yaml
+++ b/config/samples/telemetry_v1beta1_autoscaling_tls.yaml
@@ -14,7 +14,6 @@ spec:
     passwordSelectors:
     databaseAccount: aodh
     databaseInstance: openstack
-    memcachedInstance: memcached
     tls:
       api:
         internal:

--- a/config/samples/telemetry_v1beta1_telemetry.yaml
+++ b/config/samples/telemetry_v1beta1_telemetry.yaml
@@ -19,7 +19,6 @@ spec:
       passwordSelectors:
       databaseAccount: aodh
       databaseInstance: openstack
-      memcachedInstance: memcached
       secret: osp-secret
     heatInstance: heat
   ceilometer:

--- a/config/samples/telemetry_v1beta1_telemetry_tls.yaml
+++ b/config/samples/telemetry_v1beta1_telemetry_tls.yaml
@@ -22,7 +22,6 @@ spec:
       passwordSelectors:
       databaseUser: aodh
       databaseInstance: openstack
-      memcachedInstance: memcached
       secret: osp-secret
       tls:
         api:

--- a/controllers/autoscaling_controller.go
+++ b/controllers/autoscaling_controller.go
@@ -53,7 +53,6 @@ import (
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 
 	heatv1 "github.com/openstack-k8s-operators/heat-operator/api/v1beta1"
-	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
@@ -91,7 +90,6 @@ func (r *AutoscalingReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups=mariadb.openstack.org,resources=mariadbdatabases/finalizers,verbs=update
 // +kubebuilder:rbac:groups=mariadb.openstack.org,resources=mariadbaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=mariadb.openstack.org,resources=mariadbaccounts/finalizers,verbs=update
-// +kubebuilder:rbac:groups=memcached.openstack.org,resources=memcacheds,verbs=get;list;watch;
 // +kubebuilder:rbac:groups=heat.openstack.org,resources=heats,verbs=get;list;watch;
 // service account, role, rolebinding
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update
@@ -169,7 +167,6 @@ func (r *AutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		condition.UnknownCondition(condition.RoleBindingReadyCondition, condition.InitReason, condition.RoleBindingReadyInitMessage),
 		// Prometheus, Aodh, Heat conditions
 		condition.UnknownCondition(telemetryv1.HeatReadyCondition, condition.InitReason, telemetryv1.HeatReadyInitMessage),
-		condition.UnknownCondition(condition.MemcachedReadyCondition, condition.InitReason, condition.MemcachedReadyInitMessage),
 		condition.UnknownCondition(condition.ServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
 		condition.UnknownCondition(condition.DBReadyCondition, condition.InitReason, condition.DBReadyInitMessage),
 		condition.UnknownCondition(condition.DBSyncReadyCondition, condition.InitReason, condition.DBSyncReadyInitMessage),
@@ -338,41 +335,6 @@ func (r *AutoscalingReconciler) reconcileNormal(
 	// run check OpenStack secret - end
 
 	//
-	// Check for required memcached used for caching
-	//
-	memcached, err := memcachedv1.GetMemcachedByName(ctx, helper, instance.Spec.Aodh.MemcachedInstance, instance.Namespace)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.MemcachedReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
-				condition.MemcachedReadyWaitingMessage))
-			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("memcached %s not found", instance.Spec.Aodh.MemcachedInstance)
-		}
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.MemcachedReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.MemcachedReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
-
-	if !memcached.IsReady() {
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.MemcachedReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
-			condition.MemcachedReadyWaitingMessage))
-		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("memcached %s is not ready", memcached.Name)
-	}
-	// Mark the Memcached Service as Ready if we get to this point with no errors
-	instance.Status.Conditions.MarkTrue(
-		condition.MemcachedReadyCondition, condition.MemcachedReadyMessage)
-	// run check memcached - end
-
-	//
 	// Check for required heat used for autoscaling
 	//
 	heat, err := r.getAutoscalingHeat(ctx, helper, instance)
@@ -461,7 +423,7 @@ func (r *AutoscalingReconciler) reconcileNormal(
 	// - %-scripts configmap holding scripts to e.g. bootstrap the service
 	// - %-config configmap holding minimal autoscaling config required to get the service up, user can add additional files to be added to the service
 	//
-	err = r.generateServiceConfig(ctx, helper, instance, &configMapVars, memcached, db)
+	err = r.generateServiceConfig(ctx, helper, instance, &configMapVars, db)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ServiceConfigReadyCondition,
@@ -542,7 +504,6 @@ func (r *AutoscalingReconciler) generateServiceConfig(
 	h *helper.Helper,
 	instance *telemetryv1.Autoscaling,
 	envVars *map[string]env.Setter,
-	mc *memcachedv1.Memcached,
 	db *mariadbv1.Database,
 ) error {
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(autoscaling.ServiceName), map[string]string{})
@@ -584,14 +545,12 @@ func (r *AutoscalingReconciler) generateServiceConfig(
 	databaseSecret := db.GetSecret()
 
 	templateParameters := map[string]interface{}{
-		"AodhUser":                 instance.Spec.Aodh.ServiceUser,
-		"AodhPassword":             string(ospSecret.Data[instance.Spec.Aodh.PasswordSelectors.AodhService]),
-		"KeystoneInternalURL":      keystoneInternalURL,
-		"TransportURL":             string(transportURLSecret.Data["transport_url"]),
-		"PrometheusHost":           instance.Status.PrometheusHost,
-		"PrometheusPort":           instance.Status.PrometheusPort,
-		"MemcachedServers":         mc.GetMemcachedServerListString(),
-		"MemcachedServersWithInet": mc.GetMemcachedServerListWithInetString(),
+		"AodhUser":            instance.Spec.Aodh.ServiceUser,
+		"AodhPassword":        string(ospSecret.Data[instance.Spec.Aodh.PasswordSelectors.AodhService]),
+		"KeystoneInternalURL": keystoneInternalURL,
+		"TransportURL":        string(transportURLSecret.Data["transport_url"]),
+		"PrometheusHost":      instance.Status.PrometheusHost,
+		"PrometheusPort":      instance.Status.PrometheusPort,
 		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
 			databaseAccount.Spec.UserName,
 			string(databaseSecret.Data[mariadbv1.DatabasePasswordSelector]),
@@ -754,34 +713,6 @@ func (r *AutoscalingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 		}
 		return nil
 	}
-	memcachedFn := func(ctx context.Context, o client.Object) []reconcile.Request {
-		result := []reconcile.Request{}
-
-		// get all autoscaling CRs
-		autoscalings := &telemetryv1.AutoscalingList{}
-		listOpts := []client.ListOption{
-			client.InNamespace(o.GetNamespace()),
-		}
-		if err := r.Client.List(context.Background(), autoscalings, listOpts...); err != nil {
-			Log.Error(err, "Unable to retrieve Autoscaling CRs %w")
-			return nil
-		}
-
-		for _, cr := range autoscalings.Items {
-			if o.GetName() == cr.Spec.Aodh.MemcachedInstance {
-				name := client.ObjectKey{
-					Namespace: o.GetNamespace(),
-					Name:      cr.Name,
-				}
-				Log.Info(fmt.Sprintf("Memcached %s is used by Autoscaling CR %s", o.GetName(), cr.Name))
-				result = append(result, reconcile.Request{NamespacedName: name})
-			}
-		}
-		if len(result) > 0 {
-			return result
-		}
-		return nil
-	}
 	// index autoscalingCaBundleSecretNameField
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &telemetryv1.Autoscaling{}, autoscalingCaBundleSecretNameField, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
@@ -835,8 +766,6 @@ func (r *AutoscalingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 		// Watch for TransportURL Secrets which belong to any TransportURLs created by Autoscaling CRs
 		Watches(&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(transportURLSecretFn)).
-		Watches(&memcachedv1.Memcached{},
-			handler.EnqueueRequestsFromMapFunc(memcachedFn)).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForSrc),

--- a/main.go
+++ b/main.go
@@ -41,7 +41,6 @@ import (
 
 	dataplanev1 "github.com/openstack-k8s-operators/dataplane-operator/api/v1beta1"
 	heatv1 "github.com/openstack-k8s-operators/heat-operator/api/v1beta1"
-	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	infranetworkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
@@ -70,7 +69,6 @@ func init() {
 	utilruntime.Must(monv1.AddToScheme(scheme))
 	utilruntime.Must(monv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(mariadbv1beta1.AddToScheme(scheme))
-	utilruntime.Must(memcachedv1.AddToScheme(scheme))
 	utilruntime.Must(heatv1.AddToScheme(scheme))
 	utilruntime.Must(dataplanev1.AddToScheme(scheme))
 	utilruntime.Must(infranetworkv1.AddToScheme(scheme))

--- a/templates/autoscaling/config/aodh.conf
+++ b/templates/autoscaling/config/aodh.conf
@@ -31,8 +31,6 @@ transport_url = {{ .TransportURL }}
 [keystone_authtoken]
 www_authenticate_uri = {{ .KeystoneInternalURL }}
 interface=internal
-memcached_servers={{ .MemcachedServersWithInet }}
-memcache_use_advanced_pool=True
 auth_type = password
 auth_url = {{ .KeystoneInternalURL }}
 username = {{ .AodhUser }}

--- a/tests/kuttl/suites/autoscaling/tests/01-deploy.yaml
+++ b/tests/kuttl/suites/autoscaling/tests/01-deploy.yaml
@@ -12,5 +12,4 @@ spec:
     passwordSelectors:
     databaseAccount: aodh
     databaseInstance: openstack
-    memcachedInstance: memcached
   heatInstance: heat

--- a/tests/kuttl/suites/default/tests/01-deploy.yaml
+++ b/tests/kuttl/suites/default/tests/01-deploy.yaml
@@ -24,7 +24,6 @@ spec:
       passwordSelectors:
       databaseAccount: aodh
       databaseInstance: openstack
-      memcachedInstance: memcached
     heatInstance: heat
   ceilometer:
     enabled: true

--- a/tests/kuttl/suites/tls/tests/02-deploy.yaml
+++ b/tests/kuttl/suites/tls/tests/02-deploy.yaml
@@ -12,7 +12,6 @@ spec:
     passwordSelectors:
     databaseAccount: aodh
     databaseInstance: openstack
-    memcachedInstance: memcached
     tls:
       api:
         internal:


### PR DESCRIPTION
During investigatin of issues with [OSPRH-6312](https://issues.redhat.com//browse/OSPRH-6312) we discovered, that memcached in fact isn't required for aodh. Because it was a required parameter, it actually caused additional unnecessary issues. This PR removes memcached from the autoscaling api, from all example CRs and from kuttl tests.

rh-jira: https://issues.redhat.com/browse/OSPRH-6312