### PR TITLE
[OSPRH-8076] Fix CustomMonitoringStack

### DIFF
--- a/api/bases/telemetry.openstack.org_metricstorages.yaml
+++ b/api/bases/telemetry.openstack.org_metricstorages.yaml
@@ -1069,6 +1069,17 @@ spec:
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
                 type: object
+              dashboardsEnabled:
+                default: false
+                description: DashboardsEnabled allows to enable or disable dashboards
+                  and related artifacts
+                type: boolean
+              dataplaneNetwork:
+                default: ctlplane
+                description: DataplaneNetwork defines the network that will be used
+                  to scrape dataplane node_exporter endpoints
+                pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
+                type: string
               monitoringStack:
                 description: MonitoringStack allows to define a metric storage with
                   options supported by Red Hat
@@ -1078,17 +1089,6 @@ spec:
                     default: true
                     description: AlertingEnabled allows to enable or disable alertmanager
                     type: boolean
-                  dashboardsEnabled:
-                    default: false
-                    description: DashboardsEnabled allows to enable or disable dashboards
-                      and related artifacts
-                    type: boolean
-                  dataplaneNetwork:
-                    default: ctlplane
-                    description: DataplaneNetwork defines the network that will be
-                      used to scrape dataplane node_exporter endpoints
-                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
-                    type: string
                   scrapeInterval:
                     default: 30s
                     description: ScrapeInterval sets the interval between scrapes
@@ -1175,8 +1175,6 @@ spec:
                         - persistent
                         type: string
                     type: object
-                required:
-                - dataplaneNetwork
                 type: object
               prometheusTls:
                 description: TLS - Parameters related to the TLS
@@ -1189,6 +1187,8 @@ spec:
                     description: SecretName - holding the cert, key for the service
                     type: string
                 type: object
+            required:
+            - dataplaneNetwork
             type: object
           status:
             description: MetricStorageStatus defines the observed state of MetricStorage

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -1597,6 +1597,17 @@ spec:
                         pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                         type: string
                     type: object
+                  dashboardsEnabled:
+                    default: false
+                    description: DashboardsEnabled allows to enable or disable dashboards
+                      and related artifacts
+                    type: boolean
+                  dataplaneNetwork:
+                    default: ctlplane
+                    description: DataplaneNetwork defines the network that will be
+                      used to scrape dataplane node_exporter endpoints
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
+                    type: string
                   enabled:
                     default: false
                     description: Enabled - Whether a MetricStorage should be deployed
@@ -1611,17 +1622,6 @@ spec:
                         default: true
                         description: AlertingEnabled allows to enable or disable alertmanager
                         type: boolean
-                      dashboardsEnabled:
-                        default: false
-                        description: DashboardsEnabled allows to enable or disable
-                          dashboards and related artifacts
-                        type: boolean
-                      dataplaneNetwork:
-                        default: ctlplane
-                        description: DataplaneNetwork defines the network that will
-                          be used to scrape dataplane node_exporter endpoints
-                        pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
-                        type: string
                       scrapeInterval:
                         default: 30s
                         description: ScrapeInterval sets the interval between scrapes
@@ -1710,8 +1710,6 @@ spec:
                             - persistent
                             type: string
                         type: object
-                    required:
-                    - dataplaneNetwork
                     type: object
                   prometheusTls:
                     description: TLS - Parameters related to the TLS
@@ -1724,6 +1722,8 @@ spec:
                         description: SecretName - holding the cert, key for the service
                         type: string
                     type: object
+                required:
+                - dataplaneNetwork
                 type: object
             type: object
           status:

