### PR TITLE
[OSPRH-12079] Verify mysqld_exporter image is set

### DIFF
--- a/controllers/ceilometer_controller.go
+++ b/controllers/ceilometer_controller.go
@@ -764,6 +764,15 @@ func (r *CeilometerReconciler) reconcileMysqldExporter(
 		return r.reconcileDeleteMysqldExporter(ctx, instance, helper)
 	}
 
+	if instance.Spec.MysqldExporterImage == "" {
+		instance.CeilometerStatus.Conditions.Set(condition.FalseCondition(
+			telemetryv1.MysqldExporterDeploymentReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityError,
+			"mysqld_exporter container image isn't set"))
+		return ctrl.Result{}, nil
+	}
+
 	configMapVars := make(map[string]env.Setter)
 	//
 	// TLS input validation


### PR DESCRIPTION
This checks that the mysqld_exporter image is set. The mysqld_exporter reconciliation ends with an error if it isn't set.