### PR TITLE
Consume Topology CR by reference

### DIFF
--- a/api/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/api/bases/telemetry.openstack.org_autoscalings.yaml
@@ -345,6 +345,24 @@ spec:
                           a pre-created bundle file
                         type: string
                     type: object
+                  topologyRef:
+                    description: |-
+                      TopologyRef to apply the Topology defined by the associated CR referenced
+                      by name
+                    properties:
+                      name:
+                        description: Name - The Topology CR name that the Service
+                          references
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace - The Namespace to fetch the Topology CR referenced
+                          NOTE: Namespace currently points by default to the same namespace where
+                          the Service is deployed. Customizing the namespace is not supported and
+                          webhooks prevent editing this field to a value different from the
+                          current project
+                        type: string
+                    type: object
                 required:
                 - apiImage
                 - databaseInstance
@@ -449,6 +467,9 @@ spec:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
+              lastAppliedTopology:
+                description: LastAppliedTopology - the last applied Topology
+                type: string
               networks:
                 description: Networks in addtion to the cluster network, the service
                   is attached to

--- a/api/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/api/bases/telemetry.openstack.org_ceilometers.yaml
@@ -242,6 +242,23 @@ spec:
                     description: SecretName - holding the cert, key for the service
                     type: string
                 type: object
+              topologyRef:
+                description: |-
+                  TopologyRef to apply the Topology defined by the associated CR referenced
+                  by name
+                properties:
+                  name:
+                    description: Name - The Topology CR name that the Service references
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace - The Namespace to fetch the Topology CR referenced
+                      NOTE: Namespace currently points by default to the same namespace where
+                      the Service is deployed. Customizing the namespace is not supported and
+                      webhooks prevent editing this field to a value different from the
+                      current project
+                    type: string
+                type: object
             required:
             - centralImage
             - computeImage
@@ -310,6 +327,9 @@ spec:
                 description: ReadyCount of kube-state-metrics instances
                 format: int32
                 type: integer
+              lastAppliedTopology:
+                description: LastAppliedTopology - the last applied Topology
+                type: string
               mysqldExporterExportedGaleras:
                 description: List of galera CRs, which are being exported with mysqld_exporter
                 items:

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -348,6 +348,24 @@ spec:
                               in a pre-created bundle file
                             type: string
                         type: object
+                      topologyRef:
+                        description: |-
+                          TopologyRef to apply the Topology defined by the associated CR referenced
+                          by name
+                        properties:
+                          name:
+                            description: Name - The Topology CR name that the Service
+                              references
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace - The Namespace to fetch the Topology CR referenced
+                              NOTE: Namespace currently points by default to the same namespace where
+                              the Service is deployed. Customizing the namespace is not supported and
+                              webhooks prevent editing this field to a value different from the
+                              current project
+                            type: string
+                        type: object
                     required:
                     - apiImage
                     - databaseInstance
@@ -536,6 +554,24 @@ spec:
                         type: string
                       secretName:
                         description: SecretName - holding the cert, key for the service
+                        type: string
+                    type: object
+                  topologyRef:
+                    description: |-
+                      TopologyRef to apply the Topology defined by the associated CR referenced
+                      by name
+                    properties:
+                      name:
+                        description: Name - The Topology CR name that the Service
+                          references
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace - The Namespace to fetch the Topology CR referenced
+                          NOTE: Namespace currently points by default to the same namespace where
+                          the Service is deployed. Customizing the namespace is not supported and
+                          webhooks prevent editing this field to a value different from the
+                          current project
                         type: string
                     type: object
                 required:
@@ -1894,6 +1930,23 @@ spec:
                 description: NodeSelector to target subset of worker nodes running
                   this service
                 type: object
+              topologyRef:
+                description: |-
+                  TopologyRef to apply the Topology defined by the associated CR referenced
+                  by name
+                properties:
+                  name:
+                    description: Name - The Topology CR name that the Service references
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace - The Namespace to fetch the Topology CR referenced
+                      NOTE: Namespace currently points by default to the same namespace where
+                      the Service is deployed. Customizing the namespace is not supported and
+                      webhooks prevent editing this field to a value different from the
+                      current project
+                    type: string
+                type: object
             type: object
           status:
             description: TelemetryStatus defines the observed state of Telemetry
@@ -1945,6 +1998,9 @@ spec:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
+              lastAppliedTopology:
+                description: LastAppliedTopology - the last applied Topology
+                type: string
               observedGeneration:
                 description: |-
                   ObservedGeneration - the most recent generation observed for this

--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.34.1
-	github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250204091142-ae8379c31edb
+	github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250213131341-8e63f078f923
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250205143454-43504d7ad19a
 	github.com/rhobs/observability-operator v0.3.1
 	k8s.io/api v0.29.13

--- a/api/go.sum
+++ b/api/go.sum
@@ -72,8 +72,8 @@ github.com/onsi/ginkgo/v2 v2.20.1 h1:YlVIbqct+ZmnEph770q9Q7NVAz4wwIiVNahee6JyUzo
 github.com/onsi/ginkgo/v2 v2.20.1/go.mod h1:lG9ey2Z29hR41WMVthyJBGUBcBhGOtoPF2VFMvBXFCI=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
-github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250204091142-ae8379c31edb h1:SedlzLahRyzctVTXzVrpmjui78A7Z0g8V1cmPBoQzYY=
-github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250204091142-ae8379c31edb/go.mod h1:TDaE7BVQvJwJGFm33R6xcPTeF8LKAnMh+a1ho+YqJHs=
+github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250213131341-8e63f078f923 h1:PpGup24Ri4sgw8UNyaEENy16dUHLIo8i4bpj8hLQWoU=
+github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250213131341-8e63f078f923/go.mod h1:kkjcOSZ7jkHbVzxJd0nDQzjB+vqafuAMgSf7AnEXydw=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250205143454-43504d7ad19a h1:3LuUgB85VxGD6lmVOeZelYEASmytkrzaudU014PN7xw=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250205143454-43504d7ad19a/go.mod h1:KxnNSUk15llkKTSq/bQEE7pnc0IMk44fxhoBRpimMa8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/api/v1beta1/autoscaling_types.go
+++ b/api/v1beta1/autoscaling_types.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
@@ -131,6 +132,11 @@ type AodhCore struct {
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service
 	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// TopologyRef to apply the Topology defined by the associated CR referenced
+	// by name
+	TopologyRef *topologyv1.TopoRef `json:"topologyRef,omitempty"`
 }
 
 // APIOverrideSpec to override the generated manifest of several child resources.
