### PR TITLE
OSPRH-16753: Use functional-tests-osp18 as a github-check job

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -138,19 +138,12 @@
       jobs:
         - telemetry-openstack-meta-content-provider-master
         - telemetry-operator-multinode-default-telemetry
-        - functional-graphing-tests-osp18:
-            voting: false
-            required-projects:
-              - name: infrawatch/feature-verification-tests
-                override-checkout: master
-            irrelevant-files: *irrelevant_files
-        - functional-autoscaling-tests-osp18: &fvt_jobs_config
+        - functional-tests-osp18: &fvt_jobs_config
             voting: true
             required-projects:
               - name: infrawatch/feature-verification-tests
                 override-checkout: master
             irrelevant-files: *irrelevant_files
-        - functional-logging-tests-osp18: *fvt_jobs_config
         - feature-verification-tests-noop:
             files: *irrelevant_files
         # TODO: Uncomment once the job merges in FVT


### PR DESCRIPTION
In which PR https://github.com/infrawatch/feature-verification-tests/pull/275, The following `infrawatch/feature-verification-tests` were consolidated in `functional-tests-osp18` job

- autoscaling
- logging
- graphing

Hence, I propose in this PR to use the `functional-tests-osp18` as a `github-check` job for the `telemetry-operator` instead of the `infrawatch/feature-verification-tests` aliases:

- functional-logging-tests-osp18
- functional-autoscaling-tests-osp18
- functional-graphing-tests-osp18