### PR TITLE
[OSPRH-9848] enhance NodeExporter metrics

### DIFF
--- a/pkg/metricstorage/scrape_config.go
+++ b/pkg/metricstorage/scrape_config.go
@@ -27,11 +27,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type LabeledTarget struct {
+	IP       string
+	Hostname string
+}
+
 // ScrapeConfig creates a ScrapeConfig CR
 func ScrapeConfig(
 	instance *telemetryv1.MetricStorage,
 	labels map[string]string,
-	targets []string,
+	targets interface{},
 	tlsEnabled bool,
 ) *monv1alpha1.ScrapeConfig {
 	var scrapeInterval monv1.Duration
@@ -46,10 +51,28 @@ func ScrapeConfig(
 		scrapeInterval = telemetryv1.DefaultScrapeInterval
 	}
 
-	sort.Strings(targets)
-	var convertedTargets []monv1alpha1.Target
-	for _, t := range targets {
-		convertedTargets = append(convertedTargets, monv1alpha1.Target(t))
+	var staticConfigs []monv1alpha1.StaticConfig
+	if ips, ok := targets.([]string); ok {
+		sort.Strings(ips)
+		var convertedTargets []monv1alpha1.Target
+		for _, t := range ips {
+			convertedTargets = append(convertedTargets, monv1alpha1.Target(t))
+		}
+		staticConfigs = append(staticConfigs, monv1alpha1.StaticConfig{
+			Targets: convertedTargets,
+		})
+	} else if labeledTargets, ok := targets.([]LabeledTarget); ok {
+		sort.Slice(labeledTargets, func(i, j int) bool {
+			return labeledTargets[i].IP < labeledTargets[j].IP
+		})
+		for _, t := range labeledTargets {
+			staticConfigs = append(staticConfigs, monv1alpha1.StaticConfig{
+				Targets: []monv1alpha1.Target{monv1alpha1.Target(t.IP)},
+				Labels: map[monv1.LabelName]string{
+					"hostname": t.Hostname,
+				},
+			})
+		}
 	}
 
 	scrapeConfig := &monv1alpha1.ScrapeConfig{
@@ -82,11 +105,7 @@ func ScrapeConfig(
 				},
 			},
 			ScrapeInterval: &scrapeInterval,
-			StaticConfigs: []monv1alpha1.StaticConfig{
-				{
-					Targets: convertedTargets,
-				},
-			},
+			StaticConfigs:  staticConfigs,
 		},
 	}
 

--- a/tests/kuttl/suites/metricstorage/tests/01-assert.yaml
+++ b/tests/kuttl/suites/metricstorage/tests/01-assert.yaml
@@ -81,8 +81,19 @@ metadata:
   - kind: MetricStorage
     name: telemetry-kuttl
 spec:
-  staticConfigs:
-    - {}
+  scrapeInterval: 30s
+---
+apiVersion: monitoring.rhobs/v1alpha1
+kind: ScrapeConfig
+metadata:
+  labels:
+    service: metricStorage
+  name: telemetry-node-exporter-tls
+  ownerReferences:
+  - kind: MetricStorage
+    name: telemetry-kuttl
+spec:
+  scrapeInterval: 30s
 ---
 apiVersion: monitoring.rhobs/v1alpha1
 kind: ScrapeConfig

--- a/tests/kuttl/suites/metricstorage/tests/04-assert.yaml
+++ b/tests/kuttl/suites/metricstorage/tests/04-assert.yaml
@@ -93,8 +93,19 @@ metadata:
   - kind: MetricStorage
     name: telemetry-kuttl
 spec:
-  staticConfigs:
-    - {}
+  scrapeInterval: 40s
+---
+apiVersion: monitoring.rhobs/v1alpha1
+kind: ScrapeConfig
+metadata:
+  labels:
+    service: metricStorage
+  name: telemetry-node-exporter-tls
+  ownerReferences:
+  - kind: MetricStorage
+    name: telemetry-kuttl
+spec:
+  scrapeInterval: 40s
 ---
 apiVersion: monitoring.rhobs/v1alpha1
 kind: ScrapeConfig


### PR DESCRIPTION
This adds a "hostname" label to NodeExporter metrics
to make the identification of the node of origin a little easier
than just having the IP address.

As a side effect of needing a little different parsing for
NodeExporter and Kepler ScrapeConfigs, the code to get compute
node IPs from ansible facts and from IPsets is now executed
only once (in comparison to executing it twice), which greatly
reduces k8s api calls.