### PR TITLE
[OSPRH-14074] Update sg-core tag

### DIFF
--- a/api/v1beta1/ceilometer_types.go
+++ b/api/v1beta1/ceilometer_types.go
@@ -31,7 +31,7 @@ const (
 	// CeilometerNotificationContainerImage - default fall-back image for Ceilometer Notification
 	CeilometerNotificationContainerImage = "quay.io/podified-antelope-centos9/openstack-ceilometer-notification:current-podified"
 	// CeilometerSgCoreContainerImage - default fall-back image for Ceilometer SgCore
-	CeilometerSgCoreContainerImage = "quay.io/openstack-k8s-operators/sg-core:v6.0.0"
+	CeilometerSgCoreContainerImage = "quay.io/openstack-k8s-operators/sg-core:latest"
 	// CeilometerComputeContainerImage - default fall-back image for Ceilometer Compute
 	CeilometerComputeContainerImage = "quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified"
 	// CeilometerIpmiContainerImage - default fall-back image for Ceilometer Ipmi

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -20,7 +20,7 @@ spec:
         - name: RELATED_IMAGE_CEILOMETER_IPMI_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-ceilometer-ipmi:current-podified
         - name: RELATED_IMAGE_CEILOMETER_SGCORE_IMAGE_URL_DEFAULT
-          value: quay.io/openstack-k8s-operators/sg-core:v6.0.0
+          value: quay.io/openstack-k8s-operators/sg-core:latest
         - name: RELATED_IMAGE_APACHE_IMAGE_URL_DEFAULT
           value: registry.redhat.io/ubi9/httpd-24:latest
         - name: RELATED_IMAGE_AODH_API_IMAGE_URL_DEFAULT


### PR DESCRIPTION
sg-core is now being built and pushed automatically similarly to how the operators or must-gather are being built and pushed. The latest tag follows the main branch of the repository.

Related openstack-operator PR: https://github.com/openstack-k8s-operators/openstack-operator/pull/1308