@@ -217,6 +223,9 @@ type AutoscalingStatus struct {
 	// then the controller has not processed the latest changes injected by
 	// the openstack-operator in the top-level CR (e.g. the ContainerImage)
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// LastAppliedTopology - the last applied Topology
+	LastAppliedTopology string `json:"lastAppliedTopology,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/ceilometer_types.go
+++ b/api/v1beta1/ceilometer_types.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
@@ -149,6 +150,11 @@ type CeilometerSpecCore struct {
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service
 	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// TopologyRef to apply the Topology defined by the associated CR referenced
+	// by name
+	TopologyRef *topologyv1.TopoRef `json:"topologyRef,omitempty"`
 }
 
 // CeilometerStatus defines the observed state of Ceilometer
@@ -189,6 +195,9 @@ type CeilometerStatus struct {
 
 	// Map of hashes to track e.g. job status
 	KSMHash map[string]string `json:"ksmHash,omitempty"`
+
+	// LastAppliedTopology - the last applied Topology
+	LastAppliedTopology string `json:"lastAppliedTopology,omitempty"`
 }
 
 // NOTE(mmagr): remove KSMStatus with API version increment

--- a/api/v1beta1/telemetry_types.go
+++ b/api/v1beta1/telemetry_types.go
@@ -21,6 +21,7 @@ import (
 
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 )
 
 // PasswordsSelector to identify the Service password from the Secret
@@ -75,6 +76,11 @@ type TelemetrySpecBase struct {
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service
 	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// TopologyRef to apply the Topology defined by the associated CR referenced
+	// by name
+	TopologyRef *topologyv1.TopoRef `json:"topologyRef,omitempty"`
 }
 
 // CeilometerSection defines the desired state of the ceilometer service
@@ -174,6 +180,9 @@ type TelemetryStatus struct {
 	// then the controller has not processed the latest changes injected by
 	// the openstack-operator in the top-level CR (e.g. the ContainerImage)
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// LastAppliedTopology - the last applied Topology
+	LastAppliedTopology string `json:"lastAppliedTopology,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1beta1
 
 import (
 	networkv1beta1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
+	topologyv1beta1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	"github.com/rhobs/observability-operator/pkg/apis/monitoring/v1alpha1"
@@ -95,6 +96,11 @@ func (in *AodhCore) DeepCopyInto(out *AodhCore) {
 				(*out)[key] = val
 			}
 		}
+	}
+	if in.TopologyRef != nil {
+		in, out := &in.TopologyRef, &out.TopologyRef
+		*out = new(topologyv1beta1.TopoRef)
+		**out = **in
 	}
 }
 
@@ -491,6 +497,11 @@ func (in *CeilometerSpecCore) DeepCopyInto(out *CeilometerSpecCore) {
 				(*out)[key] = val
 			}
 		}
+	}
+	if in.TopologyRef != nil {
+		in, out := &in.TopologyRef, &out.TopologyRef
+		*out = new(topologyv1beta1.TopoRef)
+		**out = **in
 	}
 }
 
@@ -1036,6 +1047,11 @@ func (in *TelemetrySpecBase) DeepCopyInto(out *TelemetrySpecBase) {
 				(*out)[key] = val
 			}
 		}
+	}
+	if in.TopologyRef != nil {
+		in, out := &in.TopologyRef, &out.TopologyRef
+		*out = new(topologyv1beta1.TopoRef)
+		**out = **in
 	}
 }
 

--- a/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
+++ b/config/crd/bases/telemetry.openstack.org_autoscalings.yaml
@@ -345,6 +345,24 @@ spec:
                           a pre-created bundle file
                         type: string
                     type: object
+                  topologyRef:
+                    description: |-
+                      TopologyRef to apply the Topology defined by the associated CR referenced
+                      by name
+                    properties:
+                      name:
+                        description: Name - The Topology CR name that the Service
+                          references
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace - The Namespace to fetch the Topology CR referenced
+                          NOTE: Namespace currently points by default to the same namespace where
+                          the Service is deployed. Customizing the namespace is not supported and
+                          webhooks prevent editing this field to a value different from the
+                          current project
+                        type: string
+                    type: object
                 required:
                 - apiImage
                 - databaseInstance
@@ -449,6 +467,9 @@ spec:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
+              lastAppliedTopology:
+                description: LastAppliedTopology - the last applied Topology
+                type: string
               networks:
                 description: Networks in addtion to the cluster network, the service
                   is attached to

--- a/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
+++ b/config/crd/bases/telemetry.openstack.org_ceilometers.yaml
@@ -242,6 +242,23 @@ spec:
                     description: SecretName - holding the cert, key for the service
                     type: string
                 type: object
+              topologyRef:
+                description: |-
+                  TopologyRef to apply the Topology defined by the associated CR referenced
+                  by name
+                properties:
+                  name:
+                    description: Name - The Topology CR name that the Service references
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace - The Namespace to fetch the Topology CR referenced
+                      NOTE: Namespace currently points by default to the same namespace where
+                      the Service is deployed. Customizing the namespace is not supported and
+                      webhooks prevent editing this field to a value different from the
+                      current project
+                    type: string
+                type: object
             required:
             - centralImage
             - computeImage
