### PR TITLE
Move memcached defaulting into *Core* Default()

### DIFF
--- a/api/v1beta1/autoscaling_webhook.go
+++ b/api/v1beta1/autoscaling_webhook.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -60,6 +61,7 @@ func (r *Autoscaling) Default() {
 	autoscalinglog.Info("default", "name", r.Name)
 
 	r.Spec.Default()
+	r.Spec.Aodh.AodhCore.Default()
 }
 
 // Default - set defaults for this Autoscaling spec
@@ -76,8 +78,13 @@ func (spec *AutoscalingSpec) Default() {
 	if spec.Aodh.ListenerImage == "" {
 		spec.Aodh.ListenerImage = autoscalingDefaults.AodhListenerContainerImageURL
 	}
-	if spec.Aodh.MemcachedInstance == "" {
-		spec.Aodh.MemcachedInstance = "memcached"
+}
+
+// Default - note only *Core* versions like this will have validations that are called from the
+// Controlplane webhook
+func (spec *AodhCore) Default() {
+	if spec.MemcachedInstance == "" {
+		spec.MemcachedInstance = "memcached"
 	}
 }
 

--- a/api/v1beta1/telemetry_webhook.go
+++ b/api/v1beta1/telemetry_webhook.go
@@ -110,14 +110,12 @@ func (spec *TelemetrySpec) Default() {
 	if spec.Autoscaling.AutoscalingSpec.Aodh.ListenerImage == "" {
 		spec.Autoscaling.AutoscalingSpec.Aodh.ListenerImage = telemetryDefaults.AodhListenerContainerImageURL
 	}
-	if spec.Autoscaling.AutoscalingSpec.Aodh.MemcachedInstance == "" {
-		spec.Autoscaling.AutoscalingSpec.Aodh.MemcachedInstance = "memcached"
-	}
 }
 
 // Default - set defaults for this Telemetry spec core
+// NOTE: only this version gets called by the Controlplane Webhook
 func (spec *TelemetrySpecCore) Default() {
-	// nothing here yet
+	spec.Autoscaling.Aodh.Default()
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.


### PR DESCRIPTION
Only the *Core* validation functions get used via
the OpenStackControlplane webhooks.