### PR TITLE
Add missing dependency project

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -95,3 +95,4 @@
         - functional-logging-tests-osp18: *fvt_jobs_config
         - functional-graphing-tests-osp18: *fvt_jobs_config
         - functional-metric-verification-tests-osp18: *fvt_jobs_config
+        - openstack-k8s-operators-content-provider


### PR DESCRIPTION
The functional-tests-on-osp18 job requires openstack-k8s-operators-content-provider job to be set, but it was not defined.