### PR TITLE
Manage ObservabilityUIPlugin for Dashboards plugin

### DIFF
--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -56,6 +56,8 @@ const (
 
 	DashboardPrometheusRuleReadyCondition condition.Type = "DashboardPrometheusRuleReady"
 
+	DashboardPluginReadyCondition condition.Type = "DashboardPluginReady"
+
 	DashboardDatasourceReadyCondition condition.Type = "DashboardDatasourceReady"
 
 	DashboardDefinitionReadyCondition condition.Type = "DashboardDefinitionReady"
@@ -202,6 +204,9 @@ const (
 
 	DashboardPrometheusRuleReadyInitMessage = "Dashboard PrometheusRule not started"
 	DashboardPrometheusRuleUnableToOwnMessage = "Error occured when trying to own %s"
+
+	DashboardPluginReadyInitMessage = "Dashboard Plugin not started"
+	DashboardPluginFailedMessage = "Error occured when trying to install the dashboard plugin: %s"
 
 	DashboardDatasourceReadyInitMessage = "Dashboard Datasource not started"
 	DashboardDatasourceFailedMessage = "Error occured when trying to install the dashboard datasource: %s"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -277,6 +277,7 @@ rules:
   resources:
   - uiplugins
   verbs:
+  - create
   - get
   - list
   - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -273,6 +273,15 @@ rules:
   - list
   - watch
 - apiGroups:
+  - observability.openshift.io
+  resources:
+  - uiplugins
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - rabbitmq.openstack.org
   resources:
   - transporturls

--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -105,7 +105,7 @@ func (r *MetricStorageReconciler) GetLogger(ctx context.Context) logr.Logger {
 //+kubebuilder:rbac:groups=network.openstack.org,resources=ipsets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=dataplane.openstack.org,resources=openstackdataplanenodesets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=dataplane.openstack.org,resources=openstackdataplaneservices,verbs=get;list;watch
-//+kubebuilder:rbac:groups=observability.openshift.io,resources=uiplugins,verbs=get;list;watch;patch
+//+kubebuilder:rbac:groups=observability.openshift.io,resources=uiplugins,verbs=get;list;watch;create;patch
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reconciles MetricStorage

--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -105,6 +105,8 @@ func (r *MetricStorageReconciler) GetLogger(ctx context.Context) logr.Logger {
 //+kubebuilder:rbac:groups=network.openstack.org,resources=ipsets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=dataplane.openstack.org,resources=openstackdataplanenodesets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=dataplane.openstack.org,resources=openstackdataplaneservices,verbs=get;list;watch
+//+kubebuilder:rbac:groups=observability.openshift.io,resources=uiplugins,verbs=get;list;watch;patch
+//+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reconciles MetricStorage
 func (r *MetricStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {

--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -504,7 +504,7 @@ func (r *MetricStorageReconciler) reconcileNormal(
 		// uiPluginObj := &obsui.ObservabilityUIPlugin{
 		// 	ObjectMeta: metav1.ObjectMeta{
 		// 		Name:      "ui-dashboards",
-		// 		Namespace: instance.Namespace,
+		// 		Namespace: dashboardPluginNamespace,
 		// 	},
 		// }
 		// =====
@@ -515,15 +515,15 @@ func (r *MetricStorageReconciler) reconcileNormal(
 			},
 		})
 		uiPluginObj.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "observabilityui.rhobs",
+			Group:   "observabilityui.rhobs", // ***** Soon to be "uiplugins.observability.openshift.io" https://github.com/rhobs/observability-operator/pull/434/files#diff-87f3ff0ffd8a86bfc90125fa3543caff45c234d6d2d54e2da371c560b65c0e1dR129
 			Version: "v1alpha1",
-			Kind:    "ObservabilityUIPlugin",
+			Kind:    "ObservabilityUIPlugin", // ***** Soon to be "UIPlugin"
 		})
 		uiPluginObj.SetName("ui-dashboards")
 		uiPluginObj.SetNamespace(dashboardPluginNamespace)
 		// =====
 		op, err = controllerutil.CreateOrPatch(ctx, r.Client, uiPluginObj, func() error {
-			// uiPluginObj.Spec.Type = "Dashboards" // After COO 0.2.0
+			// uiPluginObj.Spec.Type = "Dashboards" // After we update to COO 0.2.0 as dependency
 			return nil
 		})
 		if err != nil {

--- a/pkg/metricstorage/dashboard_datasource.go
+++ b/pkg/metricstorage/dashboard_datasource.go
@@ -32,7 +32,7 @@ func DashboardDatasourceData(ctx context.Context, c client.Client, instance *tel
 	if instance.Spec.PrometheusTLS.Enabled() {
 		scheme = "https"
 		namespacedName := types.NamespacedName{
-			Name:      instance.Spec.PrometheusTLS.CaBundleSecretName,
+			Name:      *instance.Spec.PrometheusTLS.SecretName,
 			Namespace: instance.Namespace,
 		}
 		caSecret := &corev1.Secret{}
@@ -40,7 +40,7 @@ func DashboardDatasourceData(ctx context.Context, c client.Client, instance *tel
 		if err != nil {
 			return nil, err
 		}
-		certText = string(caSecret.Data["internal-ca-bundle.pem"])
+		certText = string(caSecret.Data["ca.crt"])
 	}
 
 	return map[string]string{

--- a/pkg/metricstorage/dashboard_datasource.go
+++ b/pkg/metricstorage/dashboard_datasource.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricstorage
+
+import (
+	"context"
+
+	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func DashboardDatasourceData(ctx context.Context, c client.Client, instance *telemetryv1.MetricStorage, datasourceName string, namespace string) (map[string]string, error) {
+
+	scheme := "http"
+	certText := ""
+	if instance.Spec.PrometheusTLS.Enabled() {
+		scheme = "https"
+		namespacedName := types.NamespacedName{
+			Name:      instance.Spec.PrometheusTLS.CaBundleSecretName,
+			Namespace: instance.Namespace,
+		}
+		caSecret := &corev1.Secret{}
+		err := c.Get(ctx, namespacedName, caSecret)
+		if err != nil {
+			return nil, err
+		}
+		certText = string(caSecret.Data["internal-ca-bundle.pem"])
+	}
+
+	return map[string]string{
+		// WARNING: The value lines below MUST be indented with spaces, not tabs (because they are YAML strings)
+		"dashboard-datasource-ca": certText,
+		"dashboard-datasource.yaml": `
+kind: "Datasource"
+metadata:
+    name: "` + datasourceName + `"
+    project: "` + namespace + `"
+spec:
+    plugin:
+        kind: "PrometheusDatasource"
+        spec:
+            direct_url: "` + scheme + `://metric-storage-prometheus.` + instance.Namespace + `.svc.cluster.local:9090"
+`}, nil
+}


### PR DESCRIPTION
* We need to control a new CR that installs the plugin
* Using Unstructured{} to avoid golang 1.21 and core k8s dep updates in newest OBO