### PR TITLE
Dnm/test fr2 add cp

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -88,13 +88,13 @@
         - telemetry-operator-multinode-autoscaling-tempest
         - telemetry-operator-multinode-default-telemetry
         - telemetry-operator-multinode-power-monitoring
-        - functional-tests-on-osp18: &fvt_jobs_config
-            voting: true
-            required-projects:
-              - name: infrawatch/feature-verification-tests
-                override-checkout: master
-              - name: openstack-k8s-operators/ci-framework
-                override-checkout: main
-        - functional-logging-tests-osp18: *fvt_jobs_config
-        - functional-graphing-tests-osp18: *fvt_jobs_config
-        - functional-metric-verification-tests-osp18: *fvt_jobs_config
+        #- functional-tests-on-osp18: &fvt_jobs_config
+        #    voting: true
+        #    required-projects:
+        #      - name: infrawatch/feature-verification-tests
+        #        override-checkout: master
+        #      - name: openstack-k8s-operators/ci-framework
+        #        override-checkout: main
+        #- functional-logging-tests-osp18: *fvt_jobs_config
+        #- functional-graphing-tests-osp18: *fvt_jobs_config
+        #- functional-metric-verification-tests-osp18: *fvt_jobs_config

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -84,16 +84,17 @@
       - podified-multinode-edpm-pipeline
     github-check:
       jobs:
+        - openstack-k8s-operators-content-provider
         - telemetry-operator-multinode-autoscaling-tempest
         - telemetry-operator-multinode-default-telemetry
         - telemetry-operator-multinode-power-monitoring
-        # - functional-tests-on-osp18: &fvt_jobs_config
-        #     voting: true
-        #     required-projects:
-        #       - name: infrawatch/feature-verification-tests
-        #         override-checkout: master
-        #       - name: openstack-k8s-operators/ci-framework
-        #         override-checkout: main
-        # - functional-logging-tests-osp18: *fvt_jobs_config
-        # - functional-graphing-tests-osp18: *fvt_jobs_config
-        # - functional-metric-verification-tests-osp18: *fvt_jobs_config
+        - functional-tests-on-osp18: &fvt_jobs_config
+            voting: true
+            required-projects:
+              - name: infrawatch/feature-verification-tests
+                override-checkout: master
+              - name: openstack-k8s-operators/ci-framework
+                override-checkout: main
+        - functional-logging-tests-osp18: *fvt_jobs_config
+        - functional-graphing-tests-osp18: *fvt_jobs_config
+        - functional-metric-verification-tests-osp18: *fvt_jobs_config

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -92,6 +92,8 @@
             required-projects:
               - name: infrawatch/feature-verification-tests
                 override-checkout: master
+              - name: openstack-k8s-operators/ci-framework
+                override-checkout: main
         - functional-logging-tests-osp18: *fvt_jobs_config
         - functional-graphing-tests-osp18: *fvt_jobs_config
         - functional-metric-verification-tests-osp18: *fvt_jobs_config

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -96,6 +96,8 @@
                 override-checkout: master
               - name: openstack-k8s-operators/ci-framework
                 override-checkout: main
+              - name: openstack-k8s-operators/repo-setup
+                override-checkout: main
         - functional-logging-tests-osp18: *fvt_jobs_config
         - functional-graphing-tests-osp18: *fvt_jobs_config
         - functional-metric-verification-tests-osp18: *fvt_jobs_config

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -87,13 +87,13 @@
         - telemetry-operator-multinode-autoscaling-tempest
         - telemetry-operator-multinode-default-telemetry
         - telemetry-operator-multinode-power-monitoring
-        - functional-tests-on-osp18: &fvt_jobs_config
-            voting: true
-            required-projects:
-              - name: infrawatch/feature-verification-tests
-                override-checkout: master
-              - name: openstack-k8s-operators/ci-framework
-                override-checkout: main
-        - functional-logging-tests-osp18: *fvt_jobs_config
-        - functional-graphing-tests-osp18: *fvt_jobs_config
-        - functional-metric-verification-tests-osp18: *fvt_jobs_config
+        # - functional-tests-on-osp18: &fvt_jobs_config
+        #     voting: true
+        #     required-projects:
+        #       - name: infrawatch/feature-verification-tests
+        #         override-checkout: master
+        #       - name: openstack-k8s-operators/ci-framework
+        #         override-checkout: main
+        # - functional-logging-tests-osp18: *fvt_jobs_config
+        # - functional-graphing-tests-osp18: *fvt_jobs_config
+        # - functional-metric-verification-tests-osp18: *fvt_jobs_config

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -85,7 +85,8 @@
     github-check:
       debug: true
       jobs:
-        - openstack-k8s-operators-content-provider
+        - openstack-k8s-operators-content-provider:
+            override-checkout: main
         - telemetry-operator-multinode-autoscaling-tempest
         - telemetry-operator-multinode-default-telemetry
         - telemetry-operator-multinode-power-monitoring

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -83,6 +83,7 @@
     templates:
       - podified-multinode-edpm-pipeline
     github-check:
+      debug: true
       jobs:
         - openstack-k8s-operators-content-provider
         - telemetry-operator-multinode-autoscaling-tempest

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -88,13 +88,13 @@
         - telemetry-operator-multinode-autoscaling-tempest
         - telemetry-operator-multinode-default-telemetry
         - telemetry-operator-multinode-power-monitoring
-        #- functional-tests-on-osp18: &fvt_jobs_config
-        #    voting: true
-        #    required-projects:
-        #      - name: infrawatch/feature-verification-tests
-        #        override-checkout: master
-        #      - name: openstack-k8s-operators/ci-framework
-        #        override-checkout: main
-        #- functional-logging-tests-osp18: *fvt_jobs_config
-        #- functional-graphing-tests-osp18: *fvt_jobs_config
-        #- functional-metric-verification-tests-osp18: *fvt_jobs_config
+        - functional-tests-on-osp18: &fvt_jobs_config
+            voting: true
+            required-projects:
+              - name: infrawatch/feature-verification-tests
+                override-checkout: master
+              - name: openstack-k8s-operators/ci-framework
+                override-checkout: main
+        - functional-logging-tests-osp18: *fvt_jobs_config
+        - functional-graphing-tests-osp18: *fvt_jobs_config
+        - functional-metric-verification-tests-osp18: *fvt_jobs_config

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -87,9 +87,12 @@
       jobs:
         - openstack-k8s-operators-content-provider:
             override-checkout: main
-        - telemetry-operator-multinode-autoscaling-tempest
-        - telemetry-operator-multinode-default-telemetry
-        - telemetry-operator-multinode-power-monitoring
+        - telemetry-operator-multinode-autoscaling-tempest: &jobs_config
+            required-projects:
+              - name: openstack-k8s-operators/ci-framework
+                override-checkout: main
+        - telemetry-operator-multinode-default-telemetry: *jobs_config
+        - telemetry-operator-multinode-power-monitoring: *jobs_config
         - functional-tests-on-osp18: &fvt_jobs_config
             voting: true
             required-projects:


### PR DESCRIPTION
Explicitly add the content provider to the github-check pipeline to try to resolve the error: `Unable to freeze job graph: Job functional-tests-on-osp18 depends on openstack-k8s-operators-content-provider which was not run.`