### PR TITLE
[ci] Remove the tempest image configs that we don't need to override

### DIFF
--- a/ci/vars-autoscaling-tempest.yml
+++ b/ci/vars-autoscaling-tempest.yml
@@ -1,9 +1,7 @@
 ---
 cifmw_run_tests: true
 cifmw_run_test_role: test_operator
-cifmw_test_operator_tempest_namespace: podified-antelope-centos9
 cifmw_test_operator_tempest_container: openstack-tempest-all
-cifmw_test_operator_tempest_image_tag: 'current-podified'
 # This value is used to populate the `tempestconfRun` parameter of the Tempest CR: https://openstack-k8s-operators.github.io/test-operator/crds.html#tempest-custom-resource
 # https://github.com/openstack-k8s-operators/ci-framework/blob/main/roles/test_operator/defaults/main.yml
 # Cinder is disabled because the number of replicas is set to 0 by default for cinder volumes.


### PR DESCRIPTION
* cifmw_test_operator_tempest_namespace defaults to `podified-antelope-centos9`
* cifmw_test_operator_tempest_image_tag defaults to `current-podified`

There is no need to override these to set them to the default values.