### PR TITLE
Autoscaling should use the prometheus secret

### DIFF
--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -534,8 +534,8 @@ func (r *MetricStorageReconciler) prometheusEndpointSecret(
 	}
 
 	secret.Data = map[string][]byte{
-		"host": []byte(fmt.Sprintf("%s-prometheus.%s.svc", telemetryv1.DefaultServiceName, instance.Namespace)),
-		"port": []byte(strconv.Itoa(telemetryv1.DefaultPrometheusPort)),
+		metricstorage.PrometheusHost: []byte(fmt.Sprintf("%s-prometheus.%s.svc", telemetryv1.DefaultServiceName, instance.Namespace)),
+		metricstorage.PrometheusPort: []byte(strconv.Itoa(telemetryv1.DefaultPrometheusPort)),
 	}
 
 	if _, err := controllerutil.CreateOrUpdate(context.TODO(), helper.GetClient(), secret, func() error {
@@ -554,8 +554,8 @@ func (r *MetricStorageReconciler) prometheusEndpointSecret(
 	if instance.Spec.PrometheusTLS.Enabled() {
 		tlsSecret := &corev1.Secret{
 			Data: map[string][]byte{
-				"ca_secret": []byte(*instance.Spec.PrometheusTLS.SecretName),
-				"ca_key":    []byte(tls.CAKey),
+				metricstorage.PrometheusCaCertSecret: []byte(*instance.Spec.PrometheusTLS.SecretName),
+				metricstorage.PrometheusCaCertKey:    []byte(tls.CAKey),
 			},
 		}
 
@@ -565,7 +565,7 @@ func (r *MetricStorageReconciler) prometheusEndpointSecret(
 		}
 
 		if err := r.Client.Patch(ctx, secret, client.RawPatch(types.StrategicMergePatchType, patch)); err != nil {
-			panic(err)
+			return err
 		}
 	}
 

--- a/pkg/autoscaling/const.go
+++ b/pkg/autoscaling/const.go
@@ -41,6 +41,8 @@ const (
 
 	// CustomPrometheusCaCertFolderPath -
 	CustomPrometheusCaCertFolderPath = "/etc/pki/ca-trust/extracted/pem/"
+
+	PrometheusEndpointSecret = "metric-storage-prometheus-endpoint"
 )
 
 // PrometheusReplicas -

--- a/pkg/metricstorage/const.go
+++ b/pkg/metricstorage/const.go
@@ -17,4 +17,9 @@ package metricstorage
 
 const (
 	RabbitMQPrometheusPort = 15691
+
+	PrometheusHost         = "host"
+	PrometheusPort         = "port"
+	PrometheusCaCertSecret = "ca_secret"
+	PrometheusCaCertKey    = "ca_key"
 )


### PR DESCRIPTION
In this PR, the PrometheusHost and PrometheusPort are read from the secret. However, aodh still continues to keep using the combined-ca-bundle instead of the ca_cert and ca_key combination, as that bundle is already mounted in the pod, so it would make little sense to mount the same certificate twice on the same pod.

The ca_cert/ca_key combination is provided for just in case other services (like Watcher) do not want to rely on the combined-ca-bundle to making it easier the integration with external prometheus.

I also included a couple of cleanups/small fixes.