### PR TITLE
[DNM][ci] add temp config

### DIFF
--- a/ci/vars-autoscaling.yml
+++ b/ci/vars-autoscaling.yml
@@ -32,3 +32,27 @@ cifmw_edpm_prepare_kustomizations:
                 mysqldExporterEnabled: true
       target:
         kind: OpenStackControlPlane
+    - patch: |-
+        apiVersion: core.openstack.org/v1beta1
+        kind: OpenStackControlPlane
+        metadata:
+          name: unused
+        spec:
+          nova:
+            customServiceConfig: |
+              [cache]
+              memcache_sasl_enabled=False
+          neutron:
+            customServiceConfig: |
+              [cache]
+              memcache_sasl_enabled=False
+          keystone:
+            customServiceConfig: |
+              [cache]
+              memcache_sasl_enabled=False
+          heat:
+            customServiceConfig: |
+              [cache]
+              memcache_sasl_enabled=False
+      target:
+        kind: OpenStackControlPlane


### PR DESCRIPTION
This is to workaround a previous workaround (revert is in progress) This change should not be merged, but is intended to unblock CI while we wait for the fixes to be merged into the operators.

Since https://review.opendev.org/c/openstack/oslo.cache/+/950561 was merged, the workaournd is not needed, but the reverts have not all merged yet.