### PR TITLE
Revert "Remove memcached from autoscaling"

### DIFF
--- a/api/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/api/bases/telemetry.openstack.org_autoscalings.yaml
@@ -42,6 +42,7 @@ spec:
                   databaseInstance: openstack
                   evaluatorImage: ""
                   listenerImage: ""
+                  memcachedInstance: memcached
                   notifierImage: ""
                   passwordSelector:
                     aodhService: AodhPassword
@@ -82,6 +83,10 @@ spec:
                   evaluatorImage:
                     type: string
                   listenerImage:
+                    type: string
+                  memcachedInstance:
+                    default: memcached
+                    description: Memcached instance name.
                     type: string
                   networkAttachmentDefinitions:
                     description: NetworkAttachmentDefinitions list of network attachment
@@ -345,6 +350,7 @@ spec:
                 - databaseInstance
                 - evaluatorImage
                 - listenerImage
+                - memcachedInstance
                 - notifierImage
                 - secret
                 type: object

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -45,6 +45,7 @@ spec:
                       databaseInstance: openstack
                       evaluatorImage: ""
                       listenerImage: ""
+                      memcachedInstance: memcached
                       notifierImage: ""
                       passwordSelector:
                         aodhService: AodhPassword
@@ -85,6 +86,10 @@ spec:
                       evaluatorImage:
                         type: string
                       listenerImage:
+                        type: string
+                      memcachedInstance:
+                        default: memcached
+                        description: Memcached instance name.
                         type: string
                       networkAttachmentDefinitions:
                         description: NetworkAttachmentDefinitions list of network
@@ -358,6 +363,7 @@ spec:
                     - databaseInstance
                     - evaluatorImage
                     - listenerImage
+                    - memcachedInstance
                     - notifierImage
                     - secret
                     type: object

