### PR TITLE
Set image_base in cifmw_operator_build_operators for meta operator

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -5,11 +5,15 @@
       A meta content provider zuul job to build telemetry
       specific containers.
     vars:
+      # Note(Chandan Kumar): image_base is the operator name without -operator.
+      # It is needed by openstack-operator to include telemetry operator images
+      # in the openstack-operator catalog image.
       cifmw_operator_build_operators:
         - name: telemetry-operator
           src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/telemetry-operator"
         - name: openstack-operator
           src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-operator"
+          image_base: telemetry
       cifmw_build_containers_image_tag: telemetry_latest
       zuul_project_container_path: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/telemetry-operator/ci/files/containers.yaml"
       cifmw_build_containers_config_file: "{{ ansible_user_dir }}/containers.yaml"


### PR DESCRIPTION
image_base is used to specify the operator project name. It is used openstack operator to include telemetry operator catalog image into the openstack-operator catalog image.

Note: It is not needed for standalone operator.

Resolves: OSPCIX-965