### PR TITLE
Refactor Ceilometer services' status objects

### DIFF
--- a/api/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometers.yaml
@@ -44,7 +44,9 @@ spec:
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           ksmStatus:
-            description: KSMStatus defines the observed state of kube-state-metrics
+            description: |-
+              NOTE(mmagr): remove with API version increment
+              Deprecated
             properties:
               conditions:
                 description: Conditions
@@ -136,6 +138,10 @@ spec:
                 type: object
               ipmiImage:
                 type: string
+              ksmEnabled:
+                default: true
+                description: Whether kube-state-metrics should be deployed
+                type: boolean
               ksmImage:
                 type: string
               ksmTls:
@@ -295,6 +301,15 @@ spec:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
+              ksmHash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              ksmReadyCount:
+                description: ReadyCount of kube-state-metrics instances
+                format: int32
+                type: integer
               mysqldExporterExportedGaleras:
                 description: List of galera CRs, which are being exported with mysqld_exporter
                 items:

--- a/api/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometers.yaml
@@ -44,9 +44,8 @@ spec:
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           ksmStatus:
-            description: |-
-              NOTE(mmagr): remove with API version increment
-              Deprecated
+            description: KSMStatus defines the observed state of kube-state-metrics
+              [DEPRECATED, Status is used instead]
             properties:
               conditions:
                 description: Conditions

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -433,6 +433,10 @@ spec:
                     type: boolean
                   ipmiImage:
                     type: string
+                  ksmEnabled:
+                    default: true
+                    description: Whether kube-state-metrics should be deployed
+                    type: boolean
                   ksmImage:
                     type: string
                   ksmTls:

--- a/api/v1beta1/ceilometer_types.go
+++ b/api/v1beta1/ceilometer_types.go
@@ -190,8 +190,9 @@ type CeilometerStatus struct {
 	KSMHash map[string]string `json:"ksmHash,omitempty"`
 }
 
