### PR TITLE
Do not ignore err on GetSecret()

### DIFF
--- a/controllers/ceilometer_controller.go
+++ b/controllers/ceilometer_controller.go
@@ -818,8 +818,15 @@ func (r *CeilometerReconciler) generateServiceConfig(
 		return err
 	}
 
-	transportURLSecret, _, _ := secret.GetSecret(ctx, h, instance.CeilometerStatus.TransportURLSecret, instance.Namespace)
-	ceilometerPasswordSecret, _, _ := secret.GetSecret(ctx, h, instance.Spec.Secret, instance.Namespace)
+	transportURLSecret, _, err := secret.GetSecret(ctx, h, instance.CeilometerStatus.TransportURLSecret, instance.Namespace)
+	if err != nil {
+		return err
+	}
+
+	ceilometerPasswordSecret, _, err := secret.GetSecret(ctx, h, instance.Spec.Secret, instance.Namespace)
+	if err != nil {
+		return err
+	}
 
 	templateParameters := map[string]interface{}{
 		"KeystoneInternalURL": keystoneInternalURL,
@@ -891,8 +898,15 @@ func (r *CeilometerReconciler) generateComputeServiceConfig(
 		return err
 	}
 
-	transportURLSecret, _, _ := secret.GetSecret(ctx, h, instance.CeilometerStatus.TransportURLSecret, instance.Namespace)
-	ceilometerPasswordSecret, _, _ := secret.GetSecret(ctx, h, instance.Spec.Secret, instance.Namespace)
+	transportURLSecret, _, err := secret.GetSecret(ctx, h, instance.CeilometerStatus.TransportURLSecret, instance.Namespace)
+	if err != nil {
+		return err
+	}
+
+	ceilometerPasswordSecret, _, err := secret.GetSecret(ctx, h, instance.Spec.Secret, instance.Namespace)
+	if err != nil {
+		return err
+	}
 
 	templateParameters := map[string]interface{}{
 		"KeystoneInternalURL":      keystoneInternalURL,


### PR DESCRIPTION
In CI jobs it was seen that the controller menager restarted due to a nil ptr when set the transport url in the config. The issue iss that when the TransportURL secret gets fetched, no check is perforned if an error happened.

This adds the err checks on the TransportURL and Password secret.