### PR TITLE
[zuul] Drop autoscaling-tempest job

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -107,7 +107,6 @@
       - podified-multinode-edpm-pipeline
     github-check:
       jobs:
-        - telemetry-operator-multinode-autoscaling-tempest
         - telemetry-operator-multinode-default-telemetry
         - functional-graphing-tests-osp18:
             voting: false


### PR DESCRIPTION
The tempest-only job for autoscaling is not needed, since the tests are included in the functional-autoscaling-tests-osp18 job.