### PR TITLE
Enable prom-exporter in ceilometer-ipmi

### DIFF
--- a/api/v1beta1/telemetry_consts.go
+++ b/api/v1beta1/telemetry_consts.go
@@ -32,6 +32,8 @@ const (
 	DefaultOpenStackNetworkExporterPort = 9105
 	// DefaultCeilometerComputePromExporterPort -
 	DefaultCeilometerComputePromExporterPort = 9101
+	// DefaultCeilometerIpmiPromExporterPort -
+	DefaultCeilometerIpmiPromExporterPort = 9102
 	// DefaultScrapeInterval -
 	DefaultScrapeInterval = "30s"
 	// PauseBetweenWatchAttempts -

--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -840,6 +840,12 @@ func (r *MetricStorageReconciler) createScrapeConfigs(
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	// openstack Ceilometer IPMI's prom exporters
+	err = r.createComputeScrapeConfig(ctx, instance, helper, telemetry.ServiceName, "ceilometer-ipmi-prom-exporter", telemetryv1.DefaultCeilometerIpmiPromExporterPort, true)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	err = r.createComputeScrapeConfig(ctx, instance, helper, telemetry.ServiceName, "podman-exporter", telemetryv1.DefaultPodmanExporterPort, false)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/templates/ceilometeripmi/config/ceilometer.conf
+++ b/templates/ceilometeripmi/config/ceilometer.conf
@@ -4,7 +4,7 @@ debug=True
 log_dir=/var/log/ceilometer
 rpc_response_timeout=60
 polling_namespaces=ipmi
-transport_url={{ .TransportURL }}
+
 
 [service_credentials]
 auth_type=password
@@ -26,10 +26,13 @@ notify_address_prefix=
 [oslo_messaging_notifications]
 driver=messagingv2
 topics=notifications
-transport_url={{ .TransportURL }}
+
 
 [polling]
 heartbeat_socket_dir=/var/lib/ceilometer
+enable_notifications=False
+enable_prometheus_exporter=true
+prometheus_listen_addresses='0.0.0.0:9102'
 
 [publisher]
 telemetry_secret=eQ5qb0yysfJ8lx82Vl061vSyY


### PR DESCRIPTION
1- Disable RabbitMq  in ceilometer-ipmi 
2- Enable prom-exporter in ceilometer-ipmi 
3- Add scrapeconfig for the new port (9102)