### PR TITLE
Add openstack-approvers to approvers/reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,9 @@
 approvers:
   - telemetry-approvers
   - ci-approvers
+  - openstack-approvers
 
 reviewers:
   - telemetry-approvers
   - ci-approvers
+  - openstack-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,3 +11,8 @@ aliases:
   - lewisdenny
   - frenzyfriday
   - viroel
+  openstack-approvers:
+  - abays
+  - dprince
+  - olliewalsh
+  - stuggi


### PR DESCRIPTION
The source for ci-operator/config/openstack-k8s-operators/telemetry-operator/OWNERS in the the CI configuration at github.com/openshift/release is the OWNERS of this repo.
To update the CI configuration for e.g. feature branching, the openstack-approvers should be in the OWNERS_ALIASES/OWNERS like for in the other repositories.