### PR TITLE
[ci] Force metacontent provider to always rebuild the container images

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -136,7 +136,10 @@
       - podified-multinode-edpm-pipeline
     github-check:
       jobs:
-        - telemetry-openstack-meta-content-provider-master
+        - telemetry-openstack-meta-content-provider-master:
+            vars:
+              # temp workaround for expired :current-tested tag on ceilometer-compute images
+              cifmw_build_containers_force: true
         - telemetry-operator-multinode-default-telemetry
         - functional-tests-osp18: &fvt_jobs_config
             voting: true


### PR DESCRIPTION
The current-tested tag expired from the openstack-ceilometer-compute image on quay.rdoproject.org/podified-master-centos10, which causes the edpm deployment to fail, since the image is not available.

This is being temperorily worked around by forcing the meta-content provider to always build and use all the telemetry images.

This is not an ideal solution, since the image builds take time, and this increases the overall buildset duration.