### PR TITLE
[zuul] Bump COO install wait time

### DIFF
--- a/ci/create-coo-subscription.yaml
+++ b/ci/create-coo-subscription.yaml
@@ -29,7 +29,7 @@
       ansible.builtin.command:
         cmd:
           oc get csv --namespace=openshift-operators -l operators.coreos.com/cluster-observability-operator.openshift-operators
-      delay: 2
+      delay: 5
       retries: 10
       register: output
       until: output.stdout_lines | length != 0


### PR DESCRIPTION
Bump the COO install wait time from 20 sec to 50 sec after recent CI failures.