### PR TITLE
[OSPRH-10035] Expand "Can't own" messages

### DIFF
--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -299,10 +299,10 @@ func (r *MetricStorageReconciler) reconcileNormal(
 	err := r.ensureWatches(ctx, "monitoringstacks.monitoring.rhobs", &obov1.MonitoringStack{}, eventHandler)
 	if err != nil {
 		instance.Status.Conditions.MarkFalse(telemetryv1.MonitoringStackReadyCondition,
-			condition.Reason("Can't own MonitoringStack resource"),
+			condition.Reason("Can't own MonitoringStack resource. The Cluster Observability Operator probably isn't installed"),
 			condition.SeverityError,
 			telemetryv1.MonitoringStackUnableToOwnMessage, err)
-		Log.Info("Can't own MonitoringStack resource")
+		Log.Info("Can't own MonitoringStack resource. The Cluster Observability Operator probably isn't installed")
 		return ctrl.Result{RequeueAfter: telemetryv1.PauseBetweenWatchAttempts}, nil
 	}
 
@@ -347,10 +347,10 @@ func (r *MetricStorageReconciler) reconcileNormal(
 		err = r.ensureWatches(ctx, "prometheuses.monitoring.rhobs", &monv1.Prometheus{}, handler.EnqueueRequestsFromMapFunc(prometheusWatchFn))
 		if err != nil {
 			instance.Status.Conditions.MarkFalse(telemetryv1.PrometheusReadyCondition,
-				condition.Reason("Can't watch prometheus resource"),
+				condition.Reason("Can't watch prometheus resource. The Cluster Observability Operator probably isn't installed"),
 				condition.SeverityError,
 				telemetryv1.PrometheusUnableToWatchMessage, err)
-			Log.Info("Can't watch Prometheus resource")
+			Log.Info("Can't watch Prometheus resource. The Cluster Observability Operator probably isn't installed")
 			return ctrl.Result{RequeueAfter: telemetryv1.PauseBetweenWatchAttempts}, nil
 		}
 		prometheusTLSPatch := metricstorage.PrometheusTLS(instance)
@@ -542,10 +542,10 @@ func (r *MetricStorageReconciler) createScrapeConfigs(
 	err := r.ensureWatches(ctx, "scrapeconfigs.monitoring.rhobs", &monv1alpha1.ScrapeConfig{}, eventHandler)
 	if err != nil {
 		instance.Status.Conditions.MarkFalse(telemetryv1.ScrapeConfigReadyCondition,
-			condition.Reason("Can't own ScrapeConfig resource"),
+			condition.Reason("Can't own ScrapeConfig resource. The Cluster Observability Operator probably isn't installed"),
 			condition.SeverityError,
 			telemetryv1.ScrapeConfigUnableToOwnMessage, err)
-		Log.Info("Can't own ScrapeConfig resource")
+		Log.Info("Can't own ScrapeConfig resource. The Cluster Observability Operator probably isn't installed")
 		return ctrl.Result{RequeueAfter: telemetryv1.PauseBetweenWatchAttempts}, nil
 	}
 
@@ -661,10 +661,10 @@ func (r *MetricStorageReconciler) createDashboardObjects(ctx context.Context, in
 	err = r.ensureWatches(ctx, "prometheusrules.monitoring.rhobs", &monv1.PrometheusRule{}, eventHandler)
 	if err != nil {
 		instance.Status.Conditions.MarkFalse(telemetryv1.DashboardPrometheusRuleReadyCondition,
-			condition.Reason("Can't own PrometheusRule resource"),
+			condition.Reason("Can't own PrometheusRule resource. The Cluster Observability Operator probably isn't installed"),
 			condition.SeverityError,
 			telemetryv1.DashboardPrometheusRuleUnableToOwnMessage, err)
-		Log.Info("Can't own PrometheusRule resource")
+		Log.Info("Can't own PrometheusRule resource. The Cluster Observability Operator probably isn't installed")
 		return ctrl.Result{RequeueAfter: telemetryv1.PauseBetweenWatchAttempts}, nil
 	}
 	prometheusRule := &monv1.PrometheusRule{


### PR DESCRIPTION
Logs with the new code:
```
2024-10-10T08:53:37-04:00	DEBUG	events	Can't own MonitoringStack resource. The Cluster Observability Operator probably isn't installed	{"type": "Warning", "object": {"kind":"MetricStorage","namespace":"openstack","name":"metric-storage","uid":"ca0b7aa1-8885-40c0-8622-272cee8d57c8","apiVersion":"telemetry.openstack.org/v1beta1","resourceVersion":"8632360"}, "reason": "Failed own"}
2024-10-10T08:54:37-04:00	INFO	Controllers.MetricStorage	Reconciling Service 'metric-storage'	{"controller": "metricstorage", "controllerGroup": "telemetry.openstack.org", "controllerKind": "MetricStorage", "MetricStorage": {"name":"metric-storage","namespace":"openstack"}, "namespace": "openstack", "name": "metric-storage", "reconcileID": "a744e797-47d3-427c-b052-04bc630847f0"}
2024-10-10T08:54:37-04:00	INFO	Controllers.MetricStorage	Can't own MonitoringStack resource. The Cluster Observability Operator probably isn't installed	{"controller": "metricstorage", "controllerGroup": "telemetry.openstack.org", "controllerKind": "MetricStorage", "MetricStorage": {"name":"metric-storage","namespace":"openstack"}, "namespace": "openstack", "name": "metric-storage", "reconcileID": "a744e797-47d3-427c-b052-04bc630847f0"}
2024-10-10T08:54:37-04:00	DEBUG	events	Can't own MonitoringStack resource. The Cluster Observability Operator probably isn't installed	{"type": "Warning", "object": {"kind":"MetricStorage","namespace":"openstack","name":"metric-storage","uid":"ca0b7aa1-8885-40c0-8622-272cee8d57c8","apiVersion":"telemetry.openstack.org/v1beta1","resourceVersion":"8632360"}, "reason": "Failed own"}
2024-10-10T08:55:37-04:00	INFO	Controllers.MetricStorage	Reconciling Service 'metric-storage'	{"controller": "metricstorage", "controllerGroup": "telemetry.openstack.org", "controllerKind": "MetricStorage", "MetricStorage": {"name":"metric-storage","namespace":"openstack"}, "namespace": "openstack", "name": "metric-storage", "reconcileID": "0a439f22-5c4c-45b0-83c3-3cc7ec05dd63"}
2024-10-10T08:55:37-04:00	INFO	Controllers.MetricStorage	Can't own MonitoringStack resource. The Cluster Observability Operator probably isn't installed	{"controller": "metricstorage", "controllerGroup": "telemetry.openstack.org", "controllerKind": "MetricStorage", "MetricStorage": {"name":"metric-storage","namespace":"openstack"}, "namespace": "openstack", "name": "metric-storage", "reconcileID": "0a439f22-5c4c-45b0-83c3-3cc7ec05dd63"}
2024-10-10T08:55:37-04:00	DEBUG	events	Can't own MonitoringStack resource. The Cluster Observability Operator probably isn't installed	{"type": "Warning", "object": {"kind":"MetricStorage","namespace":"openstack","name":"metric-storage","uid":"ca0b7aa1-8885-40c0-8622-272cee8d57c8","apiVersion":"telemetry.openstack.org/v1beta1","resourceVersion":"8632360"}, "reason": "Failed own"}
```

CR statuses with the new code:
```
$ oc get metricstorage metric-storage -oyaml | yq {.status}
lastTransitionTime: "2024-10-10T11:58:49Z"
message: 'Error occured when trying to own: customresourcedefinitions.apiextensions.k8s.io "monitoringstacks.monitoring.rhobs" not found'
reason: Can't own MonitoringStack resource. The Cluster Observability Operator probably isn't installed
severity: Error
status: "False"
type: Ready
lastTransitionTime: "2024-10-10T11:55:53Z"
message: Dashboard Datasource not started
reason: Init
status: Unknown
type: DashboardDatasourceReady
lastTransitionTime: "2024-10-10T11:55:53Z"
message: Dashboard Definition not started
reason: Init
status: Unknown
type: DashboardDefinitionReady
lastTransitionTime: "2024-10-10T11:55:53Z"
message: Dashboard Plugin not started
reason: Init
status: Unknown
type: DashboardPluginReady
lastTransitionTime: "2024-10-10T11:55:53Z"
message: Dashboard PrometheusRule not started
reason: Init
status: Unknown
type: DashboardPrometheusRuleReady
lastTransitionTime: "2024-10-10T11:58:49Z"
message: 'Error occured when trying to own: customresourcedefinitions.apiextensions.k8s.io "monitoringstacks.monitoring.rhobs" not found'
reason: Can't own MonitoringStack resource. The Cluster Observability Operator probably isn't installed
severity: Error
status: "False"
type: MonitoringStackReady
lastTransitionTime: "2024-10-10T11:55:53Z"
message: Prometheus not ready
reason: Init
status: Unknown
type: PrometheusReady
lastTransitionTime: "2024-10-10T11:55:53Z"
message: ScrapeConfig not started
reason: Init
status: Unknown
type: ScrapeConfigReady
lastTransitionTime: "2024-10-10T11:55:53Z"
message: Input data not checked
reason: Init
status: Unknown
type: TLSInputReady



$ oc get telemetry telemetry -oyaml | yq {.status}
lastTransitionTime: "2024-10-10T11:58:49Z"
message: 'Error occured when trying to own: customresourcedefinitions.apiextensions.k8s.io "monitoringstacks.monitoring.rhobs" not found'
reason: Can't own MonitoringStack resource. The Cluster Observability Operator probably isn't installed
severity: Error
status: "False"
type: Ready
lastTransitionTime: "2024-10-10T11:58:57Z"
message: Setup complete
reason: Ready
status: "True"
type: AutoscalingReady
lastTransitionTime: "2024-10-10T09:54:32Z"
message: Setup complete
reason: Ready
status: "True"
type: CeilometerReady
lastTransitionTime: "2024-10-10T11:58:49Z"
message: 'Error occured when trying to own: customresourcedefinitions.apiextensions.k8s.io "monitoringstacks.monitoring.rhobs" not found'
reason: Can't own MonitoringStack resource. The Cluster Observability Operator probably isn't installed
severity: Error
status: "False"
type: MetricStorageReady
```