### PR TITLE
[18.0-fr3] Use meta content provider in telemetry-operator

### DIFF
--- a/ci/files/containers.yaml
+++ b/ci/files/containers.yaml
@@ -1,0 +1,17 @@
+---
+# tcib container images used by cloudops team for telemetry testing
+container_images:
+- imagename: quay.rdoproject.org/podified-master-centos10/openstack-aodh-api:current-tested
+- imagename: quay.rdoproject.org/podified-master-centos10/openstack-aodh-evaluator:current-tested
+- imagename: quay.rdoproject.org/podified-master-centos10/openstack-aodh-listener:current-tested
+- imagename: quay.rdoproject.org/podified-master-centos10/openstack-aodh-notifier:current-tested
+- imagename: quay.rdoproject.org/podified-master-centos10/openstack-ceilometer-central:current-tested
+- imagename: quay.rdoproject.org/podified-master-centos10/openstack-ceilometer-compute:current-tested
+- imagename: quay.rdoproject.org/podified-master-centos10/openstack-ceilometer-notification:current-tested
+- imagename: quay.rdoproject.org/podified-master-centos10/openstack-ceilometer-ipmi:current-tested
+- imagename: quay.rdoproject.org/podified-master-centos10/openstack-cloudkitty-api:current-tested
+- imagename: quay.rdoproject.org/podified-master-centos10/openstack-cloudkitty-processor:current-tested
+- imagename: quay.rdoproject.org/podified-master-centos10/openstack-heat-api-cfn:current-tested
+- imagename: quay.rdoproject.org/podified-master-centos10/openstack-heat-api:current-tested
+- imagename: quay.rdoproject.org/podified-master-centos10/openstack-heat-engine:current-tested
+- imagename: quay.rdoproject.org/podified-master-centos10/openstack-tempest-all:current-tested

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,9 +1,27 @@
 - job:
+    name: telemetry-openstack-meta-content-provider-master
+    parent: openstack-meta-content-provider-master
+    description: |
+      A meta content provider zuul job to build telemetry
+      specific containers.
+    vars:
+      cifmw_operator_build_operators:
+        - name: telemetry-operator
+          src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/telemetry-operator"
+        - name: openstack-operator
+          src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-operator"
+      cifmw_build_containers_image_tag: telemetry_latest
+      zuul_project_container_path: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/telemetry-operator/ci/files/containers.yaml"
+      cifmw_build_containers_config_file: "{{ ansible_user_dir }}/containers.yaml"
+      # build tcib containers only when there is opendev depends-on
+      cifmw_build_containers_force: false
+
+- job:
     name: telemetry-operator-multinode-autoscaling
     parent: podified-multinode-edpm-deployment-crc
     dependencies: ["openstack-k8s-operators-content-provider"]
     description: |
-      Deploy OpenStack with Autoscaling features enabled
+      Deploy OpenStack with Autoscaling features enabled.
     vars:
       cifmw_extras:
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir  }}/scenarios/centos-9/multinode-ci.yml"
@@ -41,7 +59,14 @@
     dependencies: ["openstack-k8s-operators-content-provider"]
     description: |
       Deploy a default OpenStack with telemetry enabled, but without COO installed. Check that the telemetry-operator logs don't have any errors.
+    extra-vars: &mcp_extra_vars
+      # Override zuul meta content provider provided content_provider_dlrn_md5_hash
+      # var. As returned dlrn md5 hash comes from master release but job is using
+      # antelope content.
+      content_provider_dlrn_md5_hash: ''
+
     vars:
+      cifmw_update_containers: false
       cifmw_extras:
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir  }}/scenarios/centos-9/multinode-ci.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-default-telemetry.yml"
@@ -113,6 +138,7 @@
                 override-checkout: main
               - name: openstack-k8s-operators/repo-setup
                 override-checkout: main
+        - telemetry-openstack-meta-content-provider-master: *override-missing-fr3-branches
         - telemetry-operator-multinode-default-telemetry: *override-missing-fr3-branches
         - functional-graphing-tests-osp18:
             voting: false


### PR DESCRIPTION
This is a cherry-pick of https://github.com/openstack-k8s-operators/telemetry-operator/pull/715 