### PR TITLE
Add missing Aodh memcachedInstance defaulting

### DIFF
--- a/api/v1beta1/telemetry_webhook.go
+++ b/api/v1beta1/telemetry_webhook.go
@@ -110,6 +110,9 @@ func (spec *TelemetrySpec) Default() {
 	if spec.Autoscaling.AutoscalingSpec.Aodh.ListenerImage == "" {
 		spec.Autoscaling.AutoscalingSpec.Aodh.ListenerImage = telemetryDefaults.AodhListenerContainerImageURL
 	}
+	if spec.Autoscaling.AutoscalingSpec.Aodh.MemcachedInstance == "" {
+		spec.Autoscaling.AutoscalingSpec.Aodh.MemcachedInstance = "memcached"
+	}
 }
 
 // Default - set defaults for this Telemetry spec core


### PR DESCRIPTION
The defaulting webhook for the umbrella `Telemetry` resource is missing logic that is contained in the `Autoscaling` defaulting webhook.  While the `Telemetry` default webhook properly defaults the images, it does not handle `aodh.spec.memcachedInstance` like the `Autoscaling` webhook does [1].  This adds the missing logic, but perhaps it would be better to de-duplicate this code and have a common func that both webhooks call.  Anyhow, this fix is needed to unblock a major overhaul of OpenStack operator install for FR2 [2].

[1] https://github.com/openstack-k8s-operators/telemetry-operator/blob/c1e8bc2a1a2e4b4351ac33190388f2ba0c0db656/api/v1beta1/autoscaling_webhook.go#L79-L81
[2] https://github.com/openstack-k8s-operators/openstack-operator/pull/1185