### PR TITLE
Remove dataplane-operator references

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -50,8 +50,6 @@
             required-projects:
               - name: openstack-k8s-operators/ci-framework
                 override-checkout: main
-              - name: openstack-k8s-operators/dataplane-operator
-                override-checkout: main
               - name: openstack-k8s-operators/install_yamls
                 override-checkout: main
               - name: openstack-k8s-operators/infra-operator


### PR DESCRIPTION
Now that the dataplane-operator is combined and
not installed through a separate repo.