### PR TITLE
[OSPRH-6400] Add Proxy image to telemetry and default_images

### DIFF
--- a/api/v1beta1/telemetry_types.go
+++ b/api/v1beta1/telemetry_types.go
@@ -211,6 +211,7 @@ func SetupDefaultsTelemetry() {
 		IpmiContainerImageURL:         util.GetEnvVar("RELATED_IMAGE_CEILOMETER_IPMI_IMAGE_URL_DEFAULT", CeilometerIpmiContainerImage),
 		NotificationContainerImageURL: util.GetEnvVar("RELATED_IMAGE_CEILOMETER_NOTIFICATION_IMAGE_URL_DEFAULT", CeilometerNotificationContainerImage),
 		SgCoreContainerImageURL:       util.GetEnvVar("RELATED_IMAGE_CEILOMETER_SGCORE_IMAGE_URL_DEFAULT", CeilometerSgCoreContainerImage),
+		ProxyContainerImageURL:        util.GetEnvVar("RELATED_IMAGE_CEILOMETER_PROXY_IMAGE_URL_DEFAULT", CeilometerProxyContainerImage),
 
 		// Autoscaling
 		AodhAPIContainerImageURL:       util.GetEnvVar("RELATED_IMAGE_AODH_API_IMAGE_URL_DEFAULT", AodhAPIContainerImage),

--- a/api/v1beta1/telemetry_webhook.go
+++ b/api/v1beta1/telemetry_webhook.go
@@ -33,6 +33,7 @@ type TelemetryDefaults struct {
 	ComputeContainerImageURL       string
 	NotificationContainerImageURL  string
 	SgCoreContainerImageURL        string
+	ProxyContainerImageURL         string
 	IpmiContainerImageURL          string
 	AodhAPIContainerImageURL       string
 	AodhEvaluatorContainerImageURL string
@@ -85,6 +86,9 @@ func (spec *TelemetrySpec) Default() {
 	}
 	if spec.Ceilometer.CeilometerSpec.SgCoreImage == "" {
 		spec.Ceilometer.CeilometerSpec.SgCoreImage = telemetryDefaults.SgCoreContainerImageURL
+	}
+	if spec.Ceilometer.CeilometerSpec.ProxyImage == "" {
+		spec.Ceilometer.CeilometerSpec.ProxyImage = telemetryDefaults.ProxyContainerImageURL
 	}
 	if spec.Autoscaling.AutoscalingSpec.Aodh.APIImage == "" {
 		spec.Autoscaling.AutoscalingSpec.Aodh.APIImage = telemetryDefaults.AodhAPIContainerImageURL

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -21,6 +21,8 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi:current-podified
         - name: RELATED_IMAGE_CEILOMETER_SGCORE_IMAGE_URL_DEFAULT
           value: quay.io/infrawatch/sg-core:v5.2.0-nextgen
+        - name: RELATED_IMAGE_CEILOMETER_PROXY_IMAGE_URL_DEFAULT
+          value: quay.io/podified-antelope-centos9/openstack-aodh-api:current-podified
         - name: RELATED_IMAGE_AODH_API_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-aodh-api:current-podified
         - name: RELATED_IMAGE_AODH_EVALUATOR_IMAGE_URL_DEFAULT


### PR DESCRIPTION
openstack-operator isn't able to set the image correctly and it isn't able to put it inside the openstackversions CR because it's missing in these files.

rh-jira: https://issues.redhat.com/browse/OSPRH-6400