### PR TITLE
Add status to CLI

### DIFF
--- a/api/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/api/bases/telemetry.openstack.org_autoscalings.yaml
@@ -15,7 +15,16 @@ spec:
     singular: autoscaling
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Autoscaling is the Schema for the autoscalings API

--- a/api/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometers.yaml
@@ -15,7 +15,16 @@ spec:
     singular: ceilometer
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Ceilometer is the Schema for the ceilometers API

--- a/api/bases/telemetry.openstack.org_loggings.yaml
+++ b/api/bases/telemetry.openstack.org_loggings.yaml
@@ -17,7 +17,16 @@ spec:
     singular: logging
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Logging is the Schema for the loggings API

--- a/api/bases/telemetry.openstack.org_metricstorages.yaml
+++ b/api/bases/telemetry.openstack.org_metricstorages.yaml
@@ -15,7 +15,16 @@ spec:
     singular: metricstorage
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: MetricStorage is the Schema for the metricstorages API

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -15,7 +15,16 @@ spec:
     singular: telemetry
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Telemetry is the Schema for the telemetry API

--- a/api/v1beta1/autoscaling_types.go
+++ b/api/v1beta1/autoscaling_types.go
@@ -19,8 +19,8 @@ package v1beta1
 import (
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
@@ -212,6 +212,8 @@ type AutoscalingStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status",description="Status"
+//+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
 
 // Autoscaling is the Schema for the autoscalings API
 type Autoscaling struct {

--- a/api/v1beta1/ceilometer_types.go
+++ b/api/v1beta1/ceilometer_types.go
@@ -158,6 +158,8 @@ type KSMStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status",description="Status"
+//+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
 
 // Ceilometer is the Schema for the ceilometers API
 type Ceilometer struct {

--- a/api/v1beta1/logging_types.go
+++ b/api/v1beta1/logging_types.go
@@ -78,6 +78,8 @@ type LoggingStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:categories=logging
+//+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status",description="Status"
+//+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
 
 // Logging is the Schema for the loggings API
 type Logging struct {

--- a/api/v1beta1/metricstorage_types.go
+++ b/api/v1beta1/metricstorage_types.go
@@ -120,8 +120,8 @@ type MetricStorageSpec struct {
 
 // MetricStorageStatus defines the observed state of MetricStorage
 type MetricStorageStatus struct {
-	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
-	PrometheusTLSPatched bool `json:"prometheusTLSPatched,omitempty" optional:"true"`
+	Conditions           condition.Conditions `json:"conditions,omitempty" optional:"true"`
+	PrometheusTLSPatched bool                 `json:"prometheusTLSPatched,omitempty" optional:"true"`
 	// ObservedGeneration - the most recent generation observed for this
 	// service. If the observed generation is less than the spec generation,
 	// then the controller has not processed the latest changes injected by
@@ -131,6 +131,8 @@ type MetricStorageStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status",description="Status"
+//+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
 
 // MetricStorage is the Schema for the metricstorages API
 type MetricStorage struct {

--- a/api/v1beta1/telemetry_types.go
+++ b/api/v1beta1/telemetry_types.go
@@ -174,6 +174,8 @@ type TelemetryStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status",description="Status"
+//+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
 
 // Telemetry is the Schema for the telemetry API
 type Telemetry struct {

--- a/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
@@ -15,7 +15,16 @@ spec:
     singular: autoscaling
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Autoscaling is the Schema for the autoscalings API

--- a/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
@@ -15,7 +15,16 @@ spec:
     singular: ceilometer
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Ceilometer is the Schema for the ceilometers API

--- a/config/crd/bases/telemetry.openstack.org_loggings.yaml
+++ b/config/crd/bases/telemetry.openstack.org_loggings.yaml
@@ -17,7 +17,16 @@ spec:
     singular: logging
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Logging is the Schema for the loggings API

--- a/config/crd/bases/telemetry.openstack.org_metricstorages.yaml
+++ b/config/crd/bases/telemetry.openstack.org_metricstorages.yaml
@@ -15,7 +15,16 @@ spec:
     singular: metricstorage
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: MetricStorage is the Schema for the metricstorages API

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -15,7 +15,16 @@ spec:
     singular: telemetry
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: Telemetry is the Schema for the telemetry API

--- a/config/manifests/bases/telemetry-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/telemetry-operator.clusterserviceversion.yaml
@@ -34,6 +34,9 @@ spec:
       kind: Ceilometer
       name: ceilometers.telemetry.openstack.org
       specDescriptors:
+      - description: KSMTLS - Parameters related to the TLS for kube-state-metrics
+        displayName: KSMTLS
+        path: ksmTls
       - description: TLS - Parameters related to the TLS
         displayName: TLS
         path: tls
@@ -72,6 +75,9 @@ spec:
         path: ceilometer.enabled
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: KSMTLS - Parameters related to the TLS for kube-state-metrics
+        displayName: KSMTLS
+        path: ceilometer.ksmTls
       - description: TLS - Parameters related to the TLS
         displayName: TLS
         path: ceilometer.tls


### PR DESCRIPTION
Qualify of life improvement to show resource status when using the CLI (i.e. `oc get telemetry`, etc)