### PR TITLE
Don't assume dns_search_domains item length

### DIFF
--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -1217,7 +1217,7 @@ func getAddressFromIPSet(
 	if ok {
 		for _, domain := range domains {
 			domainString, ok := domain.(string)
-			if ok && domainString[0:8] == "ctlplane" {
+			if ok && strings.HasPrefix(domainString, "ctlplane") {
 				ctlplaneDNSDomain = domainString
 			}
 		}


### PR DESCRIPTION
This patch removes assumption that above mentioned item length at least 8 characters.

Fixes: [OSPRH-16162](https://issues.redhat.com//browse/OSPRH-16162)