### PR TITLE
Rename UIPlugin for compatibility with COO 0.3

### DIFF
--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -509,7 +509,7 @@ func (r *MetricStorageReconciler) reconcileNormal(
 		// =====
 		// uiPluginObj := &obsui.ObservabilityUIPlugin{
 		// 	ObjectMeta: metav1.ObjectMeta{
-		// 		Name:      "ui-dashboards",
+		// 		Name:      "dashboards",
 		// 	},
 		// }
 		// =====
@@ -524,7 +524,7 @@ func (r *MetricStorageReconciler) reconcileNormal(
 			Version: "v1alpha1",
 			Kind:    "UIPlugin",
 		})
-		uiPluginObj.SetName("ui-dashboards")
+		uiPluginObj.SetName("dashboards")
 		// =====
 		op, err = controllerutil.CreateOrPatch(ctx, r.Client, uiPluginObj, func() error {
 			// uiPluginObj.Spec.Type = "Dashboards" // After we update to COO 0.2.0 as dependency

--- a/tests/kuttl/suites/metricstorage/tests/01-assert.yaml
+++ b/tests/kuttl/suites/metricstorage/tests/01-assert.yaml
@@ -74,7 +74,7 @@ spec:
 apiVersion: observability.openshift.io/v1alpha1
 kind: UIPlugin
 metadata:
-  name: ui-dashboards
+  name: dashboards
 spec:
   type: Dashboards
 status:


### PR DESCRIPTION
When constructing the UIPlugin object for dashboarding, Telemetry Operator uses the name "ui-dashboards" since that was the required name proposed in the COO PR at the time of writing[1]. Since then, the proposed name has changed, and is expected to be "dashboards"  in COO 0.3.0 once this PR[2] merges.

Either value will work with COO 0.2.0, so this should be safe to merge at any time.

[1] [https://github.com/rhobs/observability-operator/commit/3d749fb6111fce29ee5cc1daeeb39f540ce3d1e6#diff-0f04a43a39bdfcead12[…]7f44a05d1852eda7feb72bR40](https://github.com/rhobs/observability-operator/commit/3d749fb6111fce29ee5cc1daeeb39f540ce3d1e6#diff-0f04a43a39bdfcead12f4dc8f4bf27ca0665c650ba7f44a05d1852eda7feb72bR40)

[2] https://github.com/rhobs/observability-operator/pull/481/files#diff-0f04a43a39bdfcead12f4dc8f4bf27ca0665c650ba7f44a05d1852eda7feb72bR263