### PR TITLE
Modernize Go code with latest style conventions

### DIFF
--- a/controllers/logging_controller.go
+++ b/controllers/logging_controller.go
@@ -294,7 +294,7 @@ func (r *LoggingReconciler) generateComputeServiceConfig(
 		instance.Spec.RsyslogQueueType = "linkedList"
 	}
 
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"RsyslogAddress":   service.Annotations["metallb.universe.tf/loadBalancerIPs"],
 		"RsyslogPort":      instance.Spec.Port,
 		"RsyslogRetries":   instance.Spec.RsyslogRetries,

--- a/controllers/telemetry_common.go
+++ b/controllers/telemetry_common.go
@@ -34,7 +34,7 @@ import (
 
 type conditionUpdater interface {
 	Set(c *condition.Condition)
-	MarkTrue(t condition.Type, messageFormat string, messageArgs ...interface{})
+	MarkTrue(t condition.Type, messageFormat string, messageArgs ...any)
 }
 
 type topologyHandler interface {

--- a/pkg/metricstorage/scrape_config.go
+++ b/pkg/metricstorage/scrape_config.go
@@ -37,7 +37,7 @@ type LabeledTarget struct {
 func ScrapeConfig(
 	instance *telemetryv1.MetricStorage,
 	labels map[string]string,
-	targets interface{},
+	targets any,
 	tlsEnabled bool,
 ) *monv1alpha1.ScrapeConfig {
 	var scrapeInterval monv1.Duration


### PR DESCRIPTION
Modernize using `gopls modernize tool` to update:

- Replace interface{} with any type alias (Go 1.18+)
- Update range loops to use idiomatic range syntax
- Replace fmt.Sprintf with fmt.Appendf where appropriate

These changes improve code readability and align with current Go best practices.

Co-Authored-By: Claude <noreply@anthropic.com>