### PR TITLE
Update logging operators for OCP 4.16

### DIFF
--- a/ci/deploy-logging-dependencies/files/operators.yaml
+++ b/ci/deploy-logging-dependencies/files/operators.yaml
@@ -35,7 +35,7 @@ metadata:
   name: loki-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: stable-6.1
+  channel: stable-6.2
   installPlanApproval: Automatic
   name: loki-operator
   source: redhat-operators
@@ -47,7 +47,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: stable-6.1
+  channel: stable-6.2
   installPlanApproval: Automatic
   name: cluster-logging
   source: redhat-operators


### PR DESCRIPTION
Update to the latest logging operators for OCP 4.16
- cluster-logging
- loki-operator