### PR TITLE
Update metricStorage NAD kuttl tests

### DIFF
--- a/tests/kuttl/suites/tls/tests/03-assert.yaml
+++ b/tests/kuttl/suites/tls/tests/03-assert.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: prometheus-telemetry-kuttl-metricstorage-with-nad-0
+  name: prometheus-telemetry-kuttl-metricstorage-0
   ownerReferences:
   - kind: StatefulSet
-    name: prometheus-telemetry-kuttl-metricstorage-with-nad
+    name: prometheus-telemetry-kuttl-metricstorage
   annotations:
     k8s.v1.cni.cncf.io/networks: '[{"name":"ctlplane","namespace":"openstack","interface":"ctlplane"}]'
 spec:
@@ -18,12 +18,12 @@ spec:
         name: tls-assets
         readOnly: true
       - mountPath: /prometheus
-        name: prometheus-telemetry-kuttl-metricstorage-with-nad-db
+        name: prometheus-telemetry-kuttl-metricstorage-db
       - mountPath: /etc/prometheus/secrets/combined-ca-bundle
         name: secret-combined-ca-bundle
         readOnly: true
-      - mountPath: /etc/prometheus/rules/prometheus-telemetry-kuttl-metricstorage-with-nad-rulefiles-0
-        name: prometheus-telemetry-kuttl-metricstorage-with-nad-rulefiles-0
+      - mountPath: /etc/prometheus/rules/prometheus-telemetry-kuttl-metricstorage-rulefiles-0
+        name: prometheus-telemetry-kuttl-metricstorage-rulefiles-0
       - mountPath: /etc/prometheus/web_config/web-config.yaml
         name: web-config
         readOnly: true

--- a/tests/kuttl/suites/tls/tests/03-assert.yaml
+++ b/tests/kuttl/suites/tls/tests/03-assert.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: prometheus-telemetry-kuttl-metricstorage-0
+  ownerReferences:
+  - kind: StatefulSet
+    name: prometheus-telemetry-kuttl-metricstorage
+  annotations:
+    k8s.v1.cni.cncf.io/networks: '[{"name":"ctlplane","namespace":"openstack","interface":"ctlplane"}]'
+spec:
+    containers:
+    - name: prometheus
+      volumeMounts:
+      - mountPath: /etc/prometheus/config_out
+        name: config-out
+        readOnly: true
+      - mountPath: /etc/prometheus/certs
+        name: tls-assets
+        readOnly: true
+      - mountPath: /prometheus
+        name: prometheus-telemetry-kuttl-metricstorage-db
+      - mountPath: /etc/prometheus/secrets/combined-ca-bundle
+        name: secret-combined-ca-bundle
+        readOnly: true
+      - mountPath: /etc/prometheus/rules/prometheus-telemetry-kuttl-metricstorage-rulefiles-0
+        name: prometheus-telemetry-kuttl-metricstorage-rulefiles-0
+      - mountPath: /etc/prometheus/web_config/web-config.yaml
+        name: web-config
+        readOnly: true
+        subPath: web-config.yaml
+      - mountPath: /etc/prometheus/web_config/secret/cert-metric-storage-prometheus-svc-key
+        readOnly: true
+      - mountPath: /etc/prometheus/web_config/secret/cert-metric-storage-prometheus-svc-cert
+        readOnly: true
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        readOnly: true
+    - name: config-reloader
+    - name: thanos-sidecar

--- a/tests/kuttl/suites/tls/tests/03-assert.yaml
+++ b/tests/kuttl/suites/tls/tests/03-assert.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: prometheus-telemetry-kuttl-metricstorage-0
+  name: prometheus-telemetry-kuttl-metricstorage-with-nad-0
   ownerReferences:
   - kind: StatefulSet
-    name: prometheus-telemetry-kuttl-metricstorage
+    name: prometheus-telemetry-kuttl-metricstorage-with-nad
   annotations:
     k8s.v1.cni.cncf.io/networks: '[{"name":"ctlplane","namespace":"openstack","interface":"ctlplane"}]'
 spec:
@@ -18,12 +18,12 @@ spec:
         name: tls-assets
         readOnly: true
       - mountPath: /prometheus
-        name: prometheus-telemetry-kuttl-metricstorage-db
+        name: prometheus-telemetry-kuttl-metricstorage-with-nad-db
       - mountPath: /etc/prometheus/secrets/combined-ca-bundle
         name: secret-combined-ca-bundle
         readOnly: true
-      - mountPath: /etc/prometheus/rules/prometheus-telemetry-kuttl-metricstorage-rulefiles-0
-        name: prometheus-telemetry-kuttl-metricstorage-rulefiles-0
+      - mountPath: /etc/prometheus/rules/prometheus-telemetry-kuttl-metricstorage-with-nad-rulefiles-0
+        name: prometheus-telemetry-kuttl-metricstorage-with-nad-rulefiles-0
       - mountPath: /etc/prometheus/web_config/web-config.yaml
         name: web-config
         readOnly: true

