### PR TITLE
OSPRH-13452: Use functional-autoscaling-tests-osp18 job instead of the alias functional-tests-on-osp18

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -115,7 +115,7 @@
               - name: infrawatch/feature-verification-tests
                 override-checkout: master
             irrelevant-files: *irrelevant_files
-        - functional-tests-on-osp18: &fvt_jobs_config
+        - functional-autoscaling-tests-osp18: &fvt_jobs_config
             voting: true
             required-projects:
               - name: infrawatch/feature-verification-tests


### PR DESCRIPTION
This PR wants to use `functional-autoscaling-tests-osp18` job instead of the alias `functional-tests-on-osp18`