### PR TITLE
Downgrade mysqld-exporter version

### DIFF
--- a/api/v1beta1/ceilometer_types.go
+++ b/api/v1beta1/ceilometer_types.go
@@ -42,7 +42,7 @@ const (
 	// KubeStateMetricsImage - default fall-back image for KSM
 	KubeStateMetricsImage = "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.0"
 	// MysqldExporterImage - default fall-back image for mysqld_exporter
-	MysqldExporterContainerImage = "quay.io/prometheus/mysqld-exporter:v0.16.0"
+	MysqldExporterContainerImage = "quay.io/prometheus/mysqld-exporter:v0.15.1"
 )
 
 // CeilometerSpec defines the desired state of Ceilometer


### PR DESCRIPTION
Downgrade mysqld-exporter default image to 0.15.1 which is the last buildable version with go 1.21.

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1487