### PR TITLE
[zuul] Bump COO install timeout

### DIFF
--- a/ci/create-coo-subscription.yaml
+++ b/ci/create-coo-subscription.yaml
@@ -29,8 +29,8 @@
       ansible.builtin.command:
         cmd:
           oc get csv --namespace=openshift-operators -l operators.coreos.com/cluster-observability-operator.openshift-operators
-      delay: 5
-      retries: 10
+      delay: 10
+      retries: 20
       register: output
       until: output.stdout_lines | length != 0
 


### PR DESCRIPTION
I can still see errors with COO install timing out even with 50s timeout. I saw a successful PR, where it took 30s for the CSV to appear. This PR bumps the timeout to 200s.