### PR TITLE
Fix test vars to fix downstream tests

### DIFF
--- a/ci/vars-autoscaling-tempest.yml
+++ b/ci/vars-autoscaling-tempest.yml
@@ -6,7 +6,7 @@ cifmw_test_operator_tempest_container: openstack-tempest-all
 cifmw_test_operator_tempest_image_tag: 'current-podified'
 # This value is used to populate the `tempestconfRun` parameter of the Tempest CR: https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource
 # https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/test_operator/defaults/main.yml
-cifmw_test_operator_tempest_tempestconf_config:
+tempest_conf:
   overrides: |
       validation.run_validation true
       identity.v3_endpoint_type public
@@ -18,6 +18,8 @@ cifmw_test_operator_tempest_tempestconf_config:
       telemetry.ceilometer_polling_interval 120
       telemetry.prometheus_scrape_interval 30
       telemetry.alarm_threshold 50000000000
+cifmw_tempest_tempestconf_config: "{{ tempest_conf }}"
+cifmw_test_operator_tempest_tempestconf_config: "{{ tempest_conf }}"
 cifmw_test_operator_tempest_include_list: |
   telemetry_tempest_plugin.scenario
   telemetry_tempest_plugin.aodh


### PR DESCRIPTION
Fixes changes from openstack-k8s-operators/telemetry-operator#548

This makes our downstream tests fail. We need to wait for the ciframework change to get downstream first. Let's get back to this in like a month and try again.