### PR TITLE
Update hooks in Zuul jobs

### DIFF
--- a/ci/vars-default-telemetry.yml
+++ b/ci/vars-default-telemetry.yml
@@ -1,8 +1,7 @@
 ---
-pre_tests:
-  - name: Check default telemetry
-    source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/check-default-telemetry.yml"
-    type: playbook
+pre_tests_check_default_telemetry:
+  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/check-default-telemetry.yml"
+  type: playbook
 cifmw_edpm_prepare_kustomizations:
   - apiVersion: kustomize.config.k8s.io/v1beta1
     kind: Kustomization

--- a/ci/vars-logging.yml
+++ b/ci/vars-logging.yml
@@ -1,8 +1,7 @@
 ---
-pre_deploy:
-  - name: deploy_logging_dependencies
-    source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/deploy-logging-dependencies.yml"
-    type: playbook
+pre_deploy_deploy_logging_dependencies:
+  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/deploy-logging-dependencies.yml"
+  type: playbook
 cifmw_edpm_prepare_kustomizations:
   - apiVersion: kustomize.config.k8s.io/v1beta1
     kind: Kustomization


### PR DESCRIPTION
There are two ways to define hooks in ci-framework: either as a list or as a single hook in a parameter.
The second option makes it easier to combine jobs, since each new hook is defined in its own var.