### PR TITLE
[OSPRH-10956] Httpd timeout for ceilometer and aodh

### DIFF
--- a/api/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/api/bases/telemetry.openstack.org_autoscalings.yaml
@@ -62,6 +62,10 @@ spec:
                 properties:
                   apiImage:
                     type: string
+                  apiTimeout:
+                    description: APITimeout for Route and Apache
+                    minimum: 60
+                    type: integer
                   customServiceConfig:
                     default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config

--- a/api/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometers.yaml
@@ -108,6 +108,11 @@ spec:
           spec:
             description: CeilometerSpec defines the desired state of Ceilometer
             properties:
+              apiTimeout:
+                default: 60
+                description: APITimeout for Apache
+                minimum: 60
+                type: integer
               centralImage:
                 type: string
               computeImage:

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -65,6 +65,10 @@ spec:
                     properties:
                       apiImage:
                         type: string
+                      apiTimeout:
+                        description: APITimeout for Route and Apache
+                        minimum: 60
+                        type: integer
                       customServiceConfig:
                         default: '# add your customization here'
                         description: CustomServiceConfig - customize the service config

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -425,6 +425,11 @@ spec:
               ceilometer:
                 description: Ceilometer - Parameters related to the ceilometer service
                 properties:
+                  apiTimeout:
+                    default: 60
+                    description: APITimeout for Apache
+                    minimum: 60
+                    type: integer
                   centralImage:
                     type: string
                   computeImage:

--- a/api/v1beta1/autoscaling_types.go
+++ b/api/v1beta1/autoscaling_types.go
@@ -58,6 +58,12 @@ type Aodh struct {
 
 // Aodh defines the aodh component spec
 type AodhCore struct {
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum=60
+	// +kubebuilder:Default=60
+	// APITimeout for Route and Apache
+	APITimeout int `json:"apiTimeout,omitempty"`
+
 	// RabbitMQ instance name
 	// Needed to request a transportURL that is created and used in Aodh
 	// +kubebuilder:default=rabbitmq

--- a/api/v1beta1/ceilometer_types.go
+++ b/api/v1beta1/ceilometer_types.go
@@ -70,6 +70,12 @@ type CeilometerSpec struct {
 
 // CeilometerSpecCore defines the desired state of Ceilometer. This version is used by the OpenStackControlplane (no image parameters)
 type CeilometerSpecCore struct {
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=60
+	// +kubebuilder:validation:Minimum=60
+	// APITimeout for Apache
+	APITimeout int `json:"apiTimeout"`
+
 	// RabbitMQ instance name
 	// Needed to request a transportURL that is created and used in Telemetry
 	// +kubebuilder:default=rabbitmq

--- a/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
@@ -62,6 +62,10 @@ spec:
                 properties:
                   apiImage:
                     type: string
+                  apiTimeout:
+                    description: APITimeout for Route and Apache
+                    minimum: 60
+                    type: integer
                   customServiceConfig:
                     default: '# add your customization here'
                     description: CustomServiceConfig - customize the service config

--- a/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
@@ -108,6 +108,11 @@ spec:
           spec:
             description: CeilometerSpec defines the desired state of Ceilometer
             properties:
+              apiTimeout:
+                default: 60
+                description: APITimeout for Apache
+                minimum: 60
+                type: integer
               centralImage:
                 type: string
               computeImage:

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -65,6 +65,10 @@ spec:
                     properties:
                       apiImage:
                         type: string
+                      apiTimeout:
+                        description: APITimeout for Route and Apache
+                        minimum: 60
+                        type: integer
                       customServiceConfig:
                         default: '# add your customization here'
                         description: CustomServiceConfig - customize the service config

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -425,6 +425,11 @@ spec:
               ceilometer:
                 description: Ceilometer - Parameters related to the ceilometer service
                 properties:
+                  apiTimeout:
+                    default: 60
+                    description: APITimeout for Apache
+                    minimum: 60
+                    type: integer
                   centralImage:
                     type: string
                   computeImage:

--- a/controllers/autoscaling_controller.go
+++ b/controllers/autoscaling_controller.go
@@ -604,6 +604,7 @@ func (r *AutoscalingReconciler) generateServiceConfig(
 			string(databaseSecret.Data[mariadbv1.DatabasePasswordSelector]),
 			instance.Status.DatabaseHostname,
 			autoscaling.DatabaseName),
+		"Timeout": instance.Spec.Aodh.APITimeout,
 	}
 
 	prometheusParams := map[string]interface{}{

--- a/controllers/ceilometer_controller.go
+++ b/controllers/ceilometer_controller.go
@@ -839,6 +839,7 @@ func (r *CeilometerReconciler) generateServiceConfig(
 		"CeilometerPassword":  string(ceilometerPasswordSecret.Data["CeilometerPassword"]),
 		"TLS":                 false, // Default to false. Change to true later if TLS enabled
 		"SwiftRole":           false, //
+		"Timeout":             instance.Spec.APITimeout,
 	}
 
 	// create httpd  vhost template parameters

--- a/templates/autoscaling/config/wsgi-aodh.conf
+++ b/templates/autoscaling/config/wsgi-aodh.conf
@@ -34,5 +34,6 @@
   WSGIProcessGroup {{ $endpt }}
   WSGIScriptAlias / "/var/www/cgi-bin/aodh/aodh-api"
   WSGIPassAuthorization On
+  Timeout {{ $.Timeout }}
 </VirtualHost>
 {{ end }}

--- a/templates/ceilometercentral/config/httpd.conf
+++ b/templates/ceilometercentral/config/httpd.conf
@@ -53,4 +53,6 @@ CustomLog /dev/stdout proxy env=forwarded
   SSLCertificateFile      "{{ .vhost.SSLCertificateFile }}"
   SSLCertificateKeyFile   "{{ .vhost.SSLCertificateKeyFile }}"
 {{- end }}
+
+  Timeout {{ $.Timeout }}
 </VirtualHost>


### PR DESCRIPTION
This allows users to configure httpd timeouts for aodh and ceilometer as well as haproxy timeout in aodh route. An openstack-operator PR will follow once this merges.