### PR TITLE
[OSPRH-12359] Fix getting IPSets

### DIFF
--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"reflect"
 	"regexp"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -888,13 +889,9 @@ func getComputeNodesConnectionInfo(
 			continue
 		}
 		for name, item := range nodeSetGroup.Hosts {
-			namespacedName := &types.NamespacedName{
-				Name:      name,
-				Namespace: instance.GetNamespace(),
-			}
 			if len(ipSetList.Items) > 0 {
 				// if we have IPSets, lets go to search for the IPs there
-				address, _ = getAddressFromIPSet(instance, &item, namespacedName, helper)
+				address, _ = getAddressFromIPSet(instance, &item, helper)
 			} else if _, ok := item.Vars["ansible_host"]; ok {
 				address, _ = getAddressFromAnsibleHost(&item)
 			} else {
@@ -954,21 +951,44 @@ func getInventorySecretList(instance *telemetryv1.MetricStorage, helper *helper.
 func getAddressFromIPSet(
 	instance *telemetryv1.MetricStorage,
 	item *ansible.Host,
-	namespacedName *types.NamespacedName,
 	helper *helper.Helper,
 ) (string, discoveryv1.AddressType) {
 	ansibleHost := item.Vars["ansible_host"].(string)
+	canonicalHostname, _ := getCanonicalHostname(item)
+	ctlplaneDNSDomain := ""
+
+	domains, ok := item.Vars["dns_search_domains"].([]interface{})
+	if ok {
+		for _, domain := range domains {
+			domainString, ok := domain.(string)
+			if ok && domainString[0:8] == "ctlplane" {
+				ctlplaneDNSDomain = domainString
+			}
+		}
+	}
 	// we go search for an IPSet
+	namespacedName := &types.NamespacedName{
+		Name:      canonicalHostname,
+		Namespace: instance.GetNamespace(),
+	}
 	ipset := &infranetworkv1.IPSet{}
 	err := helper.GetClient().Get(context.Background(), *namespacedName, ipset)
 	if err != nil {
-		// No IPsets found, lets try to get the HostName as last resource
-		if isValidDomain(ansibleHost) {
-			return ansibleHost, discoveryv1.AddressTypeFQDN
+		// No IPsets found, lets try the shorter version of the IPSet name
+		namespacedName := &types.NamespacedName{
+			Name:      strings.TrimSuffix(canonicalHostname, "."+ctlplaneDNSDomain),
+			Namespace: instance.GetNamespace(),
 		}
-		// No IP address or valid hostname found anywhere
-		helper.GetLogger().Info("Did not found a valid hostname or IP address")
-		return "", ""
+		err = helper.GetClient().Get(context.Background(), *namespacedName, ipset)
+		if err != nil {
+			// No IPsets found, lets try to get the HostName as last resource
+			if isValidDomain(ansibleHost) {
+				return ansibleHost, discoveryv1.AddressTypeFQDN
+			}
+			// No IP address or valid hostname found anywhere
+			helper.GetLogger().Info("Did not found a valid hostname or IP address")
+			return "", ""
+		}
 	}
 	// check that the reservations list is not empty
 	if len(ipset.Status.Reservation) > 0 {
@@ -1000,9 +1020,9 @@ func getAddressFromAnsibleHost(item *ansible.Host) (string, discoveryv1.AddressT
 }
 
 func getCanonicalHostname(item *ansible.Host) (string, discoveryv1.AddressType) {
-	canonicalHostname := item.Vars["canonical_hostname"].(string)
+	canonicalHostname, ok := item.Vars["canonical_hostname"].(string)
 	// is it a valid hostname?
-	if isValidDomain(canonicalHostname) {
+	if ok && isValidDomain(canonicalHostname) {
 		// it is an valid domain name
 		return canonicalHostname, discoveryv1.AddressTypeFQDN
 	}


### PR DESCRIPTION
Turns out IPSets use the node's hostname as defined in the nodeset CR, not the node's name. These 2 might be the same, but they might differ and in case they differ, the controller doesn't find them and it uses the ansible inventory secret to get the IPs instead.

Unfortunatelly the hostname from the nodeset isn't always copied into the ansible inventory secret. It either gets copied into the canonical_hostname variable as is or a DNS domain is appended to it, so I introduced a bit of code to pick the correct parts of the canonical_hostname.

This worked for both cases described above when I tested it, there is also still the fallback to using the ansibleHost from the inventory secret.