### PR TITLE
[CI] Add test prom_secret to default telemetry job

### DIFF
--- a/ci/default-telemetry/tasks/main.yml
+++ b/ci/default-telemetry/tasks/main.yml
@@ -29,3 +29,7 @@
 - name: Test podlevel TLS with NAD for MetricStorage
   ansible.builtin.include_tasks:
     file: test_podlevel_tls_with_nad_metricstorage.yml
+
+- name: Test Prometheus_secret values
+  ansible.builtin.include_tasks:
+    file: test_prometheus_secret.yml

--- a/ci/default-telemetry/tasks/test_prometheus_secret.yml
+++ b/ci/default-telemetry/tasks/test_prometheus_secret.yml
@@ -1,0 +1,20 @@
+- name: Get metric-storage-prometheus-endpoint secret values
+  ansible.builtin.shell: |
+    oc get secret metric-storage-prometheus-endpoint -n openstack -o json \
+    | jq -r '.data | to_entries[] | "\(.key)=\(.value|@base64d)"'
+  register: secret_output
+  changed_when: false
+
+- name: Show secret decoded values
+  ansible.builtin.debug:
+    var: secret_output.stdout_lines
+
+- name: Assert secret contains expected values
+  ansible.builtin.assert:
+    that:
+      - "'ca_key=ca.crt' in secret_output.stdout_lines"
+      - "'ca_secret=cert-metric-storage-prometheus-svc' in secret_output.stdout_lines"
+      - "'host=metric-storage-prometheus.openstack.svc' in secret_output.stdout_lines"
+      - "'port=9090' in secret_output.stdout_lines"
+    fail_msg: "Secret metric-storage-prometheus-endpoint is missing required values"
+    success_msg: "Secret metric-storage-prometheus-endpoint contains all required values"


### PR DESCRIPTION
This change ensures that during the test, the metric-storage-prometheus-endpoint secret is properly validated and matches the expected structure. which can verifies that the Prometheus endpoint is correctly exposed
and also confirms that the CA certificate, secret reference, host, and port are correctly set for secure access to Prometheus.