### PR TITLE
Scrape RabbitMQ prometheus metrics

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -259,6 +259,14 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - rabbitmq.com
+  resources:
+  - rabbitmqclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - rabbitmq.openstack.org
   resources:
   - transporturls

--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -407,10 +407,10 @@ func (r *MetricStorageReconciler) reconcileNormal(
 	}
 	// ServiceMonitors for RabbitMQ monitoring
 	rabbitList := &rabbitmqv1.RabbitmqClusterList{}
-	listOpts := &client.ListOptions{
-		Namespace: instance.Namespace,
+	listOpts := []client.ListOption{
+		client.InNamespace(instance.GetNamespace()),
 	}
-	err = r.Client.List(ctx, rabbitList, listOpts)
+	err = r.Client.List(ctx, rabbitList, listOpts...)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
@@ -442,10 +442,7 @@ func (r *MetricStorageReconciler) reconcileNormal(
 	// Check that RabbitMQ monitor's RabbitMQs still exist
 	// Delete the ServiceMonitors, which don't have a RabbitMQ anymore
 	svcMonitorList := &monv1.ServiceMonitorList{}
-	listOpts = &client.ListOptions{
-		Namespace: instance.Namespace,
-	}
-	err = r.Client.List(ctx, svcMonitorList, listOpts)
+	err = r.Client.List(ctx, svcMonitorList, listOpts...)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240531085522-94fdcd5ff4fd
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240514152407-b2bea62f05db
 	github.com/openstack-k8s-operators/telemetry-operator/api v0.3.1-0.20240529090522-c780bd90b147
+	github.com/rabbitmq/cluster-operator v1.14.0
 	github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring v0.69.0-rhobs1
 	github.com/rhobs/observability-operator v0.0.28
 	golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/prometheus/common v0.46.0 h1:doXzt5ybi1HBKpsZOL0sSkaNHJJqkyfEWZGGqqSc
 github.com/prometheus/common v0.46.0/go.mod h1:Tp0qkxpb9Jsg54QMe+EAmqXkSV7Evdy1BTn+g2pa/hQ=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
+github.com/rabbitmq/cluster-operator v1.14.0 h1:1/nMyd9v/8T5IHA1BVcWbV0nrzN31F+gLP+0Ges6Y5E=
+github.com/rabbitmq/cluster-operator v1.14.0/go.mod h1:7XVU6ngbVJSPDXld+uMVk6nu68GH7fM6yYYY2MdYKek=
 github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring v0.69.0-rhobs1 h1:d6UamuHl8GaEXcQqM7VO8jMnnhzHmTA0f6h4dQTQsGk=
 github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring v0.69.0-rhobs1/go.mod h1:SDL0R6499oleOOVL5ovIxHpyLOh2sR2g0rvBuuqHyQM=
 github.com/rhobs/observability-operator v0.0.28 h1:FFMBkmI1LWJVWyJKJqelYbV5iUc4u/wJClqowRJZRoU=

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ import (
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	mariadbv1beta1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
+	rabbitmqclusterv1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
 	monv1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1"
 	monv1alpha1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	obov1 "github.com/rhobs/observability-operator/pkg/apis/monitoring/v1alpha1"
@@ -70,6 +71,7 @@ func init() {
 	utilruntime.Must(mariadbv1beta1.AddToScheme(scheme))
 	utilruntime.Must(heatv1.AddToScheme(scheme))
 	utilruntime.Must(infranetworkv1.AddToScheme(scheme))
+	utilruntime.Must(rabbitmqclusterv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/tests/kuttl/suites/metricstorage/tests/01-assert.yaml
+++ b/tests/kuttl/suites/metricstorage/tests/01-assert.yaml
@@ -35,7 +35,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     service: metricStorage
-  name: telemetry-kuttl
+  name: telemetry-kuttl-ceilometer-internal.telemetry-kuttl-tests.svc
   ownerReferences:
   - kind: MetricStorage
     name: telemetry-kuttl
@@ -57,6 +57,34 @@ spec:
   selector:
     matchLabels:
       service: ceilometer
+---
+apiVersion: monitoring.rhobs/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    service: metricStorage
+  name: telemetry-kuttl-rabbitmq.telemetry-kuttl-tests.svc
+  ownerReferences:
+  - kind: MetricStorage
+    name: telemetry-kuttl
+spec:
+  endpoints:
+  - interval: 30s
+    metricRelabelings:
+    - action: labeldrop
+      regex: pod
+    - action: labeldrop
+      regex: namespace
+    - action: labeldrop
+      regex: instance
+    - action: labeldrop
+      regex: job
+    - action: labeldrop
+      regex: publisher
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rabbitmq
 ---
 apiVersion: monitoring.rhobs/v1alpha1
 kind: ScrapeConfig

--- a/tests/kuttl/suites/tls/tests/02-assert.yaml
+++ b/tests/kuttl/suites/tls/tests/02-assert.yaml
@@ -277,7 +277,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     service: metricStorage
-  name: telemetry-kuttl-metricstorage
+  name: telemetry-kuttl-metricstorage-ceilometer-internal.telemetry-kuttl-tests.svc
   ownerReferences:
   - kind: MetricStorage
     name: telemetry-kuttl-metricstorage


### PR DESCRIPTION
This creates new ServiceMonitors, one per each RabbitMQ. RabbitMQ exposes its metric endpoint by default. The PR also changes the naming scheme of the ServiceMonitors from simply having one ServiceMonitor called `<instance-name>` to: `<instance-name>-<service-it-monitors-name>.<namespace>.svc`. So for example: `metric-storage-ceilometer-internal.openstack.svc` or `metric-storage-rabbitmq.openstack.svc`