### PR TITLE
Add test for podlevel TLS with NAD for MetricStorage

### DIFF
--- a/ci/default-telemetry/tasks/main.yml
+++ b/ci/default-telemetry/tasks/main.yml
@@ -25,3 +25,7 @@
 - name: Test CustomMonitoringStack
   ansible.builtin.include_tasks:
     file: test_custom_monitoring_stack.yml
+
+- name: Test podlevel TLS with NAD for MetricStorage
+  ansible.builtin.include_tasks:
+    file: test_podlevel_tls_with_nad_metricstorage.yml

--- a/ci/default-telemetry/tasks/test_podlevel_tls_with_nad_metricstorage.yml
+++ b/ci/default-telemetry/tasks/test_podlevel_tls_with_nad_metricstorage.yml
@@ -1,0 +1,24 @@
+- name: Enable TLS at a pod level
+  ansible.builtin.command:
+    cmd: |
+      oc patch oscp/{{ default_telemetry_control_plane_name }} --type='json' -p '[{"op": "replace", "path": "/spec/tls/podLevel/enabled", "value":true}]'
+
+- name: Set NAD for MetricStorage
+  ansible.builtin.command:
+    cmd: |
+      oc patch oscp/{{ default_telemetry_control_plane_name }} --type='json' -p '[{"op": "replace", "path": "/spec/telemetry/template/metricStorage/networkAttachments", "value":["ctlplane"]}]'
+
+- name: Wait until MetricStorage is ready
+  ansible.builtin.command:
+    cmd:
+      oc wait telemetry telemetry --for=condition=Ready --timeout=2m
+
+- name: Get telemetry-operator logs
+  ansible.builtin.import_tasks: "get-operator-logs.yml"
+
+- name: |
+    TEST Check that telemetry-operator logs don't include any errors when using TLS at a pod level
+    OSPRH-14635
+  ansible.builtin.set_fact:
+    error_list: "{{ operator_logs.stdout | ansible.builtin.regex_findall('ERROR.*') }}"
+  failed_when: error_list | length != 0


### PR DESCRIPTION
This change adds a test case to check that no errors are raised when a NAD is configured for the MetricStorage when podLevel TLS is set to True.

Related Bug: https://issues.redhat.com/browse/OSPRH-14635
Related Bug: https://issues.redhat.com/browse/OSPRH-14663