### PR TITLE
Wait for route CRD before deploying loki-operator

### DIFF
--- a/ci/cloudkitty-pre_deploy-install_loki.yml
+++ b/ci/cloudkitty-pre_deploy-install_loki.yml
@@ -14,6 +14,15 @@
             github.com/openstack-k8s-operators/telemetry-operator:
               src_dir: "{{ telemetry_operator_dir | default('telemetry-operator/') }}"
 
+    - name: Wait for the route kind to be present in the cluster
+      ansible.builtin.command:
+        cmd:
+          oc api-resources --api-group=route.openshift.io --no-headers
+      delay: 10
+      retries: 30
+      register: route_api_check
+      until: route_api_check.stdout_lines | length != 0
+
     - name: Deploy loki operator
       ansible.builtin.shell:
         cmd: |


### PR DESCRIPTION
Same fix as we already have for logging introduced in: https://github.com/openstack-k8s-operators/telemetry-operator/pull/657

Generated-By: Claude-Code claude-opus-4-6