### PR TITLE
Fix running reconcileDelete on new instance

### DIFF
--- a/controllers/ceilometer_controller.go
+++ b/controllers/ceilometer_controller.go
@@ -203,7 +203,12 @@ func (r *CeilometerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// If we're not deleting this and the service object doesn't have our finalizer, add it.
-	if !instance.DeletionTimestamp.IsZero() && controllerutil.AddFinalizer(instance, helper.GetFinalizer()) || isNewInstance {
+	if instance.DeletionTimestamp.IsZero() && controllerutil.AddFinalizer(instance, helper.GetFinalizer()) || isNewInstance {
+		return ctrl.Result{}, nil
+	}
+
+	// Handle service delete
+	if !instance.DeletionTimestamp.IsZero() {
 		return r.reconcileDelete(ctx, instance, helper)
 	}
 


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/telemetry-operator/commit/dda3b1ea767125ce043005ae6b1ab4bfa066703c refactored code and introduce the situation that on the just created new instance the reconcileDelete method runs which we can see from the operator log:

~~~
2024-10-08T21:45:28Z    INFO    ceilometer-resource     default {"name": "ceilometer"}
2024-10-08T21:45:28Z    INFO    ceilometer-resource     validate create {"name": "ceilometer"}
2024-10-08T21:45:28Z    INFO    Controllers.Ceilometer  Reconciling Service delete      {"controller": "ceilometer", "controllerGroup": "telemetry.openstack.org", "controllerKind": "Ceilometer", "Ceilometer": {"name":"ceilometer","namespace":"openstack-kuttl-tests"}, "namespace": "openstack-kuttl-tests", "name": "ceilometer", "reconcileID": "c205bb0b-1c34-4350-969a-06c0925e0cdf"}
~~~

This change moves reconcileDelete in its own condition.