--- a/api/v1beta1/autoscaling_types.go
+++ b/api/v1beta1/autoscaling_types.go
@@ -113,6 +113,11 @@ type AodhCore struct {
 	// PreserveJobs - do not delete jobs after they finished e.g. to check logs
 	PreserveJobs bool `json:"preserveJobs"`
 
+	// Memcached instance name.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:default=memcached
+	MemcachedInstance string `json:"memcachedInstance"`
+
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// TLS - Parameters related to the TLS
@@ -131,7 +136,7 @@ type AutoscalingSpec struct {
 	AutoscalingSpecBase `json:",inline"`
 
 	// Aodh spec
-	// +kubebuilder:default={rabbitMqClusterName: rabbitmq, databaseAccount: aodh, passwordSelector: {aodhService: AodhPassword}, serviceUser: aodh, apiImage: "", evaluatorImage: "", notifierImage: "", listenerImage: "", databaseInstance: "openstack", secret: "osp-secret"}
+	// +kubebuilder:default={rabbitMqClusterName: rabbitmq, databaseAccount: aodh, passwordSelector: {aodhService: AodhPassword}, serviceUser: aodh, apiImage: "", evaluatorImage: "", notifierImage: "", listenerImage: "", databaseInstance: "openstack", secret: "osp-secret", memcachedInstance: "memcached"}
 	Aodh Aodh `json:"aodh,omitempty"`
 }
 
@@ -140,7 +145,7 @@ type AutoscalingSpecCore struct {
 	AutoscalingSpecBase `json:",inline"`
 
 	// Aodh spec
-	// +kubebuilder:default={rabbitMqClusterName: rabbitmq, databaseAccount: aodh, passwordSelector: {aodhService: AodhPassword}, serviceUser: aodh, databaseInstance: "openstack", secret: "osp-secret"}
+	// +kubebuilder:default={rabbitMqClusterName: rabbitmq, databaseAccount: aodh, passwordSelector: {aodhService: AodhPassword}, serviceUser: aodh, databaseInstance: "openstack", secret: "osp-secret", memcachedInstance: "memcached"}
 	Aodh AodhCore `json:"aodh,omitempty"`
 }
 

--- a/api/v1beta1/autoscaling_webhook.go
+++ b/api/v1beta1/autoscaling_webhook.go
@@ -75,6 +75,9 @@ func (spec *AutoscalingSpec) Default() {
 	if spec.Aodh.ListenerImage == "" {
 		spec.Aodh.ListenerImage = autoscalingDefaults.AodhListenerContainerImageURL
 	}
+	if spec.Aodh.MemcachedInstance == "" {
+		spec.Aodh.MemcachedInstance = "memcached"
+	}
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.

--- a/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
@@ -42,6 +42,7 @@ spec:
                   databaseInstance: openstack
                   evaluatorImage: ""
                   listenerImage: ""
+                  memcachedInstance: memcached
                   notifierImage: ""
                   passwordSelector:
                     aodhService: AodhPassword
@@ -82,6 +83,10 @@ spec:
                   evaluatorImage:
                     type: string
                   listenerImage:
+                    type: string
+                  memcachedInstance:
+                    default: memcached
+                    description: Memcached instance name.
                     type: string
                   networkAttachmentDefinitions:
                     description: NetworkAttachmentDefinitions list of network attachment
@@ -345,6 +350,7 @@ spec:
                 - databaseInstance
                 - evaluatorImage
                 - listenerImage
+                - memcachedInstance
                 - notifierImage
                 - secret
                 type: object

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -45,6 +45,7 @@ spec:
                       databaseInstance: openstack
                       evaluatorImage: ""
                       listenerImage: ""
+                      memcachedInstance: memcached
                       notifierImage: ""
                       passwordSelector:
                         aodhService: AodhPassword
@@ -85,6 +86,10 @@ spec:
                       evaluatorImage:
                         type: string
                       listenerImage:
+                        type: string
+                      memcachedInstance:
+                        default: memcached
+                        description: Memcached instance name.
                         type: string
                       networkAttachmentDefinitions:
                         description: NetworkAttachmentDefinitions list of network
@@ -358,6 +363,7 @@ spec:
                     - databaseInstance
                     - evaluatorImage
                     - listenerImage
+                    - memcachedInstance
                     - notifierImage
                     - secret
                     type: object

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -174,6 +174,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - memcached.openstack.org
+  resources:
+  - memcacheds
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - monitoring.rhobs
   resources:
   - alertmanagers

--- a/config/samples/telemetry_v1beta1_autoscaling.yaml
+++ b/config/samples/telemetry_v1beta1_autoscaling.yaml
@@ -14,3 +14,4 @@ spec:
     passwordSelectors:
     databaseAccount: aodh
     databaseInstance: openstack
+    memcachedInstance: memcached

--- a/config/samples/telemetry_v1beta1_autoscaling_tls.yaml
+++ b/config/samples/telemetry_v1beta1_autoscaling_tls.yaml
@@ -14,6 +14,7 @@ spec:
     passwordSelectors:
     databaseAccount: aodh
     databaseInstance: openstack
+    memcachedInstance: memcached
     tls:
       api:
         internal:

--- a/config/samples/telemetry_v1beta1_telemetry.yaml
+++ b/config/samples/telemetry_v1beta1_telemetry.yaml
@@ -19,6 +19,7 @@ spec:
       passwordSelectors:
       databaseAccount: aodh
       databaseInstance: openstack
+      memcachedInstance: memcached
       secret: osp-secret
     heatInstance: heat
   ceilometer:

--- a/config/samples/telemetry_v1beta1_telemetry_tls.yaml
+++ b/config/samples/telemetry_v1beta1_telemetry_tls.yaml
@@ -22,6 +22,7 @@ spec:
       passwordSelectors:
       databaseUser: aodh
       databaseInstance: openstack
+      memcachedInstance: memcached
       secret: osp-secret
       tls:
         api:

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	heatv1 "github.com/openstack-k8s-operators/heat-operator/api/v1beta1"
+	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	infranetworkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
@@ -69,6 +70,7 @@ func init() {
 	utilruntime.Must(monv1.AddToScheme(scheme))
 	utilruntime.Must(monv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(mariadbv1beta1.AddToScheme(scheme))
+	utilruntime.Must(memcachedv1.AddToScheme(scheme))
 	utilruntime.Must(heatv1.AddToScheme(scheme))
 	utilruntime.Must(infranetworkv1.AddToScheme(scheme))
 	utilruntime.Must(rabbitmqclusterv1.AddToScheme(scheme))

--- a/templates/autoscaling/config/aodh.conf
+++ b/templates/autoscaling/config/aodh.conf
@@ -31,6 +31,8 @@ transport_url = {{ .TransportURL }}
 [keystone_authtoken]
 www_authenticate_uri = {{ .KeystoneInternalURL }}
 interface=internal
+memcached_servers={{ .MemcachedServersWithInet }}
+memcache_use_advanced_pool=True
 auth_type = password
 auth_url = {{ .KeystoneInternalURL }}
 username = {{ .AodhUser }}

--- a/tests/kuttl/suites/autoscaling/tests/01-deploy.yaml
+++ b/tests/kuttl/suites/autoscaling/tests/01-deploy.yaml
@@ -12,4 +12,5 @@ spec:
     passwordSelectors:
     databaseAccount: aodh
     databaseInstance: openstack
+    memcachedInstance: memcached
   heatInstance: heat

--- a/tests/kuttl/suites/default/tests/01-deploy.yaml
+++ b/tests/kuttl/suites/default/tests/01-deploy.yaml
@@ -24,6 +24,7 @@ spec:
       passwordSelectors:
       databaseAccount: aodh
       databaseInstance: openstack
+      memcachedInstance: memcached
     heatInstance: heat
   ceilometer:
     enabled: true

--- a/tests/kuttl/suites/tls/tests/02-deploy.yaml
+++ b/tests/kuttl/suites/tls/tests/02-deploy.yaml
@@ -12,6 +12,7 @@ spec:
     passwordSelectors:
     databaseAccount: aodh
     databaseInstance: openstack
+    memcachedInstance: memcached
     tls:
       api:
         internal:


### PR DESCRIPTION
This reverts commit bc526c54fc5c5809df48ad861ef285f7b91954f4.

Aodh needs to cache keystone tokens. In process caching is deprecated for a long time and we get a deprecation warning in the logs. This returns memcached support, which is used for this caching and it gets rid of the warning.

The warning:
```
[Tue Jul 02 13:51:22.466076 2024] [wsgi:error] [pid 14:tid 104] [remote 10.217.0.2:57004] 2024-07-02 13:51:22.465 14 WARNING keystonemiddleware.auth_token [-] Using the in-process token cache is deprecated as of the 4.2.0 release and may be removed in the 5.0.0 release or the 'O' development cycle. The in-process cache causes inconsistent results and high memory usage. When the feature is removed the auth_token middleware will not cache tokens by default which may result in performance issues. It is recommended to use  memcache for the auth_token token cache by setting the memcached_servers option.\x1b[00m  
```

rh-jira: https://issues.redhat.com/browse/OSPRH-8249