### PR TITLE
Use structured logging

### DIFF
--- a/controllers/autoscaling_controller.go
+++ b/controllers/autoscaling_controller.go
@@ -955,7 +955,7 @@ func (r *AutoscalingReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 func (r *AutoscalingReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("Autoscaling")
+	Log := r.GetLogger(ctx)
 
 	for _, field := range autoscalingAllWatchFields {
 		crList := &telemetryv1.AutoscalingList{}
@@ -969,7 +969,7 @@ func (r *AutoscalingReconciler) findObjectsForSrc(ctx context.Context, src clien
 		}
 
 		for _, item := range crList.Items {
-			l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+			Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 			requests = append(requests,
 				reconcile.Request{
@@ -988,7 +988,7 @@ func (r *AutoscalingReconciler) findObjectsForSrc(ctx context.Context, src clien
 func (r *AutoscalingReconciler) findObjectForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("Autoscaling")
+	Log := r.GetLogger(ctx)
 
 	crList := &telemetryv1.AutoscalingList{}
 	listOps := &client.ListOptions{
@@ -996,12 +996,12 @@ func (r *AutoscalingReconciler) findObjectForSrc(ctx context.Context, src client
 	}
 	err := r.Client.List(ctx, crList, listOps)
 	if err != nil {
-		l.Error(err, fmt.Sprintf("listing %s for namespace: %s", crList.GroupVersionKind().Kind, src.GetNamespace()))
+		Log.Error(err, fmt.Sprintf("listing %s for namespace: %s", crList.GroupVersionKind().Kind, src.GetNamespace()))
 		return requests
 	}
 
 	for _, item := range crList.Items {
-		l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+		Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 		requests = append(requests,
 			reconcile.Request{

--- a/controllers/ceilometer_controller.go
+++ b/controllers/ceilometer_controller.go
@@ -1826,7 +1826,7 @@ func (r *CeilometerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 func (r *CeilometerReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("Ceilometer")
+	Log := r.GetLogger(ctx)
 
 	for _, field := range ceilometerWatchFields {
 		crList := &telemetryv1.CeilometerList{}
@@ -1836,12 +1836,12 @@ func (r *CeilometerReconciler) findObjectsForSrc(ctx context.Context, src client
 		}
 		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
-			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			Log.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
 			return requests
 		}
 
 		for _, item := range crList.Items {
-			l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+			Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 			requests = append(requests,
 				reconcile.Request{
@@ -1860,7 +1860,7 @@ func (r *CeilometerReconciler) findObjectsForSrc(ctx context.Context, src client
 func (r *CeilometerReconciler) findObjectForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("Ceilometer")
+	Log := r.GetLogger(ctx)
 
 	crList := &telemetryv1.CeilometerList{}
 	listOps := &client.ListOptions{
@@ -1868,12 +1868,12 @@ func (r *CeilometerReconciler) findObjectForSrc(ctx context.Context, src client.
 	}
 	err := r.Client.List(ctx, crList, listOps)
 	if err != nil {
-		l.Error(err, fmt.Sprintf("listing %s for namespace: %s", crList.GroupVersionKind().Kind, src.GetNamespace()))
+		Log.Error(err, fmt.Sprintf("listing %s for namespace: %s", crList.GroupVersionKind().Kind, src.GetNamespace()))
 		return requests
 	}
 
 	for _, item := range crList.Items {
-		l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+		Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 		requests = append(requests,
 			reconcile.Request{

--- a/controllers/metricstorage_controller.go
+++ b/controllers/metricstorage_controller.go
@@ -1439,7 +1439,7 @@ func (r *MetricStorageReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 func (r *MetricStorageReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(context.Background()).WithName("Controllers").WithName("MetricStorage")
+	Log := r.GetLogger(ctx)
 
 	for _, field := range prometheusAllWatchFields {
 		crList := &telemetryv1.MetricStorageList{}
@@ -1453,7 +1453,7 @@ func (r *MetricStorageReconciler) findObjectsForSrc(ctx context.Context, src cli
 		}
 
 		for _, item := range crList.Items {
-			l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+			Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 			requests = append(requests,
 				reconcile.Request{
@@ -1470,7 +1470,7 @@ func (r *MetricStorageReconciler) findObjectsForSrc(ctx context.Context, src cli
 }
 
 func (r *MetricStorageReconciler) nodeSetWatchFn(ctx context.Context, o client.Object) []reconcile.Request {
-	l := log.FromContext(context.Background()).WithName("Controllers").WithName("MetricStorage")
+	Log := r.GetLogger(ctx)
 	// Reconcile all metricstorages when a nodeset changes
 	result := []reconcile.Request{}
 
@@ -1480,7 +1480,7 @@ func (r *MetricStorageReconciler) nodeSetWatchFn(ctx context.Context, o client.O
 		client.InNamespace(o.GetNamespace()),
 	}
 	if err := r.Client.List(ctx, metricstorages, listOpts...); err != nil {
-		l.Error(err, "Unable to retrieve MetricStorage CRs %v")
+		Log.Error(err, "Unable to retrieve MetricStorage CRs %v")
 		return nil
 	}
 	for _, cr := range metricstorages.Items {


### PR DESCRIPTION
This change uses GetLogger instead of direct use of log.FromContext to support structured logging.