--- a/tests/kuttl/suites/tls/tests/03-assert.yaml
+++ b/tests/kuttl/suites/tls/tests/03-assert.yaml
@@ -6,7 +6,7 @@ metadata:
   - kind: StatefulSet
     name: prometheus-telemetry-kuttl-metricstorage
   annotations:
-    k8s.v1.cni.cncf.io/networks: '[{"name":"ctlplane","namespace":"openstack","interface":"ctlplane"}]'
+    k8s.v1.cni.cncf.io/networks: '[{"name":"ctlplane","namespace":"telemetry-kuttl-tests","interface":"ctlplane"}]'
 spec:
     containers:
     - name: prometheus

--- a/tests/kuttl/suites/tls/tests/03-configure-nad-metricstorage.yaml
+++ b/tests/kuttl/suites/tls/tests/03-configure-nad-metricstorage.yaml
@@ -2,10 +2,8 @@
 apiVersion: telemetry.openstack.org/v1beta1
 kind: MetricStorage
 metadata:
-  name: telemetry-kuttl
+  name: telemetry-kuttl-metricstorage
 spec:
-  dashboardsEnabled: true
-  dataplaneNetwork: ctlplane
   monitoringStack:
     alertingEnabled: true
     scrapeInterval: 30s
@@ -14,3 +12,9 @@ spec:
       retention: 24h
       persistent:
         pvcStorageRequest: 20G
+  prometheusTls:
+    caBundleSecretName: combined-ca-bundle
+    secretName: cert-metric-storage-prometheus-svc
+  dataplaneNetwork: ctlplane
+  networkAttachments:
+  - ctlplane

--- a/tests/kuttl/suites/tls/tests/03-configure-nad-metricstorage.yaml
+++ b/tests/kuttl/suites/tls/tests/03-configure-nad-metricstorage.yaml
@@ -1,18 +1,28 @@
-# Kuttl test doesn't seem to wait correctly for the metric
-# storage to reconcile when enabling the NAD
-# Deleting it here and than recreating it in the next step
-# should ensure kuttl waits long enough.
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-delete:
-  - apiVersion: telemetry.openstack.org/v1beta1
-    kind: MetricStorage
-    name: telemetry-kuttl-metricstorage
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  labels:
+    osp/net: ctlplane
+  name: ctlplane
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "ctlplane",
+      "type": "macvlan",
+      "master": "enp7s0",
+      "ipam": {
+        "type": "whereabouts",
+        "range": "172.20.250.0/24",
+        "range_start": "172.20.250.30",
+        "range_end": "172.20.250.70"
+      }
+    }
 ---
 apiVersion: telemetry.openstack.org/v1beta1
 kind: MetricStorage
 metadata:
-  name: telemetry-kuttl-metricstorage-with-nad
+  name: telemetry-kuttl-metricstorage
 spec:
   monitoringStack:
     alertingEnabled: true

--- a/tests/kuttl/suites/tls/tests/03-configure-nad-metricstorage.yaml
+++ b/tests/kuttl/suites/tls/tests/03-configure-nad-metricstorage.yaml
@@ -1,8 +1,18 @@
+# Kuttl test doesn't seem to wait correctly for the metric
+# storage to reconcile when enabling the NAD
+# Deleting it here and than recreating it in the next step
+# should ensure kuttl waits long enough.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: telemetry.openstack.org/v1beta1
+    kind: MetricStorage
+    name: telemetry-kuttl
 ---
 apiVersion: telemetry.openstack.org/v1beta1
 kind: MetricStorage
 metadata:
-  name: telemetry-kuttl-metricstorage
+  name: telemetry-kuttl-metricstorage-with-nad
 spec:
   monitoringStack:
     alertingEnabled: true

--- a/tests/kuttl/suites/tls/tests/03-configure-nad-metricstorage.yaml
+++ b/tests/kuttl/suites/tls/tests/03-configure-nad-metricstorage.yaml
@@ -7,7 +7,7 @@ kind: TestStep
 delete:
   - apiVersion: telemetry.openstack.org/v1beta1
     kind: MetricStorage
-    name: telemetry-kuttl
+    name: telemetry-kuttl-metricstorage
 ---
 apiVersion: telemetry.openstack.org/v1beta1
 kind: MetricStorage


### PR DESCRIPTION
Drop NAD config from deploy-edpm-resources

Add configure-nad-metricstorage test which covers the scenario in which TLS is enabled and a NAD is set for a metricStorage.

Related Bug: https://issues.redhat.com/browse/OSPRH-14663