### PR TITLE
Improve mysqld image defaulting

### DIFF
--- a/api/v1beta1/telemetry_types.go
+++ b/api/v1beta1/telemetry_types.go
@@ -212,12 +212,13 @@ func init() {
 func SetupDefaultsTelemetry() {
 	// Acquire environmental defaults and initialize Telemetry defaults with them
 	telemetryDefaults := TelemetryDefaults{
-		CentralContainerImageURL:      util.GetEnvVar("RELATED_IMAGE_CEILOMETER_CENTRAL_IMAGE_URL_DEFAULT", CeilometerCentralContainerImage),
-		ComputeContainerImageURL:      util.GetEnvVar("RELATED_IMAGE_CEILOMETER_COMPUTE_IMAGE_URL_DEFAULT", CeilometerComputeContainerImage),
-		IpmiContainerImageURL:         util.GetEnvVar("RELATED_IMAGE_CEILOMETER_IPMI_IMAGE_URL_DEFAULT", CeilometerIpmiContainerImage),
-		NotificationContainerImageURL: util.GetEnvVar("RELATED_IMAGE_CEILOMETER_NOTIFICATION_IMAGE_URL_DEFAULT", CeilometerNotificationContainerImage),
-		SgCoreContainerImageURL:       util.GetEnvVar("RELATED_IMAGE_CEILOMETER_SGCORE_IMAGE_URL_DEFAULT", CeilometerSgCoreContainerImage),
-		ProxyContainerImageURL:        util.GetEnvVar("RELATED_IMAGE_APACHE_IMAGE_URL_DEFAULT", CeilometerProxyContainerImage),
+		CentralContainerImageURL:        util.GetEnvVar("RELATED_IMAGE_CEILOMETER_CENTRAL_IMAGE_URL_DEFAULT", CeilometerCentralContainerImage),
+		ComputeContainerImageURL:        util.GetEnvVar("RELATED_IMAGE_CEILOMETER_COMPUTE_IMAGE_URL_DEFAULT", CeilometerComputeContainerImage),
+		IpmiContainerImageURL:           util.GetEnvVar("RELATED_IMAGE_CEILOMETER_IPMI_IMAGE_URL_DEFAULT", CeilometerIpmiContainerImage),
+		NotificationContainerImageURL:   util.GetEnvVar("RELATED_IMAGE_CEILOMETER_NOTIFICATION_IMAGE_URL_DEFAULT", CeilometerNotificationContainerImage),
+		SgCoreContainerImageURL:         util.GetEnvVar("RELATED_IMAGE_CEILOMETER_SGCORE_IMAGE_URL_DEFAULT", CeilometerSgCoreContainerImage),
+		ProxyContainerImageURL:          util.GetEnvVar("RELATED_IMAGE_APACHE_IMAGE_URL_DEFAULT", CeilometerProxyContainerImage),
+		MysqldExporterContainerImageURL: util.GetEnvVar("RELATED_IMAGE_CEILOMETER_MYSQLD_EXPORTER_IMAGE_URL_DEFAULT", MysqldExporterContainerImage),
 
 		// Autoscaling
 		AodhAPIContainerImageURL:       util.GetEnvVar("RELATED_IMAGE_AODH_API_IMAGE_URL_DEFAULT", AodhAPIContainerImage),

--- a/api/v1beta1/telemetry_webhook.go
+++ b/api/v1beta1/telemetry_webhook.go
@@ -29,17 +29,18 @@ import (
 
 // TelemetryDefaults -
 type TelemetryDefaults struct {
-	CentralContainerImageURL       string
-	ComputeContainerImageURL       string
-	NotificationContainerImageURL  string
-	SgCoreContainerImageURL        string
-	ProxyContainerImageURL         string
-	IpmiContainerImageURL          string
-	KsmContainerImageURL           string
-	AodhAPIContainerImageURL       string
-	AodhEvaluatorContainerImageURL string
-	AodhNotifierContainerImageURL  string
-	AodhListenerContainerImageURL  string
+	CentralContainerImageURL        string
+	ComputeContainerImageURL        string
+	NotificationContainerImageURL   string
+	SgCoreContainerImageURL         string
+	ProxyContainerImageURL          string
+	IpmiContainerImageURL           string
+	KsmContainerImageURL            string
+	MysqldExporterContainerImageURL string
+	AodhAPIContainerImageURL        string
+	AodhEvaluatorContainerImageURL  string
+	AodhNotifierContainerImageURL   string
+	AodhListenerContainerImageURL   string
 }
 
 var telemetryDefaults TelemetryDefaults
@@ -93,6 +94,9 @@ func (spec *TelemetrySpec) Default() {
 	}
 	if spec.Ceilometer.CeilometerSpec.KSMImage == "" {
 		spec.Ceilometer.CeilometerSpec.KSMImage = telemetryDefaults.KsmContainerImageURL
+	}
+	if spec.Ceilometer.CeilometerSpec.MysqldExporterImage == "" {
+		spec.Ceilometer.CeilometerSpec.MysqldExporterImage = telemetryDefaults.MysqldExporterContainerImageURL
 	}
 	if spec.Autoscaling.AutoscalingSpec.Aodh.APIImage == "" {
 		spec.Autoscaling.AutoscalingSpec.Aodh.APIImage = telemetryDefaults.AodhAPIContainerImageURL


### PR DESCRIPTION
This adds mysqld exporter image to the telemetry webhook (before this it was part only of the ceilometer webhook)