### PR TITLE
DNM[test] make change to irrelevant OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
+# This update should be the only one to the PR.
+# Since this file is excluded by the job, then there should be no CI run
 approvers:
   - telemetry-approvers
   - ci-approvers


### PR DESCRIPTION
This is to test that adding the OWNERS file to the fvt repo will prevent the jobs from triggering in T-O

Depends-On: https://github.com/infrawatch/feature-verification-tests/pull/230
Depends-On: https://github.com/openstack-k8s-operators/telemetry-operator/pull/633