### PR TITLE
[OSPRH-14710] Revert "Upstream mysqld-exporter image will leak through to RHOSO 18.0 FR2 deployments"

### DIFF
--- a/api/v1beta1/ceilometer_types.go
+++ b/api/v1beta1/ceilometer_types.go
@@ -42,8 +42,7 @@ const (
 	// KubeStateMetricsImage - default fall-back image for KSM
 	KubeStateMetricsImage = "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.0"
 	// MysqldExporterImage - default fall-back image for mysqld_exporter
-	// MysqldExporterContainerImage = "quay.io/prometheus/mysqld-exporter:v0.16.0"
-	MysqldExporterContainerImage = ""
+	MysqldExporterContainerImage = "quay.io/prometheus/mysqld-exporter:v0.16.0"
 )
 
 // CeilometerSpec defines the desired state of Ceilometer

--- a/tests/kuttl/suites/ceilometer/tests/00-assert.yaml
+++ b/tests/kuttl/suites/ceilometer/tests/00-assert.yaml
@@ -178,3 +178,61 @@ status:
   currentReplicas: 1
   readyReplicas: 1
   replicas: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    service: mysqld-exporter
+  name: mysqld-exporter-0
+  ownerReferences:
+  - kind: StatefulSet
+    name: mysqld-exporter
+spec:
+  containers:
+  - name: mysqld-exporter
+  hostname: mysqld-exporter-0
+status:
+  containerStatuses:
+  - name: mysqld-exporter
+    ready: true
+    started: true
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    service: mysqld-exporter
+  name: mysqld-exporter
+  ownerReferences:
+  - kind: Ceilometer
+    name: telemetry-kuttl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: mysqld-exporter
+  template:
+    spec:
+      containers:
+      - name: mysqld-exporter
+status:
+  availableReplicas: 1
+  currentReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: mysqld-exporter
+  name: mysqld-exporter
+  ownerReferences:
+  - kind: Ceilometer
+    name: telemetry-kuttl
+spec:
+  ports:
+  - port: 9104
+    protocol: TCP
+    targetPort: 9104

--- a/tests/kuttl/suites/ceilometer/tests/00-deploy.yaml
+++ b/tests/kuttl/suites/ceilometer/tests/00-deploy.yaml
@@ -4,5 +4,5 @@ metadata:
   name: telemetry-kuttl
 spec:
   secret: osp-secret
-  mysqldExporterEnabled: false
+  mysqldExporterEnabled: true
   ksmEnabled: true

--- a/tests/kuttl/suites/metricstorage/tests/01-assert.yaml
+++ b/tests/kuttl/suites/metricstorage/tests/01-assert.yaml
@@ -95,6 +95,36 @@ metadata:
 spec:
   scrapeInterval: 30s
 ---
+apiVersion: monitoring.rhobs/v1alpha1
+kind: ScrapeConfig
+metadata:
+  labels:
+    service: metricStorage
+  name: telemetry-mysqld-exporter
+  ownerReferences:
+  - kind: MetricStorage
+    name: telemetry-kuttl
+spec:
+  metricsPath: /probe
+  relabelings:
+  - action: Replace
+    sourceLabels:
+    - __address__
+    targetLabel: __param_target
+  - action: Replace
+    regex: (.*):(.*)
+    replacement: client.$1
+    sourceLabels:
+    - __address__
+    targetLabel: __param_auth_module
+  - action: Replace
+    sourceLabels:
+    - __param_target
+    targetLabel: instance
+  - action: Replace
+    targetLabel: __address__
+  scrapeInterval: 30s
+---
 apiVersion: observability.openshift.io/v1alpha1
 kind: UIPlugin
 metadata:


### PR DESCRIPTION


FR2 is released, let's re-enable mysqld-exporter.

This reverts commit 687b6fb031090b4c46e15bd53c5c0c887712c1d6.