### PR TITLE
[zuul] Stop running the metrics-verification test

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -122,6 +122,5 @@
                 override-checkout: master
             irrelevant-files: *irrelevant_files
         - functional-logging-tests-osp18: *fvt_jobs_config
-        - functional-metric-verification-tests-osp18: *fvt_jobs_config
         - feature-verification-tests-noop:
             files: *irrelevant_files


### PR DESCRIPTION
The tests are now run in the functional-autoscaling-tests-osp18 job which is already running in the same pipeline.

[OSPRH-16190](https://issues.redhat.com//browse/OSPRH-16190)