### PR TITLE
Return nil at the end of createScrapeConfigs

### DIFF
--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -647,7 +647,7 @@ func (r *MetricStorageReconciler) createScrapeConfigs(
 	}
 
 	instance.Status.Conditions.MarkTrue(telemetryv1.ScrapeConfigReadyCondition, condition.ReadyMessage)
-	return ctrl.Result{}, err
+	return ctrl.Result{}, nil
 }
 
 func getNodeExporterTargets(nodes []ConnectionInfo) ([]metricstorage.LabeledTarget, []metricstorage.LabeledTarget) {


### PR DESCRIPTION
Currently the function returns the latest value of the "err" variable. This isn't what should be happening. If we want to return an error, we should do so in one of the `if err != nil {}` blocks. When the function gets to the end, it should be considered as successfuly executed.