### PR TITLE
Fixes for KSM

### DIFF
--- a/api/v1beta1/telemetry_webhook.go
+++ b/api/v1beta1/telemetry_webhook.go
@@ -35,6 +35,7 @@ type TelemetryDefaults struct {
 	SgCoreContainerImageURL        string
 	ProxyContainerImageURL         string
 	IpmiContainerImageURL          string
+	KsmContainerImageURL           string
 	AodhAPIContainerImageURL       string
 	AodhEvaluatorContainerImageURL string
 	AodhNotifierContainerImageURL  string
@@ -89,6 +90,9 @@ func (spec *TelemetrySpec) Default() {
 	}
 	if spec.Ceilometer.CeilometerSpec.ProxyImage == "" {
 		spec.Ceilometer.CeilometerSpec.ProxyImage = telemetryDefaults.ProxyContainerImageURL
+	}
+	if spec.Ceilometer.CeilometerSpec.KSMImage == "" {
+		spec.Ceilometer.CeilometerSpec.KSMImage = telemetryDefaults.KsmContainerImageURL
 	}
 	if spec.Autoscaling.AutoscalingSpec.Aodh.APIImage == "" {
 		spec.Autoscaling.AutoscalingSpec.Aodh.APIImage = telemetryDefaults.AodhAPIContainerImageURL

--- a/pkg/availability/statefulset.go
+++ b/pkg/availability/statefulset.go
@@ -19,7 +19,6 @@ package availability
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"k8s.io/utils/ptr"
 
@@ -74,7 +73,6 @@ func KSMStatefulSet(
 
 	labels["app.kubernetes.io/component"] = "exporter"
 	labels["app.kubernetes.io/name"] = KSMServiceName
-	labels["app.kubernetes.io/version"] = instance.Spec.KSMImage[strings.LastIndex(instance.Spec.KSMImage, ":")+1:]
 
 	// kube-state-metrics relevant default arguments
 	args := []string{


### PR DESCRIPTION
- add KSM image to telemetrydefaults webhook
- remove image version from labels, because in some cases it can exceed maximum lenght of value