### PR TITLE
Update kube-state-metrics port

### DIFF
--- a/pkg/availability/const.go
+++ b/pkg/availability/const.go
@@ -20,10 +20,10 @@ const (
 	// KSMServiceName -
 	KSMServiceName = "kube-state-metrics"
 
-	// KSMHealthPort -
-	KSMHealthPort = 8081
+	// KSMReadyPort - (/readyz)
+	KSMReadyPort = 8081
 
-	// KSMMetricsPort -
+	// KSMMetricsPort - (/metrics, /healthz, /livez)
 	KSMMetricsPort = 8080
 )
 

--- a/pkg/availability/service.go
+++ b/pkg/availability/service.go
@@ -49,7 +49,7 @@ func KSMService(
 				Name: "http-metrics",
 			},
 			{
-				Port: KSMHealthPort,
+				Port: KSMReadyPort,
 				Name: "telemetry",
 			},
 		}

--- a/pkg/availability/statefulset.go
+++ b/pkg/availability/statefulset.go
@@ -42,7 +42,7 @@ func KSMStatefulSet(
 	livenessProbe := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Path: "/healthz",
+				Path: "/livez",
 				Port: intstr.FromInt(KSMMetricsPort),
 			},
 		},
@@ -53,8 +53,8 @@ func KSMStatefulSet(
 	readinessProbe := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
-				Path: "/",
-				Port: intstr.FromInt(KSMMetricsPort),
+				Path: "/readyz",
+				Port: intstr.FromInt(KSMReadyPort),
 			},
 		},
 		InitialDelaySeconds: 5,
@@ -138,7 +138,7 @@ func KSMStatefulSet(
 				Name:          "http-metrics",
 			},
 			{
-				ContainerPort: KSMHealthPort,
+				ContainerPort: KSMReadyPort,
 				Name:          "telemetry",
 			},
 		},

--- a/pkg/availability/statefulset.go
+++ b/pkg/availability/statefulset.go
@@ -43,7 +43,7 @@ func KSMStatefulSet(
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Path: "/healthz",
-				Port: intstr.FromInt(KSMHealthPort),
+				Port: intstr.FromInt(KSMMetricsPort),
 			},
 		},
 		InitialDelaySeconds: 5,


### PR DESCRIPTION
From the logs:  
metricsServerAddress="[::]:8080" — this is the main metrics server, serving
/healthz (liveness/readiness probe)

so updating the port solve the CI Failure