### PR TITLE
Fix infinite ceilometer reconcile

### DIFF
--- a/controllers/ceilometer_controller.go
+++ b/controllers/ceilometer_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -456,6 +457,8 @@ func (r *CeilometerReconciler) reconcileNormal(ctx context.Context, instance *te
 	// Hash all the endpointurls to trigger a redeployment everytime one of the internal endpoints changes or is added
 	v := "internal"
 	endpointurls, err := keystonev1.GetKeystoneEndpointUrls(ctx, helper, instance.Namespace, &v)
+	sort.Strings(endpointurls)
+
 	if err != nil {
 
 		return ctrl.Result{}, err


### PR DESCRIPTION
The endpointurls aren't sorted (they get returned in a different order every time). Unfortunatelly the hash function produces a different hash based on the order. This is fixed by sorting the urls