### PR TITLE
OSPRH-15988: Enable dashboards for Run Graphing Console UI tests

### DIFF
--- a/ci/vars-autoscaling.yml
+++ b/ci/vars-autoscaling.yml
@@ -24,6 +24,7 @@ cifmw_edpm_prepare_kustomizations:
                 enabled: true
                 monitoringStack:
                   alertingEnabled: false
+                dashboardsEnabled: true
               autoscaling:
                 enabled: true
               ceilometer:


### PR DESCRIPTION
This PR wants to enable dashboards in the deployment stage to prepare the cluster for running `Graphing Console UI tests` by the [functional-graphing-tests-osp18](https://github.com/infrawatch/feature-verification-tests/blob/00b0d3996e190d386205d06ffd1f57818f37cf04/.zuul.yaml#L108) job

Why?
Currently, the dashboards are enabled by patching the oscp in the `Graphing Console UI tests`, waiting for it to resolve the changes, running the graphing tests, then patching the oscp to disable the dashboards again. It takes a lot longer for running test purposes.  

It takes time for the control plane to resolve the changes. It also leaves the control plane in an inconsistent state (i.e. if we want to run any other test, the control plane may still be resolving changes)