### PR TITLE
[ci] Provide a zuul status to github when irrelevant files are changed

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -116,4 +116,5 @@
         - functional-logging-tests-osp18: *fvt_jobs_config
         - functional-graphing-tests-osp18: *fvt_jobs_config
         - functional-metric-verification-tests-osp18: *fvt_jobs_config
-        - feature-verification-tests-noop
+        - feature-verification-tests-noop:
+            files: *irrelevant_files

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -116,3 +116,4 @@
         - functional-logging-tests-osp18: *fvt_jobs_config
         - functional-graphing-tests-osp18: *fvt_jobs_config
         - functional-metric-verification-tests-osp18: *fvt_jobs_config
+        - feature-verification-tests-noop


### PR DESCRIPTION
Adds the no-op job from feature-verificaton-tests, which will run and provide a passing status from zuul.
This is needed because github expects a status from zuul before it can mark a PR as passing/failing CI.