### PR TITLE
Extend loki timeout

### DIFF
--- a/ci/deploy-logging-dependencies/tasks/deploy-loki.yml
+++ b/ci/deploy-logging-dependencies/tasks/deploy-loki.yml
@@ -19,5 +19,10 @@
 
 - name: Wait for the lokistack to be ready
   ansible.builtin.command:
-    cmd: |
-      oc wait --timeout=500s --for condition=Ready=True --namespace=openshift-logging lokistacks logging-loki
+    cmd: >
+      oc get lokistack logging-loki -n openshift-logging
+      -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+  register: loki_ready
+  until: loki_ready.stdout == "True"
+  retries: 40 
+  delay: 15

--- a/ci/deploy-logging-dependencies/tasks/deploy-loki.yml
+++ b/ci/deploy-logging-dependencies/tasks/deploy-loki.yml
@@ -24,5 +24,5 @@
       -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
   register: loki_ready
   until: loki_ready.stdout == "True"
-  retries: 40 
+  retries: 40
   delay: 15


### PR DESCRIPTION
 Sometimes logging deployment fails and as a result it fails the job. It fails on timeout when deploying loki.
 it seems all the pod is up and running as expected ,so I assume we can update the ansible task instead of using oc wait to use retry and delay  