### PR TITLE
[OSPRH-13955][d-t] Move tasks for consistency

### DIFF
--- a/ci/check-default-telemetry.yml
+++ b/ci/check-default-telemetry.yml
@@ -81,24 +81,6 @@
       ansible.builtin.wait_for:
         timeout: 120
 
-    - name: |
-        TEST Check telemetry-operator didn't restart after enabling MetricStorage and Autoscaling without COO installed
-        RHOSO-123458
-      ansible.builtin.import_tasks: "get-operator-restart-counts.yml"
-      failed_when: restart_counts != [0, 0]
-
-    - name: Get telemetry-operator failed container logs
-      ansible.builtin.command:
-        cmd:
-          oc logs -n openstack-operators -p -l "openstack.org/operator-name=telemetry" --tail=-1
-      register: operator_logs_previous
-      when: restart_counts != [0, 0]
-
-    - name: Output logs of failed container for debugging purposes
-      ansible.builtin.debug:
-        var: operator_logs_previous.stdout_lines
-      when: restart_counts != [0, 0]
-
     - name: Get telemetry-operator logs
       ansible.builtin.import_tasks: "get-operator-logs.yml"
 
@@ -123,6 +105,24 @@
           - item in expected_logs
         fail_msg: "telemetry-operator logs include an unexpected error: {{ item }}"
       loop: "{{ error_list }}"
+
+    - name: |
+        TEST Check telemetry-operator didn't restart after enabling MetricStorage and Autoscaling without COO installed
+        RHOSO-123458
+      ansible.builtin.import_tasks: "get-operator-restart-counts.yml"
+      failed_when: restart_counts != [0, 0]
+
+    - name: Get telemetry-operator failed container logs
+      ansible.builtin.command:
+        cmd:
+          oc logs -n openstack-operators -p -l "openstack.org/operator-name=telemetry" --tail=-1
+      register: operator_logs_previous
+      when: restart_counts != [0, 0]
+
+    - name: Output logs of failed container for debugging purposes
+      ansible.builtin.debug:
+        var: operator_logs_previous.stdout_lines
+      when: restart_counts != [0, 0]
 
     - name: Check if we have the expected conditions for MetricStorage
       block:

--- a/ci/check-default-telemetry.yml
+++ b/ci/check-default-telemetry.yml
@@ -53,16 +53,16 @@
       ansible.builtin.import_tasks: "get-operator-restart-counts.yml"
       failed_when: restart_counts != [0, 0]
 
-    - name: Get telemetry-operator failed container logs
-      ansible.builtin.command:
-        cmd:
-          oc logs -n openstack-operators -p -l "openstack.org/operator-name=telemetry" --tail=-1
-      register: operator_logs_previous
-      when: restart_counts != [0, 0]
+    - block:
+      - name: Get telemetry-operator failed container logs
+        ansible.builtin.command:
+          cmd:
+            oc logs -n openstack-operators -p -l "openstack.org/operator-name=telemetry" --tail=-1
+        register: operator_logs_previous
 
-    - name: Output logs of failed container for debugging purposes
-      ansible.builtin.debug:
-        var: operator_logs_previous.stdout_lines
+      - name: Output logs of failed container for debugging purposes
+        ansible.builtin.debug:
+          var: operator_logs_previous.stdout_lines
       when: restart_counts != [0, 0]
 
     # Enabling Autoscaling and MetricStorage without COO installed. Expected to see errors.
@@ -112,16 +112,16 @@
       ansible.builtin.import_tasks: "get-operator-restart-counts.yml"
       failed_when: restart_counts != [0, 0]
 
-    - name: Get telemetry-operator failed container logs
-      ansible.builtin.command:
-        cmd:
-          oc logs -n openstack-operators -p -l "openstack.org/operator-name=telemetry" --tail=-1
-      register: operator_logs_previous
-      when: restart_counts != [0, 0]
+    - block:
+      - name: Get telemetry-operator failed container logs
+        ansible.builtin.command:
+          cmd:
+            oc logs -n openstack-operators -p -l "openstack.org/operator-name=telemetry" --tail=-1
+        register: operator_logs_previous
 
-    - name: Output logs of failed container for debugging purposes
-      ansible.builtin.debug:
-        var: operator_logs_previous.stdout_lines
+      - name: Output logs of failed container for debugging purposes
+        ansible.builtin.debug:
+          var: operator_logs_previous.stdout_lines
       when: restart_counts != [0, 0]
 
     - name: Check if we have the expected conditions for MetricStorage


### PR DESCRIPTION
Move some tasks around, so that the distinct parts of the
playbook are consistent between each other.

Also in second commit implement Emma's suggestion from previous PR.

Part 4/4 of the original PR https://github.com/openstack-k8s-operators/telemetry-operator/pull/604