### PR TITLE
Use advance pooling driver for MTLS

### DIFF
--- a/templates/autoscaling/config/aodh.conf
+++ b/templates/autoscaling/config/aodh.conf
@@ -32,14 +32,12 @@ transport_url = {{ .TransportURL }}
 www_authenticate_uri = {{ .KeystoneInternalURL }}
 interface=internal
 memcached_servers={{ .MemcachedServers }}
+memcache_use_advanced_pool=True
 {{- if (index . "MemcachedAuthCert")}}
 memcache_tls_certfile = {{ .MemcachedAuthCert }}
 memcache_tls_keyfile = {{ .MemcachedAuthKey }}
 memcache_tls_cafile = {{ .MemcachedAuthCa }}
 memcache_tls_enabled = true
-memcache_use_advanced_pool = false
-{{- else }}
-memcache_use_advanced_pool=True
 {{- end }}
 auth_type = password
 auth_url = {{ .KeystoneInternalURL }}


### PR DESCRIPTION
This commit reworks the keystone_authtoken section to account for the new approach taken in https://review.opendev.org/c/openstack/keystonemiddleware/+/953174 where we use the advance pooling driver for MTLS.