### PR TITLE
Return nil error in case NotFound and to use RequeueAfter

### DIFF
--- a/controllers/aodh_controller.go
+++ b/controllers/aodh_controller.go
@@ -112,7 +112,8 @@ func (r *AutoscalingReconciler) reconcileInitAodh(
 	_, _, err := secret.GetSecret(ctx, helper, instance.Spec.Aodh.Secret, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
-			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("OpenStack secret %s not found", instance.Spec.Aodh.Secret)
+			Log.Info(fmt.Sprintf("OpenStack secret %s not found", instance.Spec.Aodh.Secret))
+			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 		}
 		return ctrl.Result{}, err
 	}

--- a/controllers/autoscaling_controller.go
+++ b/controllers/autoscaling_controller.go
@@ -344,12 +344,13 @@ func (r *AutoscalingReconciler) reconcileNormal(
 	memcached, err := memcachedv1.GetMemcachedByName(ctx, helper, instance.Spec.Aodh.MemcachedInstance, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			Log.Info(fmt.Sprintf("memcached %s not found", instance.Spec.Aodh.MemcachedInstance))
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.MemcachedReadyCondition,
 				condition.RequestedReason,
 				condition.SeverityInfo,
 				condition.MemcachedReadyWaitingMessage))
-			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("memcached %s not found", instance.Spec.Aodh.MemcachedInstance)
+			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 		}
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.MemcachedReadyCondition,
@@ -361,12 +362,13 @@ func (r *AutoscalingReconciler) reconcileNormal(
 	}
 
 	if !memcached.IsReady() {
+		Log.Info(fmt.Sprintf("memcached %s is not ready", memcached.Name))
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.MemcachedReadyCondition,
 			condition.RequestedReason,
 			condition.SeverityInfo,
 			condition.MemcachedReadyWaitingMessage))
-		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("memcached %s is not ready", memcached.Name)
+		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 	}
 	// Mark the Memcached Service as Ready if we get to this point with no errors
 	instance.Status.Conditions.MarkTrue(
@@ -379,12 +381,13 @@ func (r *AutoscalingReconciler) reconcileNormal(
 	heat, err := r.getAutoscalingHeat(ctx, helper, instance)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			Log.Info(fmt.Sprintf("heat %s not found", instance.Spec.HeatInstance))
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				telemetryv1.HeatReadyCondition,
 				condition.RequestedReason,
 				condition.SeverityInfo,
 				telemetryv1.HeatReadyNotFoundMessage))
-			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("heat %s not found", instance.Spec.HeatInstance)
+			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 		}
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			telemetryv1.HeatReadyCondition,
@@ -396,12 +399,13 @@ func (r *AutoscalingReconciler) reconcileNormal(
 	}
 
 	if !heat.IsReady() {
+		Log.Info(fmt.Sprintf("heat %s is not ready", heat.Name))
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			telemetryv1.HeatReadyCondition,
 			condition.RequestedReason,
 			condition.SeverityInfo,
 			telemetryv1.HeatReadyUnreadyMessage))
-		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("heat %s is not ready", heat.Name)
+		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 	}
 	// Mark the Heat Service as Ready if we get to this point with no errors
 	instance.Status.Conditions.MarkTrue(

--- a/controllers/ceilometer_controller.go
+++ b/controllers/ceilometer_controller.go
@@ -237,7 +237,8 @@ func (r *CeilometerReconciler) reconcileInit(
 	_, _, err := secret.GetSecret(ctx, helper, instance.Spec.Secret, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
-			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("OpenStack secret %s not found", instance.Spec.Secret)
+			Log.Info(fmt.Sprintf("OpenStack secret %s not found", instance.Spec.Secret))
+			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 		}
 		return ctrl.Result{}, err
 	}

--- a/controllers/telemetry_common.go
+++ b/controllers/telemetry_common.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type conditionUpdater interface {
@@ -49,12 +50,13 @@ func ensureSecret(
 	hash, res, err := secret.VerifySecret(ctx, secretName, expectedFields, reader, requeueTimeout)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			log.FromContext(ctx).Info(fmt.Sprintf("OpenStack secret %s not found", secretName))
 			conditionUpdater.Set(condition.FalseCondition(
 				condition.InputReadyCondition,
 				condition.RequestedReason,
 				condition.SeverityInfo,
 				condition.InputReadyWaitingMessage))
-			return "", ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("OpenStack secret %s not found", secretName)
+			return "", ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 		}
 		conditionUpdater.Set(condition.FalseCondition(
 			condition.InputReadyCondition,


### PR DESCRIPTION
Currently the reconciler returned both a non-zero result and a non-nil error.
The result will always be ignored if the error is non-nil and the non-nil error causes reqeueuing with exponential backoff.

In case of NotFound return nil that the ReqeueAfter is used.

For more details, see: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler