### PR TITLE
[OSPRH-11692] node_exporter scrapeconfig must include full fqdn instead

### DIFF
--- a/pkg/metricstorage/scrape_config.go
+++ b/pkg/metricstorage/scrape_config.go
@@ -28,8 +28,8 @@ import (
 )
 
 type LabeledTarget struct {
-	IP       string
-	Hostname string
+	IP   string
+	FQDN string
 }
 
 // ScrapeConfig creates a ScrapeConfig CR
@@ -69,7 +69,7 @@ func ScrapeConfig(
 			staticConfigs = append(staticConfigs, monv1alpha1.StaticConfig{
 				Targets: []monv1alpha1.Target{monv1alpha1.Target(t.IP)},
 				Labels: map[monv1.LabelName]string{
-					"hostname": t.Hostname,
+					"fqdn": t.FQDN,
 				},
 			})
 		}


### PR DESCRIPTION
of hostname

This creates a ScrapeConfig.staticConfigs section like this

```
staticConfigs:
  - labels:
      fqdn: edpm-compute-0.ctlplane.example.com
    targets:
    - 192.168.122.100:9100
  - labels:
      fqdn: edpm-compute-1.ctlplane.example.com
    targets:
    - 192.168.122.101:9100
```