### PR TITLE
[imagePullPolicy] Switch imagePullPolicy from Always to IfNotPresent

### DIFF
--- a/internal/autoscaling/aodh_statefulset.go
+++ b/internal/autoscaling/aodh_statefulset.go
@@ -136,7 +136,7 @@ func AodhStatefulSet(
 	var replicas int32 = 1
 
 	apiContainer := corev1.Container{
-		ImagePullPolicy: corev1.PullAlways,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command: []string{
 			"/bin/bash",
 		},
@@ -148,7 +148,7 @@ func AodhStatefulSet(
 	}
 
 	evaluatorContainer := corev1.Container{
-		ImagePullPolicy: corev1.PullAlways,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command: []string{
 			"/bin/bash",
 		},
@@ -160,7 +160,7 @@ func AodhStatefulSet(
 	}
 
 	notifierContainer := corev1.Container{
-		ImagePullPolicy: corev1.PullAlways,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command: []string{
 			"/bin/bash",
 		},
@@ -172,7 +172,7 @@ func AodhStatefulSet(
 	}
 
 	listenerContainer := corev1.Container{
-		ImagePullPolicy: corev1.PullAlways,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command: []string{
 			"/bin/bash",
 		},

--- a/internal/availability/statefulset.go
+++ b/internal/availability/statefulset.go
@@ -125,7 +125,7 @@ func KSMStatefulSet(
 	}
 
 	container := corev1.Container{
-		ImagePullPolicy: corev1.PullAlways,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 		Image:           instance.Spec.KSMImage,
 		Name:            KSMServiceName,
 		Args:            args,

--- a/internal/ceilometer/statefulset.go
+++ b/internal/ceilometer/statefulset.go
@@ -137,7 +137,7 @@ func StatefulSet(
 	}
 
 	centralAgentContainer := corev1.Container{
-		ImagePullPolicy: corev1.PullAlways,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command: []string{
 			"/bin/bash",
 		},
@@ -149,7 +149,7 @@ func StatefulSet(
 		LivenessProbe: centralLivenessProbe,
 	}
 	notificationAgentContainer := corev1.Container{
-		ImagePullPolicy: corev1.PullAlways,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command: []string{
 			"/bin/bash",
 		},
@@ -161,7 +161,7 @@ func StatefulSet(
 		LivenessProbe: notificationLivenessProbe,
 	}
 	sgCoreContainer := corev1.Container{
-		ImagePullPolicy: corev1.PullAlways,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 		Image:           instance.Spec.SgCoreImage,
 		Name:            "sg-core",
 		VolumeMounts:    getSgCoreVolumeMounts(),
@@ -175,7 +175,7 @@ func StatefulSet(
 		},
 	}
 	proxyContainer := corev1.Container{
-		ImagePullPolicy: corev1.PullAlways,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 		Image:           instance.Spec.ProxyImage,
 		Name:            "proxy-httpd",
 		Ports: []corev1.ContainerPort{{

--- a/internal/mysqldexporter/statefulset.go
+++ b/internal/mysqldexporter/statefulset.go
@@ -100,7 +100,7 @@ func StatefulSet(
 	}
 
 	mysqldExporterContainer := corev1.Container{
-		ImagePullPolicy: corev1.PullAlways,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 		Args:            args,
 		Image:           instance.Spec.MysqldExporterImage,
 		Name:            ServiceName,


### PR DESCRIPTION
Use `PullIfNotPresent` instead of` PullAlways` for container image pull policy in aodh, ceilometer, availability, and mysqld-exporter statefulsets to avoid unnecessary image pulls.

Jira: https://redhat.atlassian.net/browse/OSPRH-28872