### PR TITLE
Small cleanup of cifmw_tempest_tempestconf_config

### DIFF
--- a/ci/vars-autoscaling-tempest.yml
+++ b/ci/vars-autoscaling-tempest.yml
@@ -19,7 +19,6 @@ tempest_conf:
       telemetry.ceilometer_polling_interval 120
       telemetry.prometheus_scrape_interval 30
       telemetry.alarm_threshold 50000000000
-cifmw_tempest_tempestconf_config: "{{ tempest_conf }}"
 cifmw_test_operator_tempest_tempestconf_config: "{{ tempest_conf }}"
 cifmw_test_operator_tempest_include_list: |
   ^tempest.*\[.*\bsmoke\b.*\]


### PR DESCRIPTION
The cifmw_tempest_tempestconf_config has been deprecated for a while, so I am removing it from every repository. The alternative is already used, so only a small cleanup is needed here.

Depends-On: https://github.com/openstack-k8s-operators/telemetry-operator/pull/757