### PR TITLE
Complete webhook validation for topology references

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.34.1
-	github.com/openstack-k8s-operators/infra-operator/apis v0.6.0
+	github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250319162810-463dd75a4cc4
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250315090821-34e570d2d5fb
 	github.com/rhobs/observability-operator v0.3.1
 	k8s.io/api v0.29.15

--- a/api/go.sum
+++ b/api/go.sum
@@ -72,8 +72,8 @@ github.com/onsi/ginkgo/v2 v2.20.1 h1:YlVIbqct+ZmnEph770q9Q7NVAz4wwIiVNahee6JyUzo
 github.com/onsi/ginkgo/v2 v2.20.1/go.mod h1:lG9ey2Z29hR41WMVthyJBGUBcBhGOtoPF2VFMvBXFCI=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
-github.com/openstack-k8s-operators/infra-operator/apis v0.6.0 h1:28i9Yc3UAdQK8VNzk0ubwq4n+qLuhD0nk6/7iHgD9us=
-github.com/openstack-k8s-operators/infra-operator/apis v0.6.0/go.mod h1:JgcmYJyyMKfArK8ulZnbls0L01qt8Dq6s5LH8TZH63A=
+github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250319162810-463dd75a4cc4 h1:wb2zsr9x9LantNLN/9dmYM42c3yLq3QuzsoOlGpDUxM=
+github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250319162810-463dd75a4cc4/go.mod h1:n5DV/lGE9DHryAJ+JLJSgUXI2QHTj+aN4KoeSNC3PfU=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250315090821-34e570d2d5fb h1:UAFYEHnbyhO0+yymquFmIqxc9QGji9mzreuYrDS1Ev4=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250315090821-34e570d2d5fb/go.mod h1:1CtBP0MQffdjE6buOv5jP2rB3+h7WH0a11lcyrpmxOk=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/api/v1beta1/autoscaling_types.go
+++ b/api/v1beta1/autoscaling_types.go
@@ -22,9 +22,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
-
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 const (
@@ -301,4 +301,16 @@ func (instance *Autoscaling) GetLastAppliedTopology() *topologyv1.TopoRef {
 // SetLastAppliedTopology - Sets the LastAppliedTopology value in the Status
 func (instance *Autoscaling) SetLastAppliedTopology(topologyRef *topologyv1.TopoRef) {
 	instance.Status.LastAppliedTopology = topologyRef
+}
+
+// ValidateTopology -
+func (instance *AodhCore) ValidateTopology(
+	basePath *field.Path,
+	namespace string,
+) field.ErrorList {
+	var allErrs field.ErrorList
+	allErrs = append(allErrs, topologyv1.ValidateTopologyRef(
+		instance.TopologyRef,
+		*basePath.Child("topologyRef"), namespace)...)
+	return allErrs
 }

--- a/api/v1beta1/ceilometer_types.go
+++ b/api/v1beta1/ceilometer_types.go
@@ -20,7 +20,7 @@ import (
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 )
@@ -299,4 +299,16 @@ func (instance *Ceilometer) GetLastAppliedTopology() *topologyv1.TopoRef {
 // SetLastAppliedTopology - Sets the LastAppliedTopology value in the Status
 func (instance *Ceilometer) SetLastAppliedTopology(topologyRef *topologyv1.TopoRef) {
 	instance.Status.LastAppliedTopology = topologyRef
+}
+
+// ValidateTopology -
+func (instance *CeilometerSpecCore) ValidateTopology(
+	basePath *field.Path,
+	namespace string,
+) field.ErrorList {
+	var allErrs field.ErrorList
+	allErrs = append(allErrs, topologyv1.ValidateTopologyRef(
+		instance.TopologyRef,
+		*basePath.Child("topologyRef"), namespace)...)
+	return allErrs
 }

--- a/api/v1beta1/telemetry_webhook.go
+++ b/api/v1beta1/telemetry_webhook.go
@@ -202,27 +202,20 @@ func (spec *TelemetrySpecCore) ValidateTelemetryTopology(basePath *field.Path, n
 
 	// When a TopologyRef CR is referenced, fail if a different Namespace is
 	// referenced because is not supported
-	if spec.TopologyRef != nil {
-		if err := topologyv1.ValidateTopologyNamespace(spec.TopologyRef.Namespace, *basePath, namespace); err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
+	allErrs = append(allErrs, topologyv1.ValidateTopologyRef(
+		spec.TopologyRef, *basePath.Child("topologyRef"), namespace)...)
 
 	// When a TopologyRef CR is referenced with an override to Aodh, fail
 	// if a different Namespace is referenced because not supported
-	if spec.Autoscaling.Aodh.TopologyRef != nil {
-		if err := topologyv1.ValidateTopologyNamespace(spec.Autoscaling.Aodh.TopologyRef.Namespace, *basePath, namespace); err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
+	aodhPath := basePath.Child("autoscaling").Child("aodh")
+	allErrs = append(allErrs,
+		spec.Autoscaling.Aodh.ValidateTopology(aodhPath, namespace)...)
 
 	// When a TopologyRef CR is referenced with an override to Ceilometer,
 	// fail if a different Namespace is referenced because not supported
-	if spec.Ceilometer.TopologyRef != nil {
-		if err := topologyv1.ValidateTopologyNamespace(spec.Ceilometer.TopologyRef.Namespace, *basePath, namespace); err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
+	ceilPath := basePath.Child("ceilometer")
+	allErrs = append(allErrs,
+		spec.Ceilometer.ValidateTopology(ceilPath, namespace)...)
 
 	return allErrs
 }
@@ -233,27 +226,20 @@ func (spec *TelemetrySpec) ValidateTelemetryTopology(basePath *field.Path, names
 
 	// When a TopologyRef CR is referenced, fail if a different Namespace is
 	// referenced because is not supported
-	if spec.TopologyRef != nil {
-		if err := topologyv1.ValidateTopologyNamespace(spec.TopologyRef.Namespace, *basePath, namespace); err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
+	allErrs = append(allErrs, topologyv1.ValidateTopologyRef(
+		spec.TopologyRef, *basePath.Child("topologyRef"), namespace)...)
 
 	// When a TopologyRef CR is referenced with an override to Aodh, fail
 	// if a different Namespace is referenced because not supported
-	if spec.Autoscaling.Aodh.TopologyRef != nil {
-		if err := topologyv1.ValidateTopologyNamespace(spec.Autoscaling.Aodh.TopologyRef.Namespace, *basePath, namespace); err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
+	aodhPath := basePath.Child("autoscaling").Child("aodh")
+	allErrs = append(allErrs,
+		spec.Autoscaling.Aodh.ValidateTopology(aodhPath, namespace)...)
 
 	// When a TopologyRef CR is referenced with an override to Ceilometer,
 	// fail if a different Namespace is referenced because not supported
-	if spec.Ceilometer.TopologyRef != nil {
-		if err := topologyv1.ValidateTopologyNamespace(spec.Ceilometer.TopologyRef.Namespace, *basePath, namespace); err != nil {
-			allErrs = append(allErrs, err)
-		}
-	}
+	ceilPath := basePath.Child("ceilometer")
+	allErrs = append(allErrs,
+		spec.Ceilometer.ValidateTopology(ceilPath, namespace)...)
 
 	return allErrs
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.34.1
 	github.com/openstack-k8s-operators/heat-operator/api v0.6.0
-	github.com/openstack-k8s-operators/infra-operator/apis v0.6.0
+	github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250319162810-463dd75a4cc4
 	github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250310170329-0ffb21c0bb2c
 	github.com/openstack-k8s-operators/lib-common/modules/ansible v0.6.1-0.20250315090821-34e570d2d5fb
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250315090821-34e570d2d5fb

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094 h1:J1wuGhVxpsHykZBa6
 github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/openstack-k8s-operators/heat-operator/api v0.6.0 h1:WXdflkqFy28NuGSgnZ5tHVb98+pZs6Lyjz4wep6JRfw=
 github.com/openstack-k8s-operators/heat-operator/api v0.6.0/go.mod h1:oMtgRR+Cnzjq9Jk9aJeCJIg80sru6fGMpRtO5bhDg2M=
-github.com/openstack-k8s-operators/infra-operator/apis v0.6.0 h1:28i9Yc3UAdQK8VNzk0ubwq4n+qLuhD0nk6/7iHgD9us=
-github.com/openstack-k8s-operators/infra-operator/apis v0.6.0/go.mod h1:JgcmYJyyMKfArK8ulZnbls0L01qt8Dq6s5LH8TZH63A=
+github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250319162810-463dd75a4cc4 h1:wb2zsr9x9LantNLN/9dmYM42c3yLq3QuzsoOlGpDUxM=
+github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250319162810-463dd75a4cc4/go.mod h1:n5DV/lGE9DHryAJ+JLJSgUXI2QHTj+aN4KoeSNC3PfU=
 github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250310170329-0ffb21c0bb2c h1:WWm8yn9ZxDMb4JQDzbeS8ut2CuIchR2mnL0cc2LF1Ps=
 github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250310170329-0ffb21c0bb2c/go.mod h1:yzzegC4K5/iSWD24stJXfj46WjvPG9LTjLb03XvdZ4I=
 github.com/openstack-k8s-operators/lib-common/modules/ansible v0.6.1-0.20250315090821-34e570d2d5fb h1:VradS2HKl7M+q74ajdhQvjWuShB2vbDoRNxW5emJ5eI=


### PR DESCRIPTION
This patch is a follow up of [1] in the validation `webhook` area. It enhances the validation workflow and it aims to complete the pattern by distributing the `ValidateTopology` logic across the `API` instances.
It is based on [2] and the key improvements include:

- `Distributed validation`: it provides a `ValidateTopology` function across all API instances, ensuring consistent validation throughout the system
- `Optimized validation calls`: it refines how validation is triggered and reduce code duplication; it still requires a basic struct refactor to fully de-duplicate the existing functions, but it can be done as part of a follow up

This patch leverages the centralized topology validator introduced in `infra-operator` [3].

Jira: https://issues.redhat.com/browse/OSPRH-14626

[1] openstack-k8s-operators#924
[2] openstack-k8s-operators/nova-operator#936
[3] openstack-k8s-operators/infra-operator#356