### PR TITLE
[CI] Deploy mysqldExporter with vars-autoscaling.yml

### DIFF
--- a/ci/vars-autoscaling.yml
+++ b/ci/vars-autoscaling.yml
@@ -26,5 +26,8 @@ cifmw_edpm_prepare_kustomizations:
                   alertingEnabled: false
               autoscaling:
                 enabled: true
+              ceilometer:
+                enabled: true
+                mysqldExporterEnabled: true
       target:
         kind: OpenStackControlPlane


### PR DESCRIPTION
We need to enable the mysqld exporter for metric verification job.