### PR TITLE
Add ck-build-containers target to build unmerged CloudKitty changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -417,3 +417,8 @@ PHONY: crd-schema-check
 crd-schema-check: manifests
 	INSTALL_DIR=$(LOCALBIN) CRD_SCHEMA_CHECKER_VERSION=$(CRD_SCHEMA_CHECKER_VERSION) hack/build-crd-schema-checker.sh
 	INSTALL_DIR=$(LOCALBIN) BASE_REF="$${PULL_BASE_SHA:-$(BRANCH)}" hack/crd-schema-checker.sh
+
+.PHONY: ck-build-containers
+ck-build-containers:
+	podman build -f ci/cloudkitty-api.containerfile -t $(CK_IMAGE_REGISTRY)cloudkitty-api --build-arg CK_BRANCH=$(CK_BRANCH)
+	podman build -f ci/cloudkitty-proc.containerfile -t $(CK_IMAGE_REGISTRY)cloudkitty-processor --build-arg CK_BRANCH=$(CK_BRANCH)

--- a/README.md
+++ b/README.md
@@ -293,6 +293,31 @@ If you need to connect directly to the CRC VM just use
 ssh -i ~/.crc/machines/crc/id_ecdsa core@"192.168.130.11"
 ```
 
+## Building CloudKitty images with WIP code
+
+If you want to test a version of Cloudkitty that is not yet merged, you can build the containers locally and push them to some image registry (e.g. an account on quay.io)
+
+```bash
+export CK_BRANCH=<some branch>  # e.g. refs/changes/68/950868/9
+
+make ck-build-containers
+```
+
+Tag and push the container to your registry
+
+```bash
+podman push cloudkitty-api <image-registry>
+podman push cloudkitty-processor <image-registry>
+```
+
+To use the new images, edit the telemetry or cloudkitty CR to set the image URLs
+
+```
+oc patch telemetry telemetry --type='json' -p='[{"op": "replace", "path": "/spec/cloudkitty/cloudKittyAPI/containerImage", "value": <CK_API_IMAGE>}]'
+oc patch telemetry telemetry --type='json' -p='[{"op": "replace", "path": "/spec/cloudkitty/cloudKittyProc/containerImage", "value": <CK_PROC_IMAGE>}]'
+
+```
+
 ## License
 
 ```text

--- a/ci/cloudkitty-api.containerfile
+++ b/ci/cloudkitty-api.containerfile
@@ -1,0 +1,7 @@
+FROM quay.rdoproject.org/podified-master-centos10/openstack-cloudkitty-api:current-tested
+
+ARG CK_REPO="git+https://review.opendev.org/openstack/cloudkitty"
+ARG CK_BRANCH=master
+
+RUN python3 -m ensurepip && python3 -m pip install --prefix=/usr $CK_REPO@$CK_BRANCH
+

--- a/ci/cloudkitty-api.containerfile
+++ b/ci/cloudkitty-api.containerfile
@@ -3,5 +3,6 @@ FROM quay.rdoproject.org/podified-master-centos10/openstack-cloudkitty-api:curre
 ARG CK_REPO="git+https://review.opendev.org/openstack/cloudkitty"
 ARG CK_BRANCH=master
 
+RUN rm -rf /usr/lib/python3.12/site-packages/cloudkitty
 RUN python3 -m ensurepip && python3 -m pip install --prefix=/usr $CK_REPO@$CK_BRANCH
 

--- a/ci/cloudkitty-proc.containerfile
+++ b/ci/cloudkitty-proc.containerfile
@@ -4,5 +4,6 @@ ARG CK_REPO="git+https://review.opendev.org/openstack/cloudkitty"
 ARG CK_BRANCH=master
 
 USER root
+RUN rm -rf /usr/lib/python3.12/site-packages/cloudkitty
 RUN python3 -m ensurepip && python3 -m pip install --prefix=/usr $CK_REPO@$CK_BRANCH
 USER cloudkitty

--- a/ci/cloudkitty-proc.containerfile
+++ b/ci/cloudkitty-proc.containerfile
@@ -1,0 +1,8 @@
+FROM quay.rdoproject.org/podified-master-centos10/openstack-cloudkitty-processor:current-tested
+
+ARG CK_REPO="git+https://review.opendev.org/openstack/cloudkitty"
+ARG CK_BRANCH=master
+
+USER root
+RUN python3 -m ensurepip && python3 -m pip install --prefix=/usr $CK_REPO@$CK_BRANCH
+USER cloudkitty


### PR DESCRIPTION
This allows testing the opens reviews in telemetry-operator