### PR TITLE
Use PodManagementPolicy: appsv1.ParallelPodManagement for the aodh statefulset

### DIFF
--- a/pkg/autoscaling/aodh_statefulset.go
+++ b/pkg/autoscaling/aodh_statefulset.go
@@ -201,7 +201,8 @@ func AodhStatefulSet(
 			Labels:    labels,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Replicas: &replicas,
+			PodManagementPolicy: appsv1.ParallelPodManagement,
+			Replicas:            &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},

--- a/pkg/ceilometer/statefulset.go
+++ b/pkg/ceilometer/statefulset.go
@@ -190,7 +190,8 @@ func StatefulSet(
 			Labels:    labels,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Replicas: &replicas,
+			PodManagementPolicy: appsv1.ParallelPodManagement,
+			Replicas:            &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},


### PR DESCRIPTION
With the default `PodManagementPolicy: OrderedReadyPodManagement` the statefulset controller will only progress pods when the previous/current pod is ready or terminated.

When service configuration changes while the pod is starting and the new configuration requires e.g. additional volume mounts the initial pod will never reach ready and therefore an update won't happen.

With ParallelPodManagement the statefulset controller will not wait for pods to be ready or complete termination.