### PR TITLE
[ci] Increase timeout in COO install

### DIFF
--- a/ci/create-coo-subscription.yaml
+++ b/ci/create-coo-subscription.yaml
@@ -23,7 +23,7 @@
     cmd:
       oc get csv --namespace=openshift-operators -l operators.coreos.com/cluster-observability-operator.openshift-operators
   delay: 10
-  retries: 20
+  retries: 60
   register: output
   until: output.stdout_lines | length != 0
 


### PR DESCRIPTION
Sometimes, COO fails to become available in the alotted time. This can be caused by resource contention or slow networks. This commit increases the number of retries to give the resources up to 10 minutes to appear.

This will not effect the runtimes of otherwise healthy builds, however, it should reduce the amount of failures associated with failure of this task.
Furthermore, it will allow us to check the number of times the job would have failed at this tassk, by checking the number of retries actually used.

JIRA: [OSPRH-16776](https://issues.redhat.com//browse/OSPRH-16776)

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1460