### PR TITLE
Report error if fetching IPs or hostname for edpm nodes failed

### DIFF
--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -841,11 +841,11 @@ func getMetricExporterTargets(
 				address, _ = getAddressFromAnsibleHost(&item)
 			} else {
 				// we were unable to find an IP or HostName for a node, so we do not go further
-				return addressesNonTLS, addressesTLS, nil
+				return addressesNonTLS, addressesTLS, fmt.Errorf("failed to find an IP or HostName for node %s", name)
 			}
 			if address == "" {
 				// we were unable to find an IP or HostName for a node, so we do not go further
-				return addressesNonTLS, addressesTLS, nil
+				return addressesNonTLS, addressesTLS, fmt.Errorf("failed to find an IP or HostName for node %s", name)
 			}
 			if TLSEnabled, ok := nodeSetGroup.Vars["edpm_tls_certs_enabled"].(bool); ok && TLSEnabled {
 				addressesTLS = append(addressesTLS, fmt.Sprintf("%s:%d", address, defaultMetricExporterPort))


### PR DESCRIPTION
In [1] we check whether `getMetricExporterTargets` reported error while gathering ip/hostname of edpm nodes but it never reported an error incase of failures. This change addresses such situation by returning an error.

[1] https://github.com/openstack-k8s-operators/telemetry-operator/blob/main/controllers/metricstorage_controller.go#L597-L600