### PR TITLE
[ci] deploy-logging-dependencies: Remove the workaround for cco

### DIFF
--- a/ci/deploy-logging-dependencies/tasks/deploy-operators.yml
+++ b/ci/deploy-logging-dependencies/tasks/deploy-operators.yml
@@ -1,11 +1,4 @@
-# WORKAROUND: Loki-operator is missing cluster credential operator in CRC
-# we can just apply the CRD to work around the issue. For proper fix
-# see: LOG-5431
-- name: WORKAROUND - Apply CCO CRD
-  ansible.builtin.shell:
-    cmd: |
-      oc apply -f {{ role_path }}/files/0000_03_cloud-credential-operator_01_crd.yaml
-
+---
 - name: Create the CLO subscription and loki-operator subscriptions
   ansible.builtin.shell:
     cmd: |


### PR DESCRIPTION
The file that is applied was removed in PR#559, but the task that tried to use it remained. This change removes the workaround.