### PR TITLE
[zuul] Use https in sg_core_service_url

### DIFF
--- a/ci/vars-autoscaling-tempest.yml
+++ b/ci/vars-autoscaling-tempest.yml
@@ -12,7 +12,7 @@ cifmw_tempest_tempestconf_config:
       service_available.ceilometer true
       service_available.sg_core true
       service_available.aodh true
-      telemetry.sg_core_service_url "ceilometer-internal.openstack.svc.cluster.local:3000"
+      telemetry.sg_core_service_url "https://ceilometer-internal.openstack.svc.cluster.local:3000"
 cifmw_test_operator_tempest_include_list: |
   telemetry_tempest_plugin.scenario
   telemetry_tempest_plugin.aodh


### PR DESCRIPTION
This fixes the tempest failure:

    Your browser sent a request that this server could not understand.<br />
    Reason: You're speaking plain HTTP to an SSL-enabled server port.<br />
    Instead use the HTTPS scheme to access this URL, please.<br />

The sg_core_service_url is passed straight through to the test and used as the URL base for HTTP requests. The https:// needs to be prefixed or else the connection will default to http, which is an issue when we have TLS everywhere.