### PR TITLE
Enable MTLS memcached auth

### DIFF
--- a/controllers/aodh_controller.go
+++ b/controllers/aodh_controller.go
@@ -28,6 +28,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	common "github.com/openstack-k8s-operators/lib-common/modules/common"
 	condition "github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	endpoint "github.com/openstack-k8s-operators/lib-common/modules/common/endpoint"
@@ -294,6 +295,7 @@ func (r *AutoscalingReconciler) reconcileNormalAodh(
 	instance *telemetryv1.Autoscaling,
 	helper *helper.Helper,
 	inputHash string,
+	memcached *memcachedv1.Memcached,
 ) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 	Log.Info(fmt.Sprintf("Reconciling Service Aodh '%s'", autoscaling.ServiceName))
@@ -325,7 +327,7 @@ func (r *AutoscalingReconciler) reconcileNormalAodh(
 		return ctrl.Result{}, fmt.Errorf("waiting for Topology requirements: %w", err)
 	}
 
-	sfsetDef, err := autoscaling.AodhStatefulSet(instance, inputHash, serviceLabels, topology)
+	sfsetDef, err := autoscaling.AodhStatefulSet(instance, inputHash, serviceLabels, topology, memcached)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.DeploymentReadyCondition,

--- a/controllers/autoscaling_controller.go
+++ b/controllers/autoscaling_controller.go
@@ -543,7 +543,7 @@ func (r *AutoscalingReconciler) reconcileNormal(
 	if err != nil {
 		return ctrlResult, err
 	}
-	ctrlResult, err = r.reconcileNormalAodh(ctx, instance, helper, inputHash)
+	ctrlResult, err = r.reconcileNormalAodh(ctx, instance, helper, inputHash, memcached)
 	if (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, nil
 	}
@@ -669,6 +669,13 @@ func (r *AutoscalingReconciler) generateServiceConfig(
 		httpdVhostConfig[endpt.String()] = endptConfig
 	}
 	templateParameters["VHosts"] = httpdVhostConfig
+
+	// MTLS
+	if mc.GetMemcachedMTLSSecret() != "" {
+		templateParameters["MemcachedAuthCert"] = fmt.Sprint(memcachedv1.CertMountPath())
+		templateParameters["MemcachedAuthKey"] = fmt.Sprint(memcachedv1.KeyMountPath())
+		templateParameters["MemcachedAuthCa"] = fmt.Sprint(memcachedv1.CaMountPath())
+	}
 
 	cms := []util.Template{
 		// ScriptsSecret

--- a/pkg/autoscaling/aodh_statefulset.go
+++ b/pkg/autoscaling/aodh_statefulset.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	topologyv1 "github.com/openstack-k8s-operators/infra-operator/apis/topology/v1beta1"
 	telemetryv1 "github.com/openstack-k8s-operators/telemetry-operator/api/v1beta1"
 )
@@ -45,6 +46,7 @@ func AodhStatefulSet(
 	configHash string,
 	labels map[string]string,
 	topology *topologyv1.Topology,
+	memcached *memcachedv1.Memcached,
 ) (*appsv1.StatefulSet, error) {
 	runAsUser := int64(0)
 
@@ -98,6 +100,12 @@ func AodhStatefulSet(
 	if instance.Spec.PrometheusTLSCaCertSecret != nil {
 		volumes = append(volumes, getCustomPrometheusCaVolume(instance.Spec.PrometheusTLSCaCertSecret.LocalObjectReference.Name))
 		evaluatorVolumeMounts = append(evaluatorVolumeMounts, getCustomPrometheusCaVolumeMount(instance.Spec.PrometheusTLSCaCertSecret.Key))
+	}
+
+	// add MTLS cert if defined
+	if memcached.GetMemcachedMTLSSecret() != "" {
+		volumes = append(volumes, memcached.CreateMTLSVolume())
+		apiVolumeMounts = append(apiVolumeMounts, memcached.CreateMTLSVolumeMounts(nil, nil)...)
 	}
 
 	for _, endpt := range []service.Endpoint{service.EndpointInternal, service.EndpointPublic} {

--- a/templates/autoscaling/config/aodh-api-config.json
+++ b/templates/autoscaling/config/aodh-api-config.json
@@ -53,6 +53,22 @@
         "dest": "/etc/my.cnf",
         "owner": "aodh",
         "perm": "0644"
+    },
+    {
+        "source": "/var/lib/config-data/mtls/certs/*",
+        "dest": "/etc/pki/tls/certs/",
+        "owner": "aodh:aodh",
+        "perm": "0640",
+        "optional": true,
+        "merge": true
+    },
+    {
+        "source": "/var/lib/config-data/mtls/private/*",
+        "dest": "/etc/pki/tls/private/",
+        "owner": "aodh:aodh",
+        "perm": "0640",
+        "optional": true,
+        "merge": true
     }
-    ]
+  ]
 }

