### PR TITLE
[CI] Add check for route kind

### DIFF
--- a/ci/deploy-logging-dependencies/tasks/deploy-minio.yml
+++ b/ci/deploy-logging-dependencies/tasks/deploy-minio.yml
@@ -1,3 +1,16 @@
+# The minio sometimes fails to deploy, because of:
+# no matches for kind "Route" in version "route.openshift.io/v1" ensure CRDs are installed first
+#
+# Let's try to check if the route is available in the cluster bofere deploying minio
+- name: Wait for the route kind to be present in the cluster
+  ansible.builtin.command:
+    cmd:
+      oc api-resources --api-group=route.openshift.io --no-headers
+  delay: 10
+  retries: 50
+  register: output
+  until: output.stdout_lines | length != 0
+
 - name: Create minio deployment
   ansible.builtin.shell:
     cmd: |


### PR DESCRIPTION
We sometimes get failures like:
`  stderr: |-
    Warning: would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "minio" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "minio" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "minio" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "minio" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
    resource mapping not found for name: "minio-console" namespace: "minio-dev" from "/home/zuul/src/github.com/openstack-k8s-operators/telemetry-operator/ci/deploy-logging-dependencies/files/minio-dev.yaml": no matches for kind "Route" in version "route.openshift.io/v1"
    ensure CRDs are installed first
    resource mapping not found for name: "minio-api" namespace: "minio-dev" from "/home/zuul/src/github.com/openstack-k8s-operators/telemetry-operator/ci/deploy-logging-dependencies/files/minio-dev.yaml": no matches for kind "Route" in version "route.openshift.io/v1"
    ensure CRDs are installed first`
    
This should hopefully help.