### PR TITLE
Use dns cluster info from lib common get function

### DIFF
--- a/pkg/metricstorage/dashboard_datasource.go
+++ b/pkg/metricstorage/dashboard_datasource.go
@@ -19,6 +19,7 @@ package metricstorage
 import (
 	"context"
 
+	"github.com/openstack-k8s-operators/lib-common/modules/common/clusterdns"
 	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -29,6 +30,7 @@ func DashboardDatasourceData(ctx context.Context, c client.Client, instance *tel
 
 	scheme := "http"
 	certText := ""
+	dnsDomain := clusterdns.GetDNSClusterDomain()
 	if instance.Spec.PrometheusTLS.Enabled() {
 		scheme = "https"
 		namespacedName := types.NamespacedName{
@@ -55,6 +57,6 @@ spec:
     plugin:
         kind: "PrometheusDatasource"
         spec:
-            direct_url: "` + scheme + `://metric-storage-prometheus.` + instance.Namespace + `.svc.cluster.local:9090"
+            direct_url: "` + scheme + `://metric-storage-prometheus.` + instance.Namespace + `.svc.` + dnsDomain + `:9090"
 `}, nil
 }


### PR DESCRIPTION
Openshift coreDNS creates the domain name using an string located in dnses.operator.openshift.io. This string can change in the future, calling lib-common/GetDNSClusterDomain the responsability of gathering this information correctly only falls under lib-common intead of all operators.

Resolves: [OSPRH-3627](https://issues.redhat.com//browse/OSPRH-3627)
Depends-on: openstack-k8s-operators/lib-common#580