### PR TITLE
Add tls config for ceilometer-ipmi-agent 

### DIFF
--- a/templates/ceilometeripmi/config/ceilometer.conf
+++ b/templates/ceilometeripmi/config/ceilometer.conf
@@ -33,6 +33,11 @@ heartbeat_socket_dir=/var/lib/ceilometer
 enable_notifications=False
 enable_prometheus_exporter=true
 prometheus_listen_addresses='0.0.0.0:9102'
+{{- if .TLS }}
+prometheus_tls_enable = True
+prometheus_tls_certfile = {{ .TlsCert }}
+prometheus_tls_keyfile = {{ .TlsKey }}
+{{- end }}
 
 [publisher]
 telemetry_secret=eQ5qb0yysfJ8lx82Vl061vSyY


### PR DESCRIPTION
Enable prometheus-exporter with tls enabled