### PR TITLE
[ci] Use smoke param for tempest test configs

### DIFF
--- a/ci/vars-autoscaling-tempest.yml
+++ b/ci/vars-autoscaling-tempest.yml
@@ -23,8 +23,8 @@ tempest_conf:
       telemetry.alarm_threshold 50000000000
 cifmw_tempest_tempestconf_config: "{{ tempest_conf }}"
 cifmw_test_operator_tempest_tempestconf_config: "{{ tempest_conf }}"
+cifmw_test_operator_tempest_smoke: true
 cifmw_test_operator_tempest_include_list: |
-  ^tempest.*\[.*\bsmoke\b.*\]
   telemetry_tempest_plugin.scenario
   telemetry_tempest_plugin.aodh
 cifmw_test_operator_tempest_exclude_list: |


### PR DESCRIPTION
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3184