### PR TITLE
[CI] Extend timeout for Loki to get ready

### DIFF
--- a/ci/deploy-logging-dependencies/tasks/deploy-loki.yml
+++ b/ci/deploy-logging-dependencies/tasks/deploy-loki.yml
@@ -20,4 +20,4 @@
 - name: Wait for the lokistack to be ready
   ansible.builtin.command:
     cmd: |
-      oc wait --timeout=300s --for condition=Ready=True --namespace=openshift-logging lokistacks logging-loki
+      oc wait --timeout=500s --for condition=Ready=True --namespace=openshift-logging lokistacks logging-loki


### PR DESCRIPTION
Loki apparently took 316 seconds to get ready in the downstream tests today.