--- a/templates/autoscaling/config/aodh-evaluator-config.json
+++ b/templates/autoscaling/config/aodh-evaluator-config.json
@@ -25,6 +25,22 @@
         "dest": "/etc/my.cnf",
         "owner": "aodh",
         "perm": "0644"
+      },
+      {
+        "source": "/var/lib/config-data/mtls/certs/*",
+        "dest": "/etc/pki/tls/certs/",
+        "owner": "aodh:aodh",
+        "perm": "0640",
+        "optional": true,
+        "merge": true
+      },
+      {
+        "source": "/var/lib/config-data/mtls/private/*",
+        "dest": "/etc/pki/tls/private/",
+        "owner": "aodh:aodh",
+        "perm": "0640",
+        "optional": true,
+        "merge": true
       }
     ]
   }

--- a/templates/autoscaling/config/aodh-listener-config.json
+++ b/templates/autoscaling/config/aodh-listener-config.json
@@ -19,6 +19,22 @@
         "dest": "/etc/my.cnf",
         "owner": "aodh",
         "perm": "0644"
+      },
+      {
+        "source": "/var/lib/config-data/mtls/certs/*",
+        "dest": "/etc/pki/tls/certs/",
+        "owner": "aodh:aodh",
+        "perm": "0640",
+        "optional": true,
+        "merge": true
+      },
+      {
+        "source": "/var/lib/config-data/mtls/private/*",
+        "dest": "/etc/pki/tls/private/",
+        "owner": "aodh:aodh",
+        "perm": "0640",
+        "optional": true,
+        "merge": true
       }
     ]
   }

--- a/templates/autoscaling/config/aodh-notifier-config.json
+++ b/templates/autoscaling/config/aodh-notifier-config.json
@@ -19,6 +19,22 @@
         "dest": "/etc/my.cnf",
         "owner": "aodh",
         "perm": "0644"
+      },
+      {
+        "source": "/var/lib/config-data/mtls/certs/*",
+        "dest": "/etc/pki/tls/certs/",
+        "owner": "aodh:aodh",
+        "perm": "0640",
+        "optional": true,
+        "merge": true
+      },
+      {
+        "source": "/var/lib/config-data/mtls/private/*",
+        "dest": "/etc/pki/tls/private/",
+        "owner": "aodh:aodh",
+        "perm": "0640",
+        "optional": true,
+        "merge": true
       }
     ]
   }

--- a/templates/autoscaling/config/aodh.conf
+++ b/templates/autoscaling/config/aodh.conf
@@ -31,8 +31,16 @@ transport_url = {{ .TransportURL }}
 [keystone_authtoken]
 www_authenticate_uri = {{ .KeystoneInternalURL }}
 interface=internal
-memcached_servers={{ .MemcachedServersWithInet }}
+memcached_servers={{ .MemcachedServers }}
+{{- if (index . "MemcachedAuthCert")}}
+memcache_tls_certfile = {{ .MemcachedAuthCert }}
+memcache_tls_keyfile = {{ .MemcachedAuthKey }}
+memcache_tls_cafile = {{ .MemcachedAuthCa }}
+memcache_tls_enabled = true
+memcache_use_advanced_pool = false
+{{- else }}
 memcache_use_advanced_pool=True
+{{- end }}
 auth_type = password
 auth_url = {{ .KeystoneInternalURL }}
 username = {{ .AodhUser }}


### PR DESCRIPTION
This commit allows operators to use mtls as an authentication method against Memcached.
Aodh controller will detect the presence of a purposely-created mtls certificate (authCertSecret) and use this to configure the [keystone_authtoken] section accordingly.
Additional volumes/volumemounts will be appended to each pod.

Note that this commit switches from MemcachedServersWithInet to MemcachedServers since keystone-middleware now uses pymemcache when tls=true and there is no need to use "[]" to enclose the list of memcached servers even for ipv6.