@@ -310,6 +327,9 @@ spec:
                 description: ReadyCount of kube-state-metrics instances
                 format: int32
                 type: integer
+              lastAppliedTopology:
+                description: LastAppliedTopology - the last applied Topology
+                type: string
               mysqldExporterExportedGaleras:
                 description: List of galera CRs, which are being exported with mysqld_exporter
                 items:

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -348,6 +348,24 @@ spec:
                               in a pre-created bundle file
                             type: string
                         type: object
+                      topologyRef:
+                        description: |-
+                          TopologyRef to apply the Topology defined by the associated CR referenced
+                          by name
+                        properties:
+                          name:
+                            description: Name - The Topology CR name that the Service
+                              references
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace - The Namespace to fetch the Topology CR referenced
+                              NOTE: Namespace currently points by default to the same namespace where
+                              the Service is deployed. Customizing the namespace is not supported and
+                              webhooks prevent editing this field to a value different from the
+                              current project
+                            type: string
+                        type: object
                     required:
                     - apiImage
                     - databaseInstance
@@ -536,6 +554,24 @@ spec:
                         type: string
                       secretName:
                         description: SecretName - holding the cert, key for the service
+                        type: string
+                    type: object
+                  topologyRef:
+                    description: |-
+                      TopologyRef to apply the Topology defined by the associated CR referenced
+                      by name
+                    properties:
+                      name:
+                        description: Name - The Topology CR name that the Service
+                          references
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace - The Namespace to fetch the Topology CR referenced
+                          NOTE: Namespace currently points by default to the same namespace where
+                          the Service is deployed. Customizing the namespace is not supported and
+                          webhooks prevent editing this field to a value different from the
+                          current project
                         type: string
                     type: object
                 required:
@@ -1894,6 +1930,23 @@ spec:
                 description: NodeSelector to target subset of worker nodes running
                   this service
                 type: object
+              topologyRef:
+                description: |-
+                  TopologyRef to apply the Topology defined by the associated CR referenced
+                  by name
+                properties:
+                  name:
+                    description: Name - The Topology CR name that the Service references
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace - The Namespace to fetch the Topology CR referenced
+                      NOTE: Namespace currently points by default to the same namespace where
+                      the Service is deployed. Customizing the namespace is not supported and
+                      webhooks prevent editing this field to a value different from the
+                      current project
+                    type: string
+                type: object
             type: object
           status:
             description: TelemetryStatus defines the observed state of Telemetry
@@ -1945,6 +1998,9 @@ spec:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
+              lastAppliedTopology:
+                description: LastAppliedTopology - the last applied Topology
+                type: string
               observedGeneration:
                 description: |-
                   ObservedGeneration - the most recent generation observed for this

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -469,3 +469,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - topology.openstack.org
+  resources:
+  - topologies
+  verbs:
+  - get
+  - list
+  - update
+  - watch

--- a/config/samples/telemetry_v1beta1_telemetry_topology.yaml
+++ b/config/samples/telemetry_v1beta1_telemetry_topology.yaml
@@ -1,0 +1,32 @@
+apiVersion: telemetry.openstack.org/v1beta1
+kind: Telemetry
+metadata:
+  name: telemetry
+spec:
+  topologyRef:
+    name: telemetry-topology
+  metricStorage:
+    enabled: false
+    monitoringStack:
+      alertingEnabled: true
+      scrapeInterval: 30s
+      storage:
+        strategy: persistent
+        retention: 24h
+        persistent:
+          pvcStorageRequest: 20G
+  autoscaling:
+    enabled: false
+    aodh:
+      passwordSelectors:
+      databaseUser: aodh
+      databaseInstance: openstack
+      memcachedInstance: memcached
+      secret: osp-secret
+    heatInstance: heat
+  ceilometer:
+    enabled: true
+    secret: osp-secret
+  logging:
+    enabled: false
+    port: 10514

--- a/controllers/aodh_controller.go
+++ b/controllers/aodh_controller.go
@@ -41,6 +41,7 @@ import (
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
 	autoscaling "github.com/openstack-k8s-operators/telemetry-operator/pkg/autoscaling"
@@ -303,7 +304,44 @@ func (r *AutoscalingReconciler) reconcileNormalAodh(
 	// ConfigVars
 	configVars := make(map[string]env.Setter)
 
-	sfsetDef, err := autoscaling.AodhStatefulSet(instance, inputHash, serviceLabels)
+	//
+	// Handle Topology
+	//
+	lastTopologyRef := topologyv1.TopoRef{
+		Name:      instance.Status.LastAppliedTopology,
+		Namespace: instance.Namespace,
+	}
+	topology, err := ensureTelemetryTopology(
+		ctx,
+		helper,
+		instance.Spec.Aodh.TopologyRef,
+		&lastTopologyRef,
+		instance.Name,
+		autoscaling.ServiceName,
+	)
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.TopologyReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.TopologyReadyErrorMessage,
+			err.Error()))
+		return ctrl.Result{}, fmt.Errorf("waiting for Topology requirements: %w", err)
+	}
+
+	// If TopologyRef is present and ensureManilaTopology returned a valid
+	// topology object, set .Status.LastAppliedTopology to the referenced one
+	// and mark the condition as true
+	if instance.Spec.Aodh.TopologyRef != nil {
+		// update the Status with the last retrieved Topology name
+		instance.Status.LastAppliedTopology = instance.Spec.Aodh.TopologyRef.Name
+		// update the TopologyRef associated condition
+		instance.Status.Conditions.MarkTrue(condition.TopologyReadyCondition, condition.TopologyReadyMessage)
+	} else {
+		// remove LastAppliedTopology from the .Status
+		instance.Status.LastAppliedTopology = ""
+	}
+	sfsetDef, err := autoscaling.AodhStatefulSet(instance, inputHash, serviceLabels, topology)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,