--- a/api/v1beta1/metricstorage_types.go
+++ b/api/v1beta1/metricstorage_types.go
@@ -67,19 +67,10 @@ type MonitoringStack struct {
 	// +kubebuilder:default=true
 	AlertingEnabled bool `json:"alertingEnabled"`
 
-	// DashboardsEnabled allows to enable or disable dashboards and related artifacts
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=false
-	DashboardsEnabled bool `json:"dashboardsEnabled"`
-
 	// ScrapeInterval sets the interval between scrapes
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="30s"
 	ScrapeInterval string `json:"scrapeInterval"`
-
-	// DataplaneNetwork defines the network that will be used to scrape dataplane node_exporter endpoints
-	// +kubebuilder:default=ctlplane
-	DataplaneNetwork infranetworkv1.NetNameStr `json:"dataplaneNetwork"`
 
 	// Storage allows to define options for how to store metrics
 	// +kubebuilder:validation:Optional
@@ -89,6 +80,15 @@ type MonitoringStack struct {
 
 // MetricStorageSpec defines the desired state of MetricStorage
 type MetricStorageSpec struct {
+	// DashboardsEnabled allows to enable or disable dashboards and related artifacts
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	DashboardsEnabled bool `json:"dashboardsEnabled"`
+
+	// DataplaneNetwork defines the network that will be used to scrape dataplane node_exporter endpoints
+	// +kubebuilder:default=ctlplane
+	DataplaneNetwork infranetworkv1.NetNameStr `json:"dataplaneNetwork"`
+
 	// MonitoringStack allows to define a metric storage with
 	// options supported by Red Hat
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/metricstorage_webhook.go
+++ b/api/v1beta1/metricstorage_webhook.go
@@ -55,6 +55,9 @@ func (spec *MetricStorageSpec) Default() {
 		// NOTE: If we want to enable dashboards in the future by default, set
 		//       it here like Alerting above
 	}
+	if spec.DataplaneNetwork == "" {
+		spec.DataplaneNetwork = "ctlplane"
+	}
 	if spec.MonitoringStack != nil {
 		spec.MonitoringStack.Default()
 	}
@@ -64,9 +67,6 @@ func (spec *MetricStorageSpec) Default() {
 func (ms *MonitoringStack) Default() {
 	if ms.ScrapeInterval == "" {
 		ms.ScrapeInterval = "30s"
-	}
-	if ms.DataplaneNetwork == "" {
-		ms.DataplaneNetwork = "ctlplane"
 	}
 	ms.Storage.Default()
 }

--- a/config/crd/bases/telemetry.openstack.org_metricstorages.yaml
+++ b/config/crd/bases/telemetry.openstack.org_metricstorages.yaml
@@ -1069,6 +1069,17 @@ spec:
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
                 type: object
+              dashboardsEnabled:
+                default: false
+                description: DashboardsEnabled allows to enable or disable dashboards
+                  and related artifacts
+                type: boolean
+              dataplaneNetwork:
+                default: ctlplane
+                description: DataplaneNetwork defines the network that will be used
+                  to scrape dataplane node_exporter endpoints
+                pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
+                type: string
               monitoringStack:
                 description: MonitoringStack allows to define a metric storage with
                   options supported by Red Hat
@@ -1078,17 +1089,6 @@ spec:
                     default: true
                     description: AlertingEnabled allows to enable or disable alertmanager
                     type: boolean
-                  dashboardsEnabled:
-                    default: false
-                    description: DashboardsEnabled allows to enable or disable dashboards
-                      and related artifacts
-                    type: boolean
-                  dataplaneNetwork:
-                    default: ctlplane
-                    description: DataplaneNetwork defines the network that will be
-                      used to scrape dataplane node_exporter endpoints
-                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
-                    type: string
                   scrapeInterval:
                     default: 30s
                     description: ScrapeInterval sets the interval between scrapes
@@ -1175,8 +1175,6 @@ spec:
                         - persistent
                         type: string
                     type: object
-                required:
-                - dataplaneNetwork
                 type: object
               prometheusTls:
                 description: TLS - Parameters related to the TLS
@@ -1189,6 +1187,8 @@ spec:
                     description: SecretName - holding the cert, key for the service
                     type: string
                 type: object
+            required:
+            - dataplaneNetwork
             type: object
           status:
             description: MetricStorageStatus defines the observed state of MetricStorage

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -1597,6 +1597,17 @@ spec:
                         pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                         type: string
                     type: object
+                  dashboardsEnabled:
+                    default: false
+                    description: DashboardsEnabled allows to enable or disable dashboards
+                      and related artifacts
+                    type: boolean
+                  dataplaneNetwork:
+                    default: ctlplane
+                    description: DataplaneNetwork defines the network that will be
+                      used to scrape dataplane node_exporter endpoints
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
+                    type: string
                   enabled:
                     default: false
                     description: Enabled - Whether a MetricStorage should be deployed
@@ -1611,17 +1622,6 @@ spec:
                         default: true
                         description: AlertingEnabled allows to enable or disable alertmanager
                         type: boolean
-                      dashboardsEnabled:
-                        default: false
-                        description: DashboardsEnabled allows to enable or disable
-                          dashboards and related artifacts
-                        type: boolean
-                      dataplaneNetwork:
-                        default: ctlplane
-                        description: DataplaneNetwork defines the network that will
-                          be used to scrape dataplane node_exporter endpoints
-                        pattern: ^[a-zA-Z0-9][a-zA-Z0-9\-_]*[a-zA-Z0-9]$
-                        type: string
                       scrapeInterval:
                         default: 30s
                         description: ScrapeInterval sets the interval between scrapes
@@ -1710,8 +1710,6 @@ spec:
                             - persistent
                             type: string
                         type: object
-                    required:
-                    - dataplaneNetwork
                     type: object
                   prometheusTls:
                     description: TLS - Parameters related to the TLS
@@ -1724,6 +1722,8 @@ spec:
                         description: SecretName - holding the cert, key for the service
                         type: string
                     type: object
+                required:
+                - dataplaneNetwork
                 type: object
             type: object
           status:

--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -522,7 +522,7 @@ func (r *MetricStorageReconciler) reconcileNormal(
 	}
 	instance.Status.Conditions.MarkTrue(telemetryv1.ScrapeConfigReadyCondition, condition.ReadyMessage)
 
-	if !instance.Spec.MonitoringStack.DashboardsEnabled {
+	if !instance.Spec.DashboardsEnabled {
 		if res, err := metricstorage.DeleteDashboardObjects(ctx, instance, helper); err != nil {
 			return res, err
 		}
@@ -874,7 +874,7 @@ func getAddressFromIPSet(
 	if len(ipset.Status.Reservation) > 0 {
 		// search for the network specified in the Spec
 		for _, reservation := range ipset.Status.Reservation {
-			if reservation.Network == instance.Spec.MonitoringStack.DataplaneNetwork {
+			if reservation.Network == instance.Spec.DataplaneNetwork {
 				return reservation.Address, discoveryv1.AddressTypeIPv4
 			}
 		}

--- a/controllers/telemetry_controller.go
+++ b/controllers/telemetry_controller.go
@@ -409,10 +409,14 @@ func (r TelemetryReconciler) reconcileMetricStorage(ctx context.Context, instanc
 		if instance.Spec.MetricStorage.MetricStorageSpec.CustomMonitoringStack != nil {
 			metricStorageInstance.Spec.CustomMonitoringStack = &obov1.MonitoringStackSpec{}
 			instance.Spec.MetricStorage.MetricStorageSpec.CustomMonitoringStack.DeepCopyInto(metricStorageInstance.Spec.CustomMonitoringStack)
+		} else {
+			metricStorageInstance.Spec.CustomMonitoringStack = nil
 		}
 		if instance.Spec.MetricStorage.MetricStorageSpec.MonitoringStack != nil {
 			metricStorageInstance.Spec.MonitoringStack = &telemetryv1.MonitoringStack{}
 			instance.Spec.MetricStorage.MetricStorageSpec.MonitoringStack.DeepCopyInto(metricStorageInstance.Spec.MonitoringStack)
+		} else {
+			metricStorageInstance.Spec.MonitoringStack = nil
 		}
 		instance.Spec.MetricStorage.MetricStorageSpec.PrometheusTLS.DeepCopyInto(&metricStorageInstance.Spec.PrometheusTLS)
 		// TODO: Uncomment this line when implementing TLS for Alertmanager

--- a/tests/kuttl/suites/metricstorage/tests/01-deploy.yaml
+++ b/tests/kuttl/suites/metricstorage/tests/01-deploy.yaml
@@ -3,9 +3,9 @@ kind: MetricStorage
 metadata:
   name: telemetry-kuttl
 spec:
+  dashboardsEnabled: true
   monitoringStack:
     alertingEnabled: true
-    dashboardsEnabled: true
     scrapeInterval: 30s
     storage:
       strategy: persistent

--- a/tests/kuttl/suites/metricstorage/tests/02-disable-dashboards.yaml
+++ b/tests/kuttl/suites/metricstorage/tests/02-disable-dashboards.yaml
@@ -3,9 +3,9 @@ kind: MetricStorage
 metadata:
   name: telemetry-kuttl
 spec:
+  dashboardsEnabled: false
   monitoringStack:
     alertingEnabled: true
-    dashboardsEnabled: false
     scrapeInterval: 30s
     storage:
       strategy: persistent

--- a/tests/kuttl/suites/metricstorage/tests/03-prepare-for-custom-monitoring-stack.yaml
+++ b/tests/kuttl/suites/metricstorage/tests/03-prepare-for-custom-monitoring-stack.yaml
@@ -1,0 +1,12 @@
+# Kuttl test doesn't seem to wait correctly for the metric
+# storage to reconcile in the next test step when switching
+# to CustomMonitoringStack (in the output of the test I
+# can see it applyes the resource and fails a second later).
+# Deleting it here and than recreating it in the next step
+# should ensure kuttl waits long enough.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: telemetry.openstack.org/v1beta1
+  kind: MetricStorage
+  name: telemetry-kuttl

--- a/tests/kuttl/suites/metricstorage/tests/04-assert.yaml
+++ b/tests/kuttl/suites/metricstorage/tests/04-assert.yaml
@@ -1,0 +1,111 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    prometheus: telemetry-kuttl
+  name: prometheus-telemetry-kuttl-0
+status:
+  containerStatuses:
+  - name: config-reloader
+    ready: true
+    started: true
+  - name: prometheus
+    ready: true
+    started: true
+  - name: thanos-sidecar
+    ready: true
+    started: true
+---
+apiVersion: monitoring.rhobs/v1alpha1
+kind: MonitoringStack
+metadata:
+  labels:
+    service: metricStorage
+  name: telemetry-kuttl
+spec:
+  resourceSelector:
+    matchLabels:
+      app: custom-monitoring-stack
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: telemetry-kuttl-prometheus
+  ownerReferences:
+    - kind: MonitoringStack
+      name: telemetry-kuttl
+spec:
+  ports:
+  - name: web
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+---
+apiVersion: monitoring.rhobs/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    service: metricStorage
+  name: telemetry-kuttl-ceilometer-internal.telemetry-kuttl-tests.svc
+  ownerReferences:
+  - kind: MetricStorage
+    name: telemetry-kuttl
+spec:
+  endpoints:
+  - interval: 40s
+    metricRelabelings:
+    - action: labeldrop
+      regex: pod
+    - action: labeldrop
+      regex: namespace
+    - action: labeldrop
+      regex: instance
+    - action: labeldrop
+      regex: job
+    - action: labeldrop
+      regex: publisher
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+      service: ceilometer
+---
+apiVersion: monitoring.rhobs/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    service: metricStorage
+  name: telemetry-kuttl-rabbitmq.telemetry-kuttl-tests.svc
+  ownerReferences:
+  - kind: MetricStorage
+    name: telemetry-kuttl
+spec:
+  endpoints:
+  - interval: 40s
+    metricRelabelings:
+    - action: labeldrop
+      regex: pod
+    - action: labeldrop
+      regex: namespace
+    - action: labeldrop
+      regex: instance
+    - action: labeldrop
+      regex: job
+    - action: labeldrop
+      regex: publisher
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rabbitmq
+---
+apiVersion: monitoring.rhobs/v1alpha1
+kind: ScrapeConfig
+metadata:
+  labels:
+    service: metricStorage
+  name: telemetry-kuttl
+  ownerReferences:
+  - kind: MetricStorage
+    name: telemetry-kuttl
+spec:
+  staticConfigs:
+    - {}

--- a/tests/kuttl/suites/metricstorage/tests/04-custom-monitoring-stack.yaml
+++ b/tests/kuttl/suites/metricstorage/tests/04-custom-monitoring-stack.yaml
@@ -1,0 +1,16 @@
+apiVersion: telemetry.openstack.org/v1beta1
+kind: MetricStorage
+metadata:
+  name: telemetry-kuttl
+spec:
+  dashboardsEnabled: false
+  customMonitoringStack:
+    alertmanagerConfig:
+      disabled: false
+    prometheusConfig:
+      replicas: 1
+      scrapeInterval: 40s
+    resourceSelector:
+      matchLabels:
+        app: custom-monitoring-stack
+    retention: 1d


### PR DESCRIPTION
The CRD fields "DataplaneNetwork" and "DashboardsEnabled" should be usable by all MetricStorages, so they should be in the MetricStorageSpec instead of being inside the "MonitoringStack".

As the DataplaneNetwork field is required, this fixes the CustomMonitoringStack. I also added some more kuttl tests to test deploying the CustomMonitoringStack.