### PR TITLE
Cleanup dashboards on disable/delete

### DIFF
--- a/pkg/metricstorage/dashboard_objects.go
+++ b/pkg/metricstorage/dashboard_objects.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricstorage
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
+	utils "github.com/openstack-k8s-operators/telemetry-operator/pkg/utils"
+	monv1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+const DashboardArtifactsNamespace = "openshift-config-managed"
+
+func DeleteDashboardObjects(ctx context.Context, instance *telemetryv1.MetricStorage, helper *helper.Helper) (ctrl.Result, error) {
+	fmt.Printf("%v %v %v", ctx, instance, helper)
+	promRule := &monv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		},
+	}
+	if res, err := utils.EnsureDeleted(ctx, helper, promRule); err != nil {
+		return res, err
+	}
+
+	datasourceName := instance.Namespace + "-" + instance.Name + "-datasource"
+	datasourceCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      datasourceName,
+			Namespace: DashboardArtifactsNamespace,
+		},
+	}
+	if res, err := utils.EnsureDeleted(ctx, helper, datasourceCM); err != nil {
+		return res, err
+	}
+
+	var dashboards = []string{"grafana-dashboard-openstack-cloud", "grafana-dashboard-openstack-node", "grafana-dashboard-openstack-vm"}
+	for _, name := range dashboards {
+		dashboardCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: DashboardArtifactsNamespace,
+			},
+		}
+		if res, err := utils.EnsureDeleted(ctx, helper, dashboardCM); err != nil {
+			return res, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+)
+
+// EnsureDeleted - Delete the object which in turn will clean the sub resources
+func EnsureDeleted(ctx context.Context, helper *helper.Helper, obj client.Object) (ctrl.Result, error) {
+	key := client.ObjectKeyFromObject(obj)
+	if err := helper.GetClient().Get(ctx, key, obj); err != nil {
+		if k8s_errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	// Delete the object
+	if obj.GetDeletionTimestamp().IsZero() {
+		if err := helper.GetClient().Delete(ctx, obj); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{}, nil
+
+}

--- a/tests/kuttl/suites/metricstorage/tests/02-disable-dashboards.yaml
+++ b/tests/kuttl/suites/metricstorage/tests/02-disable-dashboards.yaml
@@ -1,0 +1,14 @@
+apiVersion: telemetry.openstack.org/v1beta1
+kind: MetricStorage
+metadata:
+  name: telemetry-kuttl
+spec:
+  monitoringStack:
+    alertingEnabled: true
+    dashboardsEnabled: false
+    scrapeInterval: 30s
+    storage:
+      strategy: persistent
+      retention: 24h
+      persistent:
+        pvcStorageRequest: 20G

--- a/tests/kuttl/suites/metricstorage/tests/02-errors.yaml
+++ b/tests/kuttl/suites/metricstorage/tests/02-errors.yaml
@@ -1,0 +1,32 @@
+apiVersion: monitoring.rhobs/v1
+kind: PrometheusRule
+metadata:
+  name: telemetry-kuttl
+spec:
+  groups:
+  - name: osp-node-exporter-dashboard.rules
+  - name: osp-ceilometer-dashboard.rules
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: telemetry-kuttl-tests-telemetry-kuttl-datasource
+  namespace: openshift-config-managed
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-openstack-cloud
+  namespace: openshift-config-managed
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-openstack-node
+  namespace: openshift-config-managed
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-openstack-vm
+  namespace: openshift-config-managed


### PR DESCRIPTION
Cleans up these artifacts if dashboarding is disabled or the telemetry object is deleted:

- PrometheusRules
- Datasource definition
- Dashboard definitions

Since the UIPlugin object is a singleton we will not remove it in case there are other users.