### PR TITLE
[DNM] Test whether the issue in PR#649 is caused by ciframework branch

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -92,6 +92,8 @@
             required-projects:
               - name: infrawatch/feature-verification-tests
                 override-checkout: master
+              - name: openstack-k8s-operators/ci-framework
+                override-checkout: main
         - functional-logging-tests-osp18: *fvt_jobs_config
         - functional-graphing-tests-osp18: *fvt_jobs_config
         - functional-metric-verification-tests-osp18: *fvt_jobs_config

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -88,11 +88,11 @@
         - telemetry-operator-multinode-autoscaling-tempest
         - telemetry-operator-multinode-default-telemetry
         - telemetry-operator-multinode-power-monitoring
-        - functional-tests-on-osp18: &fvt_jobs_config
-            voting: true
-            required-projects:
-              - name: infrawatch/feature-verification-tests
-                override-checkout: master
-        - functional-logging-tests-osp18: *fvt_jobs_config
-        - functional-graphing-tests-osp18: *fvt_jobs_config
-        - functional-metric-verification-tests-osp18: *fvt_jobs_config
+        #- functional-tests-on-osp18: &fvt_jobs_config
+        #    voting: true
+        #    required-projects:
+        #      - name: infrawatch/feature-verification-tests
+        #        override-checkout: master
+        #- functional-logging-tests-osp18: *fvt_jobs_config
+        #- functional-graphing-tests-osp18: *fvt_jobs_config
+        #- functional-metric-verification-tests-osp18: *fvt_jobs_config

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -80,10 +80,11 @@
 
 - project:
     name: openstack-k8s-operators/telemetry-operator
-    templates:
-      - podified-multinode-edpm-pipeline
+    #templates:
+    #  - podified-multinode-edpm-pipeline
     github-check:
       jobs:
+        - openstack-k8s-operators-content-provider
         - telemetry-operator-multinode-autoscaling-tempest
         - telemetry-operator-multinode-default-telemetry
         - telemetry-operator-multinode-power-monitoring
@@ -92,8 +93,6 @@
             required-projects:
               - name: infrawatch/feature-verification-tests
                 override-checkout: master
-              - name: openstack-k8s-operators/ci-framework
-                override-checkout: main
         - functional-logging-tests-osp18: *fvt_jobs_config
         - functional-graphing-tests-osp18: *fvt_jobs_config
         - functional-metric-verification-tests-osp18: *fvt_jobs_config


### PR DESCRIPTION
Remove the fvt jobs to see if the issue is caused by jobs from infrawatch

Adding the override-checkout for ci-framework repo did not work -- it was supposed to check whether the lack of an fr2 branch was the issue

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/2809
