### PR TITLE
[ci] Make the fvt tests voting

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -76,7 +76,7 @@
         - telemetry-operator-multinode-autoscaling-tempest
         - telemetry-operator-multinode-default-telemetry
         - functional-tests-on-osp18: &fvt_jobs_config
-            voting: false
+            voting: true
             required-projects:
               - name: infrawatch/feature-verification-tests
                 override-checkout: master


### PR DESCRIPTION
These jobs have been running for a while. When they fail, the zuul status doesn't show. Make them voting so that the statuses are seen, and failures can be explicitly ignored, if the job is broken.