-// NOTE(mmagr): remove with API version increment
-// Deprecated
+// NOTE(mmagr): remove KSMStatus with API version increment
+
+// KSMStatus defines the observed state of kube-state-metrics [DEPRECATED, Status is used instead]
 type KSMStatus struct {
 	// ReadyCount of ksm instances
 	ReadyCount int32 `json:"readyCount,omitempty"`

--- a/api/v1beta1/ceilometer_types.go
+++ b/api/v1beta1/ceilometer_types.go
@@ -219,9 +219,9 @@ type Ceilometer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec             CeilometerSpec   `json:"spec,omitempty"`
-	CeilometerStatus CeilometerStatus `json:"status,omitempty"`
-	KSMStatus        KSMStatus        `json:"ksmStatus,omitempty"`
+	Spec      CeilometerSpec   `json:"spec,omitempty"`
+	Status    CeilometerStatus `json:"status,omitempty"`
+	KSMStatus KSMStatus        `json:"ksmStatus,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -235,7 +235,7 @@ type CeilometerList struct {
 
 // IsReady - returns true if Ceilometer is reconciled successfully
 func (instance Ceilometer) IsReady() bool {
-	return instance.CeilometerStatus.Conditions.IsTrue(condition.ReadyCondition)
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 func init() {
@@ -244,7 +244,7 @@ func init() {
 
 // RbacConditionsSet - set the conditions for the rbac object
 func (instance Ceilometer) RbacConditionsSet(c *condition.Condition) {
-	instance.CeilometerStatus.Conditions.Set(c)
+	instance.Status.Conditions.Set(c)
 }
 
 // RbacNamespace - return the namespace

--- a/api/v1beta1/ceilometer_types.go
+++ b/api/v1beta1/ceilometer_types.go
@@ -113,6 +113,11 @@ type CeilometerSpecCore struct {
 	// NetworkAttachmentDefinitions list of network attachment definitions the service pod gets attached to
 	NetworkAttachmentDefinitions []string `json:"networkAttachmentDefinitions,omitempty"`
 
+	// Whether kube-state-metrics should be deployed
+	// +kubebuilder:validation:optional
+	// +kubebuilder:default=true
+	KSMEnabled *bool `json:"ksmEnabled,omitempty"`
+
 	// Whether mysqld_exporter should be deployed
 	// +kubebuilder:validation:optional
 	MysqldExporterEnabled *bool `json:"mysqldExporterEnabled,omitempty"`
@@ -177,9 +182,16 @@ type CeilometerStatus struct {
 	// List of galera CRs, which are being exported with mysqld_exporter
 	// +listType=atomic
 	MysqldExporterExportedGaleras []string `json:"mysqldExporterExportedGaleras,omitempty"`
+
+	// ReadyCount of kube-state-metrics instances
+	KSMReadyCount int32 `json:"ksmReadyCount,omitempty"`
+
+	// Map of hashes to track e.g. job status
+	KSMHash map[string]string `json:"ksmHash,omitempty"`
 }
 
-// KSMStatus defines the observed state of kube-state-metrics
+// NOTE(mmagr): remove with API version increment
+// Deprecated
 type KSMStatus struct {
 	// ReadyCount of ksm instances
 	ReadyCount int32 `json:"readyCount,omitempty"`
@@ -223,8 +235,7 @@ type CeilometerList struct {
 
 // IsReady - returns true if Ceilometer is reconciled successfully
 func (instance Ceilometer) IsReady() bool {
-	return instance.CeilometerStatus.Conditions.IsTrue(condition.ReadyCondition) &&
-		instance.KSMStatus.Conditions.IsTrue(condition.ReadyCondition)
+	return instance.CeilometerStatus.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 func init() {

--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -56,8 +56,17 @@ const (
 
 	DashboardDefinitionReadyCondition condition.Type = "DashboardDefinitionReady"
 
-	// KSMReadyCondition Status=True condition which indicates if the KSM is configured and operational
-	KSMReadyCondition condition.Type = "KSMReady"
+	// KSMTLSInputReadyCondition Status=True condition when required TLS sources are ready for KSM
+	KSMTLSInputReadyCondition condition.Type = "KSMTLSInputReady"
+
+	// KSMDeploymentReadyCondition Status=True condition when KSM statefulset created ok
+	KSMDeploymentReadyCondition condition.Type = "KSMDeploymentReady"
+
+	// KSMServiceConfigReadyCondition Status=True Condition which indicates that all service config got rendered ok
+	KSMServiceConfigReadyCondition condition.Type = "KSMServiceConfigReady"
+
+	// KSMCreateServiceReadyCondition Status=True condition when k8s service for the KSM created ok
+	KSMCreateServiceReadyCondition condition.Type = "KSMCreateServiceReady"
 
 	// MysqldExporter conditions
 	MysqldExporterDBReadyCondition condition.Type = "MysqldExporterDBReady"
@@ -207,17 +216,8 @@ const (
 	//
 	// KSMReady condition messages
 	//
-	// KSMReadyInitMessage
-	KSMReadyInitMessage = "KSM not started"
-
-	// KSMReadyMessage
-	KSMReadyMessage = "KSM completed"
-
-	// KSMReadyErrorMessage
-	KSMReadyErrorMessage = "KSM error occured %s"
-
-	// KSMReadyRunningMessage
-	KSMReadyRunningMessage = "KSM in progress"
+	// KSMDisabledMessage
+	KSMDisabledMessage = "kube-state-metrics is disabled"
 
 	//
 	// mysqld_exporter condition messages

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -325,7 +325,7 @@ func (in *Ceilometer) DeepCopyInto(out *Ceilometer) {
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	in.Spec.DeepCopyInto(&out.Spec)
-	in.CeilometerStatus.DeepCopyInto(&out.CeilometerStatus)
+	in.Status.DeepCopyInto(&out.Status)
 	in.KSMStatus.DeepCopyInto(&out.KSMStatus)
 }
 

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -468,6 +468,11 @@ func (in *CeilometerSpecCore) DeepCopyInto(out *CeilometerSpecCore) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.KSMEnabled != nil {
+		in, out := &in.KSMEnabled, &out.KSMEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	if in.MysqldExporterEnabled != nil {
 		in, out := &in.MysqldExporterEnabled, &out.MysqldExporterEnabled
 		*out = new(bool)
@@ -532,6 +537,13 @@ func (in *CeilometerStatus) DeepCopyInto(out *CeilometerStatus) {
 		in, out := &in.MysqldExporterExportedGaleras, &out.MysqldExporterExportedGaleras
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.KSMHash != nil {
+		in, out := &in.KSMHash, &out.KSMHash
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 }
 

--- a/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
@@ -44,7 +44,9 @@ spec:
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           ksmStatus:
-            description: KSMStatus defines the observed state of kube-state-metrics
+            description: |-
+              NOTE(mmagr): remove with API version increment
+              Deprecated
             properties:
               conditions:
                 description: Conditions
@@ -136,6 +138,10 @@ spec:
                 type: object
               ipmiImage:
                 type: string
+              ksmEnabled:
+                default: true
+                description: Whether kube-state-metrics should be deployed
+                type: boolean
               ksmImage:
                 type: string
               ksmTls:
@@ -295,6 +301,15 @@ spec:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
+              ksmHash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              ksmReadyCount:
+                description: ReadyCount of kube-state-metrics instances
+                format: int32
+                type: integer
               mysqldExporterExportedGaleras:
                 description: List of galera CRs, which are being exported with mysqld_exporter
                 items:

--- a/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
@@ -44,9 +44,8 @@ spec:
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           ksmStatus:
-            description: |-
-              NOTE(mmagr): remove with API version increment
-              Deprecated
+            description: KSMStatus defines the observed state of kube-state-metrics
+              [DEPRECATED, Status is used instead]
             properties:
               conditions:
                 description: Conditions

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -433,6 +433,10 @@ spec:
                     type: boolean
                   ipmiImage:
                     type: string
+                  ksmEnabled:
+                    default: true
+                    description: Whether kube-state-metrics should be deployed
+                    type: boolean
                   ksmImage:
                     type: string
                   ksmTls:

--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -693,8 +693,8 @@ func (r *MetricStorageReconciler) createScrapeConfigs(
 
 	mysqldExporterCfgName := fmt.Sprintf("%s-mysqld-exporter", telemetry.ServiceName)
 
-	if !k8s_errors.IsNotFound(err) && len(ceilometerInstance.CeilometerStatus.MysqldExporterExportedGaleras) > 0 {
-		exportedGaleras := ceilometerInstance.CeilometerStatus.MysqldExporterExportedGaleras
+	if !k8s_errors.IsNotFound(err) && len(ceilometerInstance.Status.MysqldExporterExportedGaleras) > 0 {
+		exportedGaleras := ceilometerInstance.Status.MysqldExporterExportedGaleras
 		mysqldExporterTargets := []string{}
 		for _, galera := range exportedGaleras {
 			// NOTE: the galera port is hardcoded in the mariadb-operator without

--- a/controllers/telemetry_controller.go
+++ b/controllers/telemetry_controller.go
@@ -297,7 +297,7 @@ func (r TelemetryReconciler) reconcileCeilometer(ctx context.Context, instance *
 	} else {
 
 		// Mirror Ceilometer's condition status
-		c := ceilometerInstance.CeilometerStatus.Conditions.Mirror(telemetryv1.CeilometerReadyCondition)
+		c := ceilometerInstance.Status.Conditions.Mirror(telemetryv1.CeilometerReadyCondition)
 		if c != nil {
 			instance.Status.Conditions.Set(c)
 		}
@@ -565,7 +565,7 @@ func (r *TelemetryReconciler) checkCeilometerGeneration(
 		return false, err
 	}
 	for _, item := range clm.Items {
-		if item.Generation != item.CeilometerStatus.ObservedGeneration {
+		if item.Generation != item.Status.ObservedGeneration {
 			return false, nil
 		}
 	}

--- a/hack/crd-schema-checker.sh
+++ b/hack/crd-schema-checker.sh
@@ -16,6 +16,8 @@ for crd in config/crd/bases/*.yaml; do
     mkdir -p "$(dirname "$TMP_DIR/$crd")"
     if git show "$BASE_REF:$crd" > "$TMP_DIR/$crd"; then
         $CHECKER check-manifests \
+            --disabled-validators="NoMaps" \
+            --disabled-validators="NoBools" \
             --existing-crd-filename="$TMP_DIR/$crd" \
             --new-crd-filename="$crd"
     fi


### PR DESCRIPTION
This patch joins status objects and uses prefixed contitions instead and splits hash object for each service.

This change is required as it fixes malfunctioning KSMStatus and adds missing hashing of KSM configuration.`
