### PR TITLE
Add Kepler's scrape endpoints to prometheus config

### DIFF
--- a/api/v1beta1/telemetry_consts.go
+++ b/api/v1beta1/telemetry_consts.go
@@ -30,6 +30,8 @@ const (
 	DefaultScrapeInterval = "30s"
 	// PauseBetweenWatchAttempts -
 	PauseBetweenWatchAttempts = time.Duration(60) * time.Second
+	// DefaultKeplerPort -
+	DefaultKeplerPort = 8888
 )
 
 // PrometheusReplicas -


### PR DESCRIPTION
Generate Kepler endpoints just like Node Exporter by appending corresponding ports to their services.
Also rename `getNodeExporterEndpoint` to `getMetricExporterEndpoint` since Kepler would also use it.