### PR TITLE
[OSPRH-20452] Improve consistency of condition severity usage

### DIFF
--- a/controllers/aodh_controller.go
+++ b/controllers/aodh_controller.go
@@ -536,10 +536,12 @@ func (r *AutoscalingReconciler) reconcileNormalAodh(
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.Aodh.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}

--- a/controllers/autoscaling_controller.go
+++ b/controllers/autoscaling_controller.go
@@ -373,11 +373,16 @@ func (r *AutoscalingReconciler) reconcileNormal(
 	memcached, err := memcachedv1.GetMemcachedByName(ctx, helper, instance.Spec.Aodh.MemcachedInstance, instance.Namespace)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			// Memcached should be automatically created by the encompassing OpenStackControlPlane,
+			// but we don't propagate its name into the "memcachedInstance" field of other sub-resources,
+			// so if it is missing at this point, it *could* be because there's a mismatch between the
+			// name of the Memcached CR and the name of the Memcached instance referenced by this CR.
+			// Since that situation would block further reconciliation, we treat it as a warning.
 			Log.Info(fmt.Sprintf("memcached %s not found", instance.Spec.Aodh.MemcachedInstance))
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.MemcachedReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
+				condition.ErrorReason,
+				condition.SeverityWarning,
 				condition.MemcachedReadyWaitingMessage))
 			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 		}
@@ -410,11 +415,16 @@ func (r *AutoscalingReconciler) reconcileNormal(
 	heat, err := r.getAutoscalingHeat(ctx, helper, instance)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			// Heat should be automatically created by the encompassing OpenStackControlPlane,
+			// but if it is missing at this point, it could be because there's a mismatch between the
+			// name of the Heat CR and the name referenced in the autoscaling instance spec, or
+			// that the user somehow disabled the Heat service.  Since that situation would block
+			// further reconciliation, we treat it as a warning.
 			Log.Info(fmt.Sprintf("heat %s not found", instance.Spec.HeatInstance))
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				telemetryv1.HeatReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
+				condition.ErrorReason,
+				condition.SeverityWarning,
 				telemetryv1.HeatReadyNotFoundMessage))
 			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 		}

--- a/controllers/ceilometer_controller.go
+++ b/controllers/ceilometer_controller.go
@@ -617,10 +617,12 @@ func (r *CeilometerReconciler) reconcileCeilometer(
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
@@ -847,10 +849,12 @@ func (r *CeilometerReconciler) reconcileMysqldExporter(
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					telemetryv1.MysqldExporterTLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.MysqldExporterTLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
@@ -873,6 +877,8 @@ func (r *CeilometerReconciler) reconcileMysqldExporter(
 		hash, err := instance.Spec.MysqldExporterTLS.ValidateCertSecret(ctx, helper, instance.Namespace)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the TLS cert secret should have been automatically created by the encompassing OpenStackControlPlane,
+				// we treat this as an info.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					telemetryv1.MysqldExporterTLSInputReadyCondition,
 					condition.RequestedReason,
@@ -1026,10 +1032,12 @@ func (r *CeilometerReconciler) reconcileKSM(
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA cert secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					telemetryv1.KSMTLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.KSMTLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}

--- a/controllers/telemetry_common.go
+++ b/controllers/telemetry_common.go
@@ -118,11 +118,14 @@ func ensureSecret(
 			err.Error()))
 		return "", res, err
 	} else if (res != ctrl.Result{}) {
+		// Since some of the secrets for which the function is used should have been manually
+		// created by the user and referenced in the spec, we treat this as a warning because
+		// it means that the associated service will not be able to start.
 		log.FromContext(ctx).Info(fmt.Sprintf("OpenStack secret %s not found", secretName))
 		conditionUpdater.Set(condition.FalseCondition(
 			condition.InputReadyCondition,
-			condition.RequestedReason,
-			condition.SeverityInfo,
+			condition.ErrorReason,
+			condition.SeverityWarning,
 			condition.InputReadyWaitingMessage))
 		return "", res, nil
 	}


### PR DESCRIPTION
Use consistent condition severity across repeated patterns found in our operators, and otherwise use an appropriate severity for conditions unique to each operator.

Jira: https://issues.redhat.com/browse/OSPRH-20452

Co-authored-by: Claude (Anthropic) [claude@anthropic.com](mailto:claude@anthropic.com)