--- a/controllers/autoscaling_controller.go
+++ b/controllers/autoscaling_controller.go
@@ -57,6 +57,7 @@ import (
 	heatv1 "github.com/openstack-k8s-operators/heat-operator/api/v1beta1"
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
@@ -101,6 +102,7 @@ func (r *AutoscalingReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups=topology.openstack.org,resources=topologies,verbs=get;list;watch;update
 
 // Reconcile reconciles an Autoscaling
 func (r *AutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
@@ -185,6 +187,12 @@ func (r *AutoscalingReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	instance.Status.Conditions.Init(&cl)
 	instance.Status.ObservedGeneration = instance.Generation
 
+	// Init Topology condition if there's a reference
+	if instance.Spec.Aodh.TopologyRef != nil {
+		c := condition.UnknownCondition(condition.TopologyReadyCondition, condition.InitReason, condition.TopologyReadyInitMessage)
+		cl.Set(c)
+	}
+
 	// If we're not deleting this and the service object doesn't have our finalizer, add it.
 	if instance.DeletionTimestamp.IsZero() && controllerutil.AddFinalizer(instance, helper.GetFinalizer()) || isNewInstance {
 		return ctrl.Result{}, nil
@@ -210,6 +218,7 @@ const (
 	autoscalingTLSAPIInternalField     = ".spec.tls.api.internal.secretName"
 	autoscalingTLSAPIPublicField       = ".spec.tls.api.public.secretName"
 	autoscalingTLSField                = ".spec.tls.secretName"
+	topologyField                      = ".spec.topologyRef.Name"
 )
 
 var (
@@ -219,6 +228,7 @@ var (
 		autoscalingTLSAPIInternalField,
 		autoscalingTLSAPIPublicField,
 		autoscalingTLSField,
+		topologyField,
 	}
 )
 
@@ -234,6 +244,18 @@ func (r *AutoscalingReconciler) reconcileDelete(
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, nil
+	}
+	// Remove finalizer on the Topology CR
+	if ctrlResult, err := topologyv1.EnsureDeletedTopologyRef(
+		ctx,
+		helper,
+		&topologyv1.TopoRef{
+			Name:      instance.Status.LastAppliedTopology,
+			Namespace: instance.Namespace,
+		},
+		instance.Name,
+	); err != nil {
+		return ctrlResult, err
 	}
 	// Service is deleted so remove the finalizer.
 	controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
@@ -871,6 +893,18 @@ func (r *AutoscalingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 		return err
 	}
 
+	// index topologyField
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &telemetryv1.Autoscaling{}, topologyField, func(rawObj client.Object) []string {
+		// Extract the topology name from the spec, if one is provided
+		cr := rawObj.(*telemetryv1.Autoscaling)
+		if cr.Spec.Aodh.TopologyRef == nil {
+			return nil
+		}
+		return []string{cr.Spec.Aodh.TopologyRef.Name}
+	}); err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&telemetryv1.Autoscaling{}).
 		Owns(&appsv1.StatefulSet{}).
@@ -900,6 +934,9 @@ func (r *AutoscalingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 			handler.EnqueueRequestsFromMapFunc(metricStorageFn),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).
+		Watches(&topologyv1.Topology{},
+			handler.EnqueueRequestsFromMapFunc(r.findObjectsForSrc),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }
 

--- a/controllers/ceilometer_controller.go
+++ b/controllers/ceilometer_controller.go
@@ -56,6 +56,7 @@ import (
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
@@ -105,6 +106,7 @@ func (r *CeilometerReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups=topology.openstack.org,resources=topologies,verbs=get;list;watch;update
 
 // Reconcile reconciles a Ceilometer
 func (r *CeilometerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
@@ -190,6 +192,13 @@ func (r *CeilometerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		condition.UnknownCondition(telemetryv1.KSMServiceConfigReadyCondition, condition.InitReason, condition.ServiceConfigReadyInitMessage),
 		condition.UnknownCondition(telemetryv1.KSMTLSInputReadyCondition, condition.InitReason, condition.InputReadyInitMessage),
 	)
+
+	// Init Topology condition if there's a reference
+	if instance.Spec.TopologyRef != nil {
+		c := condition.UnknownCondition(condition.TopologyReadyCondition, condition.InitReason, condition.TopologyReadyInitMessage)
+		cl.Set(c)
+	}
+
 	instance.Status.Conditions.Init(&cl)
 	instance.Status.ObservedGeneration = instance.Generation
 
@@ -239,6 +248,7 @@ var (
 		ksmTLSField,
 		mysqldExporterCaBundleSecretNameField,
 		mysqldExporterTLSField,
+		topologyField,
 	}
 )
 
@@ -380,6 +390,19 @@ func (r *CeilometerReconciler) reconcileDelete(ctx context.Context, instance *te
 		}
 	}
 
+	// Remove finalizer on the Topology CR
+	if ctrlResult, err := topologyv1.EnsureDeletedTopologyRef(
+		ctx,
+		helper,
+		&topologyv1.TopoRef{
+			Name:      instance.Status.LastAppliedTopology,
+			Namespace: instance.Namespace,
+		},
+		instance.Name,
+	); err != nil {
+		return ctrlResult, err
+	}
+
 	// Service is deleted so remove the finalizer.
 	controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
 	Log.Info(fmt.Sprintf("Reconciled Service '%s' delete successfully", ceilometer.ServiceName))
@@ -474,25 +497,64 @@ func (r *CeilometerReconciler) reconcileNormal(ctx context.Context, instance *te
 		return rbacResult, nil
 	}
 
-	ksmRes, err := r.reconcileKSM(ctx, instance, helper)
+	//
+	// Handle Topology
+	//
+	lastTopologyRef := topologyv1.TopoRef{
+		Name:      instance.Status.LastAppliedTopology,
+		Namespace: instance.Namespace,
+	}
+	topology, err := ensureTelemetryTopology(
+		ctx,
+		helper,
+		instance.Spec.TopologyRef,
+		&lastTopologyRef,
+		instance.Name,
+		ceilometer.ServiceName,
+	)
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.TopologyReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.TopologyReadyErrorMessage,
+			err.Error()))
+		return ctrl.Result{}, fmt.Errorf("waiting for Topology requirements: %w", err)
+	}
+
+	// If TopologyRef is present and ensureTelemetryTopology returned a valid
+	// topology object, set .Status.LastAppliedTopology to the referenced one
+	// and mark the condition as true
+	if instance.Spec.TopologyRef != nil {
+		// update the Status with the last retrieved Topology name
+		instance.Status.LastAppliedTopology = instance.Spec.TopologyRef.Name
+		// update the TopologyRef associated condition
+		instance.Status.Conditions.MarkTrue(condition.TopologyReadyCondition, condition.TopologyReadyMessage)
+	} else {
+		// remove LastAppliedTopology from the .Status
+		instance.Status.LastAppliedTopology = ""
+	}
+
+	ksmRes, err := r.reconcileKSM(ctx, instance, helper, topology)
 	if err != nil {
 		return ksmRes, err
 	}
 
-	mysqldRes, err := r.reconcileMysqldExporter(ctx, instance, helper)
+	mysqldRes, err := r.reconcileMysqldExporter(ctx, instance, helper, topology)
 	if (err != nil || mysqldRes != ctrl.Result{}) {
 		return mysqldRes, err
 	}
 
 	// NOTE(mmagr): Ceilometer reconciliation has to be the last as this is the (only) place
 	//              where condition ReadyCondition is/should be evaluated
-	return r.reconcileCeilometer(ctx, instance, helper)
+	return r.reconcileCeilometer(ctx, instance, helper, topology)
 }
 
 func (r *CeilometerReconciler) reconcileCeilometer(
 	ctx context.Context,
 	instance *telemetryv1.Ceilometer,
 	helper *helper.Helper,
+	topology *topologyv1.Topology,
 ) (ctrl.Result, error) {
 	// ConfigMap
 	configMapVars := make(map[string]env.Setter)
@@ -711,7 +773,7 @@ func (r *CeilometerReconciler) reconcileCeilometer(
 	}
 
 	// Define a new StatefulSet object
-	sfsetDef, err := ceilometer.StatefulSet(instance, inputHash, serviceLabels)
+	sfsetDef, err := ceilometer.StatefulSet(instance, inputHash, serviceLabels, topology)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -770,6 +832,7 @@ func (r *CeilometerReconciler) reconcileMysqldExporter(
 	ctx context.Context,
 	instance *telemetryv1.Ceilometer,
 	helper *helper.Helper,
+	topology *topologyv1.Topology,
 ) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 	Log.Info(fmt.Sprintf(msgReconcileStart, mysqldexporter.ServiceName))
@@ -895,7 +958,7 @@ func (r *CeilometerReconciler) reconcileMysqldExporter(
 	}
 
 	// Define a new StatefulSet object
-	sfsetDef, err := mysqldexporter.StatefulSet(instance, inputHash, serviceLabels)
+	sfsetDef, err := mysqldexporter.StatefulSet(instance, inputHash, serviceLabels, topology)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -950,6 +1013,7 @@ func (r *CeilometerReconciler) reconcileKSM(
 	ctx context.Context,
 	instance *telemetryv1.Ceilometer,
 	helper *helper.Helper,
+	topology *topologyv1.Topology,
 ) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 	Log.Info(fmt.Sprintf(msgReconcileStart, availability.KSMServiceName))
@@ -1050,7 +1114,7 @@ func (r *CeilometerReconciler) reconcileKSM(
 	instance.Status.Conditions.MarkTrue(telemetryv1.KSMServiceConfigReadyCondition, condition.InputReadyMessage)
 
 	// create the kube-state-metrics statefulset
-	ssDef, err := availability.KSMStatefulSet(instance, tlsConfName, serviceLabels)
+	ssDef, err := availability.KSMStatefulSet(instance, tlsConfName, serviceLabels, topology)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -1719,6 +1783,18 @@ func (r *CeilometerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 		return err
 	}
 
+	// index topologyField
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &telemetryv1.Ceilometer{}, topologyField, func(rawObj client.Object) []string {
+		// Extract the topology name from the spec, if one is provided
+		cr := rawObj.(*telemetryv1.Ceilometer)
+		if cr.Spec.TopologyRef == nil {
+			return nil
+		}
+		return []string{cr.Spec.TopologyRef.Name}
+	}); err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&telemetryv1.Ceilometer{}).
 		Owns(&keystonev1.KeystoneService{}).
