### PR TITLE
Improved sample alerts.

### DIFF
--- a/docs/sample-alerts/openstack-observability-services-status.yaml
+++ b/docs/sample-alerts/openstack-observability-services-status.yaml
@@ -12,7 +12,7 @@ spec:
       - alert: OpenStackServicesDownWarning
         expr: |
           (
-            max(kube_pod_info{created_by_kind=~"ReplicaSet|StatefulSet|OpenStackClient"} * on(uid) group_left(phase) kube_pod_status_phase{phase="Running"}) == 1
+            kube_pod_info{created_by_kind=~"ReplicaSet|StatefulSet|OpenStackClient"} * on(uid) group_left(phase) (kube_pod_status_phase{phase!="Running"} == 1)
           )
         for: 10s
         labels:
@@ -20,11 +20,13 @@ spec:
         annotations:
           summary: "RHOSO component down (warning)"
           description: |
-            At least one of the RHOSO services is down for more than 10 seconds.
+            Pod {{ $labels.pod }} (controlled by {{ $labels.created_by_name }}) in namespace {{ $labels.namespace }} is not Running.
+            Current state: {{ $labels.phase }}
+            This has been the case for more than 10 seconds.
       - alert: OpenStackServicesDownCritical
         expr: |
           (
-            max(kube_pod_info{created_by_kind=~"ReplicaSet|StatefulSet|OpenStackClient"} * on(uid) group_left(phase) kube_pod_status_phase{phase="Running"}) == 1
+            kube_pod_info{created_by_kind=~"ReplicaSet|StatefulSet|OpenStackClient"} * on(uid) group_left(phase) (kube_pod_status_phase{phase!="Running"} == 1)
           )
         for: 60s
         labels:
@@ -32,7 +34,9 @@ spec:
         annotations:
           summary: "RHOSO component down (critical)"
           description: |
-            At least one of the RHOSO services is down for more than 1 minute.
+            Pod {{ $labels.pod }} (controlled by {{ $labels.created_by_name }}) in namespace {{ $labels.namespace }} is not Running.
+            Current state: {{ $labels.phase }}
+            This has been the case for more than 1 minute.
     - name: openstack-observability.scrapeconfig.status
       rules:
       - alert: OpenStackObservabilityDownWarning


### PR DESCRIPTION
This patch makes our sample alert queries match the better ones from our KB article[1].

* These alerts give more specific information about what component is not running
* I've tried them in my own setup and the results look correct to me
* Credit to @vkmc on the queries, I'm just making things the same

[1] https://access.redhat.com/articles/7132715