### PR TITLE
[OSPRH-8249] Set the service_token_roles_required

### DIFF
--- a/templates/autoscaling/config/aodh.conf
+++ b/templates/autoscaling/config/aodh.conf
@@ -38,6 +38,7 @@ password = {{ .AodhPassword }}
 user_domain_name = Default
 project_name = service
 project_domain_name = Default
+service_token_roles_required = True
 
 [service_credentials]
 auth_type=password


### PR DESCRIPTION
Set service_token_roles_required to true in aodh.conf. This gets rid of a warning we could see in aodh logs previously:

```
[Tue Jul 02 13:51:22.452531 2024] [wsgi:error] [pid 14:tid 104] 2024-07-02 13:51:22.452 14 WARNING keystonemiddleware.auth_token [-] AuthToken middleware is set with keystone_authtoken.service_token_roles_required set to False. This is backwards compatible but deprecated behaviour. Please set this to True.\x1b[00m
```

This setting is set to True in other services already. While testing, I was able to successfuly create an autoscaling stack. Alarms got successfully created and after a time they got evaluated. There weren't any obvious errors in aodh logs or other issues.