### PR TITLE
[OSPRH-10956] Fix aodh api timeout default

### DIFF
--- a/api/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/api/bases/telemetry.openstack.org_autoscalings.yaml
@@ -63,6 +63,7 @@ spec:
                   apiImage:
                     type: string
                   apiTimeout:
+                    default: 60
                     description: APITimeout for Route and Apache
                     minimum: 60
                     type: integer

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -66,6 +66,7 @@ spec:
                       apiImage:
                         type: string
                       apiTimeout:
+                        default: 60
                         description: APITimeout for Route and Apache
                         minimum: 60
                         type: integer

--- a/api/v1beta1/autoscaling_types.go
+++ b/api/v1beta1/autoscaling_types.go
@@ -60,9 +60,9 @@ type Aodh struct {
 type AodhCore struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=60
-	// +kubebuilder:Default=60
+	// +kubebuilder:default=60
 	// APITimeout for Route and Apache
-	APITimeout int `json:"apiTimeout,omitempty"`
+	APITimeout int `json:"apiTimeout"`
 
 	// RabbitMQ instance name
 	// Needed to request a transportURL that is created and used in Aodh

--- a/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
@@ -63,6 +63,7 @@ spec:
                   apiImage:
                     type: string
                   apiTimeout:
+                    default: 60
                     description: APITimeout for Route and Apache
                     minimum: 60
                     type: integer

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -66,6 +66,7 @@ spec:
                       apiImage:
                         type: string
                       apiTimeout:
+                        default: 60
                         description: APITimeout for Route and Apache
                         minimum: 60
                         type: integer


### PR DESCRIPTION
I noticed the default didn't appear on the rendered CRD