### PR TITLE
[OSPRH-10956] Remove minimum from APITimeout

### DIFF
--- a/api/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/api/bases/telemetry.openstack.org_autoscalings.yaml
@@ -65,7 +65,6 @@ spec:
                   apiTimeout:
                     default: 60
                     description: APITimeout for Route and Apache
-                    minimum: 60
                     type: integer
                   customServiceConfig:
                     default: '# add your customization here'

--- a/api/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometers.yaml
@@ -111,7 +111,6 @@ spec:
               apiTimeout:
                 default: 60
                 description: APITimeout for Apache
-                minimum: 60
                 type: integer
               centralImage:
                 type: string

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -68,7 +68,6 @@ spec:
                       apiTimeout:
                         default: 60
                         description: APITimeout for Route and Apache
-                        minimum: 60
                         type: integer
                       customServiceConfig:
                         default: '# add your customization here'
@@ -429,7 +428,6 @@ spec:
                   apiTimeout:
                     default: 60
                     description: APITimeout for Apache
-                    minimum: 60
                     type: integer
                   centralImage:
                     type: string

--- a/api/v1beta1/autoscaling_types.go
+++ b/api/v1beta1/autoscaling_types.go
@@ -59,7 +59,6 @@ type Aodh struct {
 // Aodh defines the aodh component spec
 type AodhCore struct {
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Minimum=60
 	// +kubebuilder:default=60
 	// APITimeout for Route and Apache
 	APITimeout int `json:"apiTimeout"`

--- a/api/v1beta1/ceilometer_types.go
+++ b/api/v1beta1/ceilometer_types.go
@@ -72,7 +72,6 @@ type CeilometerSpec struct {
 type CeilometerSpecCore struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=60
-	// +kubebuilder:validation:Minimum=60
 	// APITimeout for Apache
 	APITimeout int `json:"apiTimeout"`
 

--- a/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
@@ -65,7 +65,6 @@ spec:
                   apiTimeout:
                     default: 60
                     description: APITimeout for Route and Apache
-                    minimum: 60
                     type: integer
                   customServiceConfig:
                     default: '# add your customization here'

--- a/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
@@ -111,7 +111,6 @@ spec:
               apiTimeout:
                 default: 60
                 description: APITimeout for Apache
-                minimum: 60
                 type: integer
               centralImage:
                 type: string

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -68,7 +68,6 @@ spec:
                       apiTimeout:
                         default: 60
                         description: APITimeout for Route and Apache
-                        minimum: 60
                         type: integer
                       customServiceConfig:
                         default: '# add your customization here'
@@ -429,7 +428,6 @@ spec:
                   apiTimeout:
                     default: 60
                     description: APITimeout for Apache
-                    minimum: 60
                     type: integer
                   centralImage:
                     type: string


### PR DESCRIPTION
This causes issues in openstack-operator CI, so remove the validation.