### PR TITLE
[ci] remove cifmw_run_tests from powermonitoring vars

### DIFF
--- a/ci/vars-power-monitoring.yml
+++ b/ci/vars-power-monitoring.yml
@@ -1,5 +1,4 @@
 ---
-cifmw_run_tests: false
 pre_deploy_deploy_power-monitoring_dependencies:
   source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/deploy-power-monitoring-dependencies.yml"
   type: playbook


### PR DESCRIPTION
vars-power-monitoring.yml configures deployment.
The cifmw_run_tests is enabled/disabled with test configs