### PR TITLE
Avoid configs overwritting Prometheus pod

### DIFF
--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -371,7 +371,7 @@ func (r *MetricStorageReconciler) reconcileNormal(
 			return ctrl.Result{RequeueAfter: telemetryv1.PauseBetweenWatchAttempts}, nil
 		}
 		prometheusTLSPatch := metricstorage.PrometheusTLS(instance)
-		err = r.Client.Patch(context.Background(), &prometheusTLSPatch, client.Apply, client.FieldOwner("telemetry-operator"))
+		err = r.Client.Patch(context.Background(), &prometheusTLSPatch, client.Merge, client.FieldOwner("telemetry-operator"))
 		if err != nil {
 			Log.Error(err, "Can't patch Prometheus resource")
 			return ctrl.Result{}, err
@@ -580,7 +580,7 @@ func (r *MetricStorageReconciler) reconcileNormal(
 			return ctrl.Result{RequeueAfter: telemetryv1.PauseBetweenWatchAttempts}, nil
 		}
 		prometheusNADPatch := metricstorage.PrometheusNAD(instance, networkAnnotations)
-		err = r.Client.Patch(context.Background(), &prometheusNADPatch, client.Apply, client.FieldOwner("telemetry-operator"))
+		err = r.Client.Patch(context.Background(), &prometheusNADPatch, client.Merge, client.FieldOwner("telemetry-operator"))
 		if err != nil {
 			Log.Error(err, "Can't patch Prometheus resource")
 			return ctrl.Result{}, err


### PR DESCRIPTION
If TLS is enabled at a pod level and a NAD is configured, the telemetry-operator will fall in an infinite reconciliation loop trying to patch the Prometheus pod with the required configs

Merge configs instead of applying them avoid this issue

Co-Authored-By: jwysogla@redhat.com