### PR TITLE
Add checks to prevent potential panics

### DIFF
--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -1131,11 +1131,21 @@ func getComputeNodesConnectionInfo(
 		if err != nil {
 			return []ConnectionInfo{}, err
 		}
-		nodeSetGroup := inventory.Groups[secret.Labels["openstackdataplanenodeset"]]
+		nodeSetName, exists := secret.Labels["openstackdataplanenodeset"]
+		if !exists {
+			continue // Skip this secret if it doesn't have the required label
+		}
+		nodeSetGroup, exists := inventory.Groups[nodeSetName]
+		if !exists {
+			continue // Skip if the group doesn't exist in inventory
+		}
 		containsTargetService := false
-		for _, svc := range nodeSetGroup.Vars["edpm_services"].([]interface{}) {
-			if svc.(string) == telemetryServiceName {
-				containsTargetService = true
+		if services, ok := nodeSetGroup.Vars["edpm_services"].([]interface{}); ok {
+			for _, svc := range services {
+				if svcStr, ok := svc.(string); ok && svcStr == telemetryServiceName {
+					containsTargetService = true
+					break
+				}
 			}
 		}
 		if !containsTargetService {
@@ -1209,7 +1219,11 @@ func getAddressFromIPSet(
 	item *ansible.Host,
 	helper *helper.Helper,
 ) (string, discoveryv1.AddressType) {
-	ansibleHost := item.Vars["ansible_host"].(string)
+	ansibleHost, ok := item.Vars["ansible_host"].(string)
+	if !ok {
+		helper.GetLogger().Info("ansible_host is not a string or is missing")
+		return "", ""
+	}
 	canonicalHostname, _ := getCanonicalHostname(item)
 	ctlplaneDNSDomain := ""
 
@@ -1242,7 +1256,7 @@ func getAddressFromIPSet(
 				return ansibleHost, discoveryv1.AddressTypeFQDN
 			}
 			// No IP address or valid hostname found anywhere
-			helper.GetLogger().Info("Did not found a valid hostname or IP address")
+			helper.GetLogger().Info("Did not find a valid hostname or IP address")
 			return "", ""
 		}
 	}
@@ -1250,7 +1264,7 @@ func getAddressFromIPSet(
 	if len(ipset.Status.Reservation) > 0 {
 		// search for the network specified in the Spec
 		for _, reservation := range ipset.Status.Reservation {
-			if reservation.Network == *instance.Spec.DataplaneNetwork {
+			if instance.Spec.DataplaneNetwork != nil && reservation.Network == *instance.Spec.DataplaneNetwork {
 				return reservation.Address, discoveryv1.AddressTypeIPv4
 			}
 		}
@@ -1260,7 +1274,10 @@ func getAddressFromIPSet(
 }
 
 func getAddressFromAnsibleHost(item *ansible.Host) (string, discoveryv1.AddressType) {
-	ansibleHost := item.Vars["ansible_host"].(string)
+	ansibleHost, ok := item.Vars["ansible_host"].(string)
+	if !ok {
+		return "", ""
+	}
 	// check if ansiblehost is an IP
 	addr := net.ParseIP(ansibleHost)
 	if addr != nil {


### PR DESCRIPTION
- Use two-return type assertions to check we have correct type
- Check for a variable not being nil before dereferencing
- Check for map item existence before accessing
- Fix log message grammar

Even thought I don't expect these issues to cause problems, unless there is a change in how inventory secrets look, I think this is still an improvement, which doesn't hurt anything. As far as I see, this doesn't change any behavior, which was also confirmed by my local testing. All scrapeconfigs were created correctly, compute node IPs were retrieved like before and I haven't seen any error logs in the operator logs.

Generated-By: cursor with claude-4-sonnet model