### PR TITLE
[OSPRH-8074] Fix panic when missing ScrapeInterval

### DIFF
--- a/pkg/metricstorage/service_monitor.go
+++ b/pkg/metricstorage/service_monitor.go
@@ -36,7 +36,10 @@ func ServiceMonitor(
 	var scrapeInterval monv1.Duration
 	if instance.Spec.MonitoringStack != nil && instance.Spec.MonitoringStack.ScrapeInterval != "" {
 		scrapeInterval = monv1.Duration(instance.Spec.MonitoringStack.ScrapeInterval)
-	} else if instance.Spec.CustomMonitoringStack != nil && *instance.Spec.CustomMonitoringStack.PrometheusConfig.ScrapeInterval != monv1.Duration("") {
+	} else if instance.Spec.CustomMonitoringStack != nil &&
+		instance.Spec.CustomMonitoringStack.PrometheusConfig != nil &&
+		instance.Spec.CustomMonitoringStack.PrometheusConfig.ScrapeInterval != nil &&
+		*instance.Spec.CustomMonitoringStack.PrometheusConfig.ScrapeInterval != monv1.Duration("") {
 		scrapeInterval = *instance.Spec.CustomMonitoringStack.PrometheusConfig.ScrapeInterval
 	} else {
 		scrapeInterval = telemetryv1.DefaultScrapeInterval


### PR DESCRIPTION
The operator would panic when using the CustomMonitoringStack and not providing the ScrapeInterval. This PR adds a check if the ScrapeInterval (and the structs above it) are nil. If one of them is nil, default ScrapeInterval is used.