### PR TITLE
Ensure golangci-lint runs on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,5 +59,5 @@ repos:
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.55.2
   hooks:
-    - id: golangci-lint
+    - id: golangci-lint-full
       args: ["-v"]

--- a/controllers/autoscaling_controller.go
+++ b/controllers/autoscaling_controller.go
@@ -202,18 +202,18 @@ func (r *AutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 const (
 	autoscalingPasswordSecretField     = ".spec.secret"
 	autoscalingCaBundleSecretNameField = ".spec.tls.caBundleSecretName"
-	autoscalingTlsAPIInternalField     = ".spec.tls.api.internal.secretName"
-	autoscalingTlsAPIPublicField       = ".spec.tls.api.public.secretName"
-	autoscalingTlsField                = ".spec.tls.secretName"
+	autoscalingTLSAPIInternalField     = ".spec.tls.api.internal.secretName"
+	autoscalingTLSAPIPublicField       = ".spec.tls.api.public.secretName"
+	autoscalingTLSField                = ".spec.tls.secretName"
 )
 
 var (
 	autoscalingAllWatchFields = []string{
 		autoscalingPasswordSecretField,
 		autoscalingCaBundleSecretNameField,
-		autoscalingTlsAPIInternalField,
-		autoscalingTlsAPIPublicField,
-		autoscalingTlsField,
+		autoscalingTLSAPIInternalField,
+		autoscalingTLSAPIPublicField,
+		autoscalingTLSField,
 	}
 )
 
@@ -727,7 +727,7 @@ func (r *AutoscalingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 	}
 
 	// index autoscalingTlsAPIInternalField
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &telemetryv1.Autoscaling{}, autoscalingTlsAPIInternalField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &telemetryv1.Autoscaling{}, autoscalingTLSAPIInternalField, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*telemetryv1.Autoscaling)
 		if cr.Spec.Aodh.TLS.API.Internal.SecretName == nil {
@@ -739,7 +739,7 @@ func (r *AutoscalingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 	}
 
 	// index autoscalingTlsAPIPublicField
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &telemetryv1.Autoscaling{}, autoscalingTlsAPIPublicField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &telemetryv1.Autoscaling{}, autoscalingTLSAPIPublicField, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*telemetryv1.Autoscaling)
 		if cr.Spec.Aodh.TLS.API.Public.SecretName == nil {
@@ -778,7 +778,7 @@ func (r *AutoscalingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 func (r *AutoscalingReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(context.Background()).WithName("Controllers").WithName("Autoscaling")
+	l := log.FromContext(ctx).WithName("Controllers").WithName("Autoscaling")
 
 	for _, field := range autoscalingAllWatchFields {
 		crList := &telemetryv1.AutoscalingList{}
@@ -786,7 +786,7 @@ func (r *AutoscalingReconciler) findObjectsForSrc(ctx context.Context, src clien
 			FieldSelector: fields.OneTermEqualSelector(field, src.GetName()),
 			Namespace:     src.GetNamespace(),
 		}
-		err := r.Client.List(context.TODO(), crList, listOps)
+		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
 			return []reconcile.Request{}
 		}

--- a/controllers/ceilometer_controller.go
+++ b/controllers/ceilometer_controller.go
@@ -183,14 +183,14 @@ func (r *CeilometerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 const (
 	ceilometerPasswordSecretField     = ".spec.secret"
 	ceilometerCaBundleSecretNameField = ".spec.tls.caBundleSecretName"
-	ceilometerTlsField                = ".spec.tls.secretName"
+	ceilometerTLSField                = ".spec.tls.secretName"
 )
 
 var (
 	ceilometerWatchFields = []string{
 		ceilometerPasswordSecretField,
 		ceilometerCaBundleSecretNameField,
-		ceilometerTlsField,
+		ceilometerTLSField,
 	}
 )
 
@@ -795,7 +795,7 @@ func (r *CeilometerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 			return nil
 		}
 		// Delete the pod so the statefulset re-creates it
-		r.Client.Delete(ctx, pod)
+		_ = r.Client.Delete(ctx, pod)
 		return nil
 	}
 
@@ -824,7 +824,7 @@ func (r *CeilometerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 	}
 
 	// index ceilometerTlsField
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &telemetryv1.Ceilometer{}, ceilometerTlsField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &telemetryv1.Ceilometer{}, ceilometerTLSField, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*telemetryv1.Ceilometer)
 		if cr.Spec.TLS.SecretName == nil {
@@ -863,7 +863,7 @@ func (r *CeilometerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 func (r *CeilometerReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(context.Background()).WithName("Controllers").WithName("Ceilometer")
+	l := log.FromContext(ctx).WithName("Controllers").WithName("Ceilometer")
 
 	for _, field := range ceilometerWatchFields {
 		crList := &telemetryv1.CeilometerList{}
@@ -871,7 +871,7 @@ func (r *CeilometerReconciler) findObjectsForSrc(ctx context.Context, src client
 			FieldSelector: fields.OneTermEqualSelector(field, src.GetName()),
 			Namespace:     src.GetNamespace(),
 		}
-		err := r.Client.List(context.TODO(), crList, listOps)
+		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
 			return []reconcile.Request{}
 		}

--- a/controllers/logging_controller.go
+++ b/controllers/logging_controller.go
@@ -355,7 +355,7 @@ func (r *LoggingReconciler) createHashOfInputHashes(
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *LoggingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+func (r *LoggingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&telemetryv1.Logging{}).
 		Owns(&corev1.Secret{}).

--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -67,13 +67,13 @@ import (
 // fields to index to reconcile when change
 const (
 	prometheusCaBundleSecretNameField = ".spec.prometheusTls.caBundleSecretName"
-	prometheusTlsField                = ".spec.prometheusTls.secretName"
+	prometheusTLSField                = ".spec.prometheusTls.secretName"
 )
 
 var (
 	prometheusAllWatchFields = []string{
 		prometheusCaBundleSecretNameField,
-		prometheusTlsField,
+		prometheusTLSField,
 	}
 )
 
@@ -903,7 +903,7 @@ func (r *MetricStorageReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 	}
 
 	// index prometheusTlsField
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &telemetryv1.MetricStorage{}, prometheusTlsField, func(rawObj client.Object) []string {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &telemetryv1.MetricStorage{}, prometheusTLSField, func(rawObj client.Object) []string {
 		// Extract the secret name from the spec, if one is provided
 		cr := rawObj.(*telemetryv1.MetricStorage)
 		if cr.Spec.PrometheusTLS.SecretName == nil {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -20,8 +20,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/controllers/telemetry_controller.go
+++ b/controllers/telemetry_controller.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	logr "github.com/go-logr/logr"
-	common "github.com/openstack-k8s-operators/lib-common/modules/common"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	helper "github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"k8s.io/client-go/kubernetes"
@@ -37,7 +36,6 @@ import (
 	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
 	ceilometer "github.com/openstack-k8s-operators/telemetry-operator/pkg/ceilometer"
 	logging "github.com/openstack-k8s-operators/telemetry-operator/pkg/logging"
-	telemetry "github.com/openstack-k8s-operators/telemetry-operator/pkg/telemetry"
 	obov1 "github.com/rhobs/observability-operator/pkg/apis/monitoring/v1alpha1"
 )
 
@@ -152,12 +150,8 @@ func (r *TelemetryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		instance.Status.Hash = map[string]string{}
 	}
 
-	serviceLabels := map[string]string{
-		common.AppSelector: telemetry.ServiceName,
-	}
-
 	// Handle service init
-	ctrlResult, err := r.reconcileInit(ctx, instance, helper, serviceLabels)
+	ctrlResult, err := r.reconcileInit(ctx)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -186,9 +180,6 @@ func (r *TelemetryReconciler) reconcileDelete(ctx context.Context, instance *tel
 
 func (r *TelemetryReconciler) reconcileInit(
 	ctx context.Context,
-	instance *telemetryv1.Telemetry,
-	helper *helper.Helper,
-	serviceLabels map[string]string,
 ) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 	Log.Info("Reconciling Service init")

--- a/main.go
+++ b/main.go
@@ -162,7 +162,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(context.Background(), mgr); err != nil {
+	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create Logging controller")
 		os.Exit(1)
 	}

--- a/pkg/autoscaling/aodh_statefulset.go
+++ b/pkg/autoscaling/aodh_statefulset.go
@@ -77,7 +77,7 @@ func AodhStatefulSet(
 	}
 
 	// create Volume and VolumeMounts
-	volumes := getVolumes(ServiceName)
+	volumes := getVolumes()
 	apiVolumeMounts := getVolumeMounts("aodh-api")
 	evaluatorVolumeMounts := getVolumeMounts("aodh-evaluator")
 	notifierVolumeMounts := getVolumeMounts("aodh-notifier")

--- a/pkg/autoscaling/dbsync.go
+++ b/pkg/autoscaling/dbsync.go
@@ -34,7 +34,7 @@ func DbSyncJob(instance *autoscalingv1beta1.Autoscaling, labels map[string]strin
 	args = append(args, dbSyncCommand)
 
 	// create Volume and VolumeMounts
-	volumes := getVolumes(ServiceName)
+	volumes := getVolumes()
 	volumeMounts := getVolumeMounts("aodh-dbsync")
 	// add CA cert if defined
 	if instance.Spec.Aodh.TLS.CaBundleSecretName != "" {

--- a/pkg/autoscaling/volumes.go
+++ b/pkg/autoscaling/volumes.go
@@ -33,7 +33,7 @@ var (
 )
 
 // getVolumes - service volumes
-func getVolumes(name string) []corev1.Volume {
+func getVolumes() []corev1.Volume {
 	return []corev1.Volume{
 		{
 			Name: "scripts",

--- a/pkg/ceilometer/statefulset.go
+++ b/pkg/ceilometer/statefulset.go
@@ -81,7 +81,7 @@ func StatefulSet(
 
 	var replicas int32 = 1
 
-	volumes := getVolumes(ServiceName)
+	volumes := getVolumes()
 	centralVolumeMounts := getVolumeMounts("ceilometer-central")
 	notificationVolumeMounts := getVolumeMounts("ceilometer-notification")
 	httpdVolumeMounts := getHttpdVolumeMounts()

--- a/pkg/ceilometer/volumes.go
+++ b/pkg/ceilometer/volumes.go
@@ -30,7 +30,7 @@ var (
 	scriptMode int32 = 0740
 )
 
-func getVolumes(name string) []corev1.Volume {
+func getVolumes() []corev1.Volume {
 	return []corev1.Volume{
 		{
 			Name: "scripts",

--- a/pkg/logging/service.go
+++ b/pkg/logging/service.go
@@ -50,6 +50,7 @@ func Service(
 			"provider":                   "openshift",
 		}
 		service.Annotations = instance.Spec.Annotations
+		service.Labels = labels
 		service.Spec.Type = "LoadBalancer"
 
 		return nil

--- a/pkg/metricstorage/dashboard_prometheus_rule.go
+++ b/pkg/metricstorage/dashboard_prometheus_rule.go
@@ -26,7 +26,7 @@ import (
 func DashboardPrometheusRule(
 	instance *telemetryv1.MetricStorage,
 	labels map[string]string,
-	selector map[string]string,
+	_ map[string]string,
 ) *monv1.PrometheusRule {
 
 	prometheusRule := &monv1.PrometheusRule{


### PR DESCRIPTION
* removed unused func params and import
* ignore revive dot-imports rule on ginkgo and gomega as dot import
there is the recommended practice
* various small style fixes found by the linter