@@ -1747,6 +1823,9 @@ func (r *CeilometerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 			&mariadbv1.Galera{},
 			handler.EnqueueRequestsFromMapFunc(galeraWatchFn),
 		).
+		Watches(&topologyv1.Topology{},
+			handler.EnqueueRequestsFromMapFunc(r.findObjectsForSrc),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }
 

--- a/controllers/telemetry_common.go
+++ b/controllers/telemetry_common.go
@@ -21,7 +21,11 @@ import (
 	"fmt"
 	"time"
 
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	secret "github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -66,4 +70,65 @@ func ensureSecret(
 	}
 
 	return hash, ctrl.Result{}, nil
+}
+
+// ensureTelemetryTopology - when a Topology CR is referenced, remove the
+// finalizer from a previous referenced Topology (if any), and retrieve the
+// newly referenced topology object
+func ensureTelemetryTopology(
+	ctx context.Context,
+	helper *helper.Helper,
+	tpRef *topologyv1.TopoRef,
+	lastAppliedTopology *topologyv1.TopoRef,
+	finalizer string,
+	selector string,
+) (*topologyv1.Topology, error) {
+
+	var podTopology *topologyv1.Topology
+	var err error
+
+	// Remove (if present) the finalizer from a previously referenced topology
+	//
+	// 1. a topology reference is removed (tpRef == nil) from the Service Component
+	//    subCR and the finalizer should be deleted from the last applied topology
+	//    (lastAppliedTopology != "")
+	// 2. a topology reference is updated in the Service Component CR (tpRef != nil)
+	//    and the finalizer should be removed from the previously
+	//    referenced topology (tpRef.Name != lastAppliedTopology.Name)
+	if (tpRef == nil && lastAppliedTopology.Name != "") ||
+		(tpRef != nil && tpRef.Name != lastAppliedTopology.Name) {
+		_, err = topologyv1.EnsureDeletedTopologyRef(
+			ctx,
+			helper,
+			lastAppliedTopology,
+			finalizer,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// TopologyRef is passed as input, get the Topology object
+	if tpRef != nil {
+		// no Namespace is provided, default to instance.Namespace
+		if tpRef.Namespace == "" {
+			tpRef.Namespace = helper.GetBeforeObject().GetNamespace()
+		}
+		// Build a defaultLabelSelector (component=octavia-[api|rsyslog|healthmanager|housekeeper])
+		defaultLabelSelector := labels.GetSingleLabelSelector(
+			common.ComponentSelector,
+			selector,
+		)
+		// Retrieve the referenced Topology
+		podTopology, _, err = topologyv1.EnsureTopologyRef(
+			ctx,
+			helper,
+			tpRef,
+			finalizer,
+			&defaultLabelSelector,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return podTopology, nil
 }

--- a/controllers/telemetry_controller.go
+++ b/controllers/telemetry_controller.go
@@ -255,6 +255,10 @@ func (r TelemetryReconciler) reconcileCeilometer(ctx context.Context, instance *
 		instance.Spec.Ceilometer.NodeSelector = instance.Spec.NodeSelector
 	}
 
+	if instance.Spec.Ceilometer.TopologyRef == nil {
+		instance.Spec.Ceilometer.TopologyRef = instance.Spec.TopologyRef
+	}
+
 	helper.GetLogger().Info("Reconciling Ceilometer", ceilometerNamespaceLabel, instance.Namespace, ceilometerNameLabel, ceilometer.ServiceName)
 	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), ceilometerInstance, func() error {
 		instance.Spec.Ceilometer.CeilometerSpec.DeepCopyInto(&ceilometerInstance.Spec)
@@ -334,6 +338,10 @@ func (r TelemetryReconciler) reconcileAutoscaling(ctx context.Context, instance 
 
 	if instance.Spec.Autoscaling.Aodh.NodeSelector == nil {
 		instance.Spec.Autoscaling.Aodh.NodeSelector = instance.Spec.NodeSelector
+	}
+
+	if instance.Spec.Autoscaling.Aodh.TopologyRef == nil {
+		instance.Spec.Autoscaling.Aodh.TopologyRef = instance.Spec.TopologyRef
 	}
 
 	helper.GetLogger().Info("Reconciling Autoscaling", autoscalingNamespaceLabel, instance.Namespace, autoscalingNameLabel, autoscalingName)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.34.1
 	github.com/openstack-k8s-operators/heat-operator/api v0.5.1-0.20250209213011-8d425819ec71
-	github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250204091142-ae8379c31edb
+	github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250213131341-8e63f078f923
 	github.com/openstack-k8s-operators/keystone-operator/api v0.5.1-0.20250203105048-182afa0c45d8
 	github.com/openstack-k8s-operators/lib-common/modules/ansible v0.5.1-0.20250205143454-43504d7ad19a
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250205143454-43504d7ad19a

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094 h1:J1wuGhVxpsHykZBa6
 github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/openstack-k8s-operators/heat-operator/api v0.5.1-0.20250209213011-8d425819ec71 h1:7Y9KJx+MRoxcN8sf9yyEdJe1f+crFfKXMDPMVhz0kHs=
 github.com/openstack-k8s-operators/heat-operator/api v0.5.1-0.20250209213011-8d425819ec71/go.mod h1:MdU+91cEjTBfpHXchtm1PgRo1ipHnij4WZ4IiWEqolM=
-github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250204091142-ae8379c31edb h1:SedlzLahRyzctVTXzVrpmjui78A7Z0g8V1cmPBoQzYY=
-github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250204091142-ae8379c31edb/go.mod h1:TDaE7BVQvJwJGFm33R6xcPTeF8LKAnMh+a1ho+YqJHs=
+github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250213131341-8e63f078f923 h1:PpGup24Ri4sgw8UNyaEENy16dUHLIo8i4bpj8hLQWoU=
+github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250213131341-8e63f078f923/go.mod h1:kkjcOSZ7jkHbVzxJd0nDQzjB+vqafuAMgSf7AnEXydw=
 github.com/openstack-k8s-operators/keystone-operator/api v0.5.1-0.20250203105048-182afa0c45d8 h1:HIL7hIXZPuwMVr46jMoLxHToBHAplGWwOtR4FlMrCUU=
 github.com/openstack-k8s-operators/keystone-operator/api v0.5.1-0.20250203105048-182afa0c45d8/go.mod h1:pZ3kLMgL9thHN7ewyLsTE8R0nsI81f8KJ0yEVBBpa9Q=
 github.com/openstack-k8s-operators/lib-common/modules/ansible v0.5.1-0.20250205143454-43504d7ad19a h1:lXs4PU5v8iB8AqS8GqfGEzqO+W1Xj73kWuRtP49xrGM=

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ import (
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	infranetworkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
 	mariadbv1beta1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	rabbitmqclusterv1 "github.com/rabbitmq/cluster-operator/api/v1beta1"
@@ -78,6 +79,7 @@ func init() {
 	utilruntime.Must(infranetworkv1.AddToScheme(scheme))
 	utilruntime.Must(rabbitmqclusterv1.AddToScheme(scheme))
 	utilruntime.Must(networkv1.AddToScheme(scheme))
+	utilruntime.Must(topologyv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/pkg/availability/statefulset.go
+++ b/pkg/availability/statefulset.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
 )
 
@@ -35,6 +36,7 @@ func KSMStatefulSet(
 	instance *telemetryv1.Ceilometer,
 	tlsConfName string,
 	labels map[string]string,
+	topology *topologyv1.Topology,
 ) (*appsv1.StatefulSet, error) {
 
 	livenessProbe := &corev1.Probe{
@@ -172,6 +174,18 @@ func KSMStatefulSet(
 
 	if instance.Spec.NodeSelector != nil {
 		ss.Spec.Template.Spec.NodeSelector = *instance.Spec.NodeSelector
+	}
+	if topology != nil {
+		// Get the Topology .Spec
+		ts := topology.Spec
+		// Process TopologySpreadConstraints if defined in the referenced Topology
+		if ts.TopologySpreadConstraints != nil {
+			ss.Spec.Template.Spec.TopologySpreadConstraints = *topology.Spec.TopologySpreadConstraints
+		}
+		// Process Affinity if defined in the referenced Topology
+		if ts.Affinity != nil {
+			ss.Spec.Template.Spec.Affinity = ts.Affinity
+		}
 	}
 
 	return ss, nil

--- a/pkg/mysqldexporter/statefulset.go
+++ b/pkg/mysqldexporter/statefulset.go
@@ -18,6 +18,8 @@ package mysqldexporter
 import (
 	"fmt"
 
+	"github.com/openstack-k8s-operators/lib-common/modules/common"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/affinity"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/annotations"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
@@ -29,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
+	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
 )
 
@@ -37,6 +40,7 @@ func StatefulSet(
 	instance *telemetryv1.Ceilometer,
 	configHash string,
 	labels map[string]string,
+	topology *topologyv1.Topology,
 ) (*appsv1.StatefulSet, error) {
 	runAsUser := int64(0)
 
@@ -122,6 +126,30 @@ func StatefulSet(
 			},
 			Volumes: volumes,
 		},
+	}
+
+	if topology != nil {
+		// Get the Topology .Spec
+		ts := topology.Spec
+		// Process TopologySpreadConstraints if defined in the referenced Topology
+		if ts.TopologySpreadConstraints != nil {
+			pod.Spec.TopologySpreadConstraints = *topology.Spec.TopologySpreadConstraints
+		}
+		// Process Affinity if defined in the referenced Topology
+		if ts.Affinity != nil {
+			pod.Spec.Affinity = ts.Affinity
+		}
+	} else {
+		// If possible two pods of the same service should not
+		// run on the same worker node. If this is not possible
+		// the get still created on the same worker node.
+		pod.Spec.Affinity = affinity.DistributePods(
+			common.AppSelector,
+			[]string{
+				ServiceName,
+			},
+			corev1.LabelHostname,
+		)
 	}
 
 	statefulset := &appsv1.StatefulSet{

--- a/tests/kuttl/suites/topology/config.yaml
+++ b/tests/kuttl/suites/topology/config.yaml
@@ -1,0 +1,14 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+reportFormat: JSON
+reportName: kuttl-topology-results
+namespace: telemetry-kuttl-topology
+# we could set this lower, but the initial image pull can take a while
+timeout: 300
+parallel: 1
+skipDelete: true
+testDirs:
+  - tests/kuttl/suites/topology/
+suppress:
+  - events
+artifactsDir: tests/kuttl/suites/topology/output

--- a/tests/kuttl/suites/topology/deps/OpenStackControlPlane.yaml
+++ b/tests/kuttl/suites/topology/deps/OpenStackControlPlane.yaml
@@ -1,0 +1,35 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  storageClass: "crc-csi-hostpath-provisioner"
+  keystone:
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+  ironic:
+    enabled: false
+    template:
+      ironicConductors: []
+  manila:
+    enabled: false
+    template:
+      manilaShares: {}
+  horizon:
+    enabled: false
+  nova:
+    enabled: false
+  placement:
+    template:
+      databaseInstance: openstack
+      secret: osp-secret
+  heat:
+    enabled: true
+    template:
+      databaseInstance: openstack
+      heatAPI:
+        replicas: 1
+      heatEngine:
+        replicas: 1
+      secret: osp-secret

--- a/tests/kuttl/suites/topology/deps/infra.yaml
+++ b/tests/kuttl/suites/topology/deps/infra.yaml
@@ -1,0 +1,41 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  mariadb:
+    enabled: false
+    templates:
+      openstack:
+        replicas: 0
+      openstack-cell1:
+        replicas: 0
+  galera:
+    enabled: true
+    templates:
+      openstack:
+        replicas: 1
+        storageRequest: 500M
+      openstack-cell1:
+        replicas: 1
+        storageRequest: 500M
+        secret: osp-secret
+    secret: osp-secret
+  rabbitmq:
+    templates:
+      rabbitmq:
+        replicas: 1
+      rabbitmq-cell1:
+        replicas: 1
+  memcached:
+    templates:
+      memcached:
+        replicas: 1
+  ovn:
+    enabled: false
+    template:
+      ovnController:
+        external-ids:
+          ovn-encap-type: geneve
+  ovs:
+    enabled: false

--- a/tests/kuttl/suites/topology/deps/kustomization.yaml
+++ b/tests/kuttl/suites/topology/deps/kustomization.yaml
@@ -1,0 +1,48 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: telemetry-kuttl-default
+
+secretGenerator:
+- literals:
+  - AdminPassword=password
+  - DbRootPassword=password
+  - DatabasePassword=password
+  - KeystoneDatabasePassword=password
+  - PlacementPassword=password
+  - PlacementDatabasePassword=password
+  - GlancePassword=password
+  - GlanceDatabasePassword=password
+  - NeutronPassword=password
+  - NeutronDatabasePassword=password
+  - NovaPassword=password
+  - NovaAPIDatabasePassword=password
+  - NovaCell0DatabasePassword=password
+  - NovaCell1DatabasePassword=password
+  - AodhPassword=password
+  - AodhDatabasePassword=password
+  - CeilometerPassword=password
+  - CeilometerDatabasePassword=password
+  - HeatPassword=password
+  - HeatDatabasePassword=password
+  - HeatAuthEncryptionKey=66699966699966600666999666999666
+  - MetadataSecret=42
+  name: osp-secret
+generatorOptions:
+  disableNameSuffixHash: true
+  labels:
+    type: osp-secret
+
+resources:
+- namespace.yaml
+- OpenStackControlPlane.yaml
+
+patches:
+- patch: |-
+    apiVersion: core.openstack.org/v1beta1
+    kind: OpenStackControlPlane
+    metadata:
+      name: openstack
+    spec:
+      secret: osp-secret
+- path: infra.yaml
+- path: telemetry.yaml

--- a/tests/kuttl/suites/topology/deps/namespace.yaml
+++ b/tests/kuttl/suites/topology/deps/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: telemetry-kuttl

--- a/tests/kuttl/suites/topology/deps/rhobs.yaml
+++ b/tests/kuttl/suites/topology/deps/rhobs.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-observability-operator
+  namespace: openshift-operators
+spec:
+  channel: development
+  installPlanApproval: Automatic
+  name: cluster-observability-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/tests/kuttl/suites/topology/deps/telemetry.yaml
+++ b/tests/kuttl/suites/topology/deps/telemetry.yaml
@@ -1,0 +1,7 @@
+apiVersion: core.openstack.org/v1beta1
+kind: OpenStackControlPlane
+metadata:
+  name: openstack
+spec:
+  telemetry:
+    enabled: false

--- a/tests/kuttl/suites/topology/tests/00-assert-topology.yaml
+++ b/tests/kuttl/suites/topology/tests/00-assert-topology.yaml
@@ -1,0 +1,9 @@
+#
+# Check for:
+#
+# - telemetry-topology
+
+apiVersion: topology.openstack.org/v1beta1
+kind: Topology
+metadata:
+  name: telemetry-topology

--- a/tests/kuttl/suites/topology/tests/00-deps.yaml
+++ b/tests/kuttl/suites/topology/tests/00-deps.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      # COO is required for MetricStorage
+      oc apply -f ../deps/rhobs.yaml
+      until oc api-resources | grep -q rhobs; do sleep 1; done

--- a/tests/kuttl/suites/topology/tests/00-telemetry-topology.yaml
+++ b/tests/kuttl/suites/topology/tests/00-telemetry-topology.yaml
@@ -1,0 +1,9 @@
+apiVersion: topology.openstack.org/v1beta1
+kind: Topology
+metadata:
+  name: telemetry-topology
+spec:
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: "topology.kubernetes.io/hostname"
+    whenUnsatisfiable: ScheduleAnyway

--- a/tests/kuttl/suites/topology/tests/01-assert.yaml
+++ b/tests/kuttl/suites/topology/tests/01-assert.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    service: ceilometer
+  name: ceilometer
+  ownerReferences:
+  - kind: Ceilometer
+    name: ceilometer
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+       - maxSkew: 1
+         topologyKey: "topology.kubernetes.io/hostname"
+         whenUnsatisfiable: ScheduleAnyway
+         labelSelector:
+           matchLabels:
+             service: ceilometer
+status:
+  availableReplicas: 1
+  currentReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    service: aodh
+  name: aodh
+  ownerReferences:
+  - kind: Autoscaling
+    name: autoscaling
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+       - maxSkew: 1
+         topologyKey: "topology.kubernetes.io/hostname"
+         whenUnsatisfiable: ScheduleAnyway
+         labelSelector:
+           matchLabels:
+             service: aodh
+status:
+  availableReplicas: 1
+  currentReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: telemetry.openstack.org/v1beta1
+kind: Autoscaling
+metadata:
+  name: autoscaling
+status:
+  lastAppliedTopology: telemetry-topology
+---
+apiVersion: telemetry.openstack.org/v1beta1
+kind: Ceilometer
+metadata:
+  name: ceilometer
+status:
+  lastAppliedTopology: telemetry-topology

--- a/tests/kuttl/suites/topology/tests/01-deploy.yaml
+++ b/tests/kuttl/suites/topology/tests/01-deploy.yaml
@@ -1,0 +1,33 @@
+apiVersion: telemetry.openstack.org/v1beta1
+kind: Telemetry
+metadata:
+  name: telemetry-kuttl
+spec:
+  topologyRef:
+    name: telemetry-topology
+  metricStorage:
+    enabled: true
+    monitoringStack:
+      alertingEnabled: true
+      scrapeInterval: 30s
+      storage:
+        strategy: persistent
+        retention: 24h
+        persistent:
+          pvcStorageRequest: 20G
+  autoscaling:
+    enabled: true
+    aodh:
+      secret: osp-secret
+      passwordSelectors:
+      databaseAccount: aodh
+      databaseInstance: openstack
+      memcachedInstance: memcached
+    heatInstance: heat
+  ceilometer:
+    enabled: true
+    secret: osp-secret
+  logging:
+    enabled: false
+    port: 10514
+    cloNamespace: openshift-logging


### PR DESCRIPTION
This patch provides more granular control over `Pod` placement and scheduling through the `Topology` CR integration introduced in `infra-operator`.
In particular it provides:

- a new `API` parameter (`TopologyRef`) defined for each `Component` that allows to reference an existing `Topology` CR in the same namespace

- the operator logic that retrieves and processes the referenced `Topology` CR through the functions provided by `infra-operator`

- enhanced `StatefulSet` and deployment configuration that incorporates the processed `Topology`

- a set of kuttl tests to double check the topology propagation

Note that `webhooks` are in place to prevent referencing a `Topology` from a different namespace (which is not a supported scenario).

Jira: https://issues.redhat.com/browse/OSPRH-14064