### PR TITLE
[OSPRH-8065] Change autoscaling TLS condition

### DIFF
--- a/controllers/autoscaling_controller.go
+++ b/controllers/autoscaling_controller.go
@@ -393,7 +393,8 @@ func (r *AutoscalingReconciler) reconcileNormal(
 	} else {
 		instance.Status.PrometheusPort = instance.Spec.PrometheusPort
 	}
-	if instance.Spec.PrometheusTLSCaCertSecret == nil {
+	if instance.Spec.PrometheusHost == "" {
+		// We're using MetricStorage for Prometheus. Set TLS accordingly
 		metricStorage := &telemetryv1.MetricStorage{}
 		err := r.Client.Get(ctx, client.ObjectKey{
 			Namespace: instance.Namespace,
@@ -409,7 +410,8 @@ func (r *AutoscalingReconciler) reconcileNormal(
 		}
 		instance.Status.PrometheusTLS = metricStorage.Spec.PrometheusTLS.Enabled()
 	} else {
-		instance.Status.PrometheusTLS = true
+		// We're using user-deployed Prometheus. Set TLS based on PrometheusTLSCaCertSecret
+		instance.Status.PrometheusTLS = instance.Spec.PrometheusTLSCaCertSecret != nil
 	}
 
 	db, result, err := r.ensureDB(ctx, helper, instance)


### PR DESCRIPTION
Change the condition for which Prometheus to use for autoscaling.

I noticed the status of autoscaling wasn't being set to Ready when trying to use user-deployed prometheus while having the MetricStorage disabled. It'd wrongly try to get a MetricStorage, which wasn't there and set the error into the status.

Now we're using a better condition. We're looking for MetricStorages only when we're using a MetricStorage Prometheus. When using a user-deployed Prometheus, we aren't looking at MetricStorage.