### PR TITLE
Update telemetry-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,8 +3,8 @@
 aliases:
   telemetry-approvers:
   - csibbitt
+  - elfiesmelfie
   - jlarriba
-  - mrunge
   - paramite
   - vyzigold
   - yadneshk


### PR DESCRIPTION
- Emma is active in contributing to the operator recently, but I noticed she is missing from the telemetry approvers list.

- Matthias requested to be removed, because he doesn't contribute.