### PR TITLE
[OSPRH-29177] Add Zuul job and Ansible role for CADF audit logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ This operator deploys a multiple telemetry agents, both in the control plane and
     ansible-playbook ci/deploy-logging-dependencies.yml --tags clo
     ```
 
+    4.e. Enable CADF audit logging for OpenStack services (barbican, cinder, glance, keystone, neutron, nova):
+
+    NOTE: This should be run after OpenStack is deployed (step 3).
+
+    ```bash
+    ansible-playbook ci/enable-audit-logging.yml -e enable_audit_logging_local_apply=true
+    ```
+
     4.d. Update openstack services
 
     NOTE: This can be done later except for updating ceilometer, which should be done before deploying the dataplane.

--- a/README.md
+++ b/README.md
@@ -59,14 +59,6 @@ This operator deploys a multiple telemetry agents, both in the control plane and
     ansible-playbook ci/deploy-logging-dependencies.yml --tags clo
     ```
 
-    4.e. Enable CADF audit logging for OpenStack services (barbican, cinder, glance, keystone, neutron, nova):
-
-    NOTE: This should be run after OpenStack is deployed (step 3).
-
-    ```bash
-    ansible-playbook ci/enable-audit-logging.yml -e enable_audit_logging_local_apply=true
-    ```
-
     4.d. Update openstack services
 
     NOTE: This can be done later except for updating ceilometer, which should be done before deploying the dataplane.
@@ -77,6 +69,12 @@ This operator deploys a multiple telemetry agents, both in the control plane and
     oc patch --type merge openstackversions openstack-galera-network-isolation --patch-file=ci/files/master-cloudkitty-patch.yaml # required for cloudkitty
     oc patch --type merge openstackversions openstack-galera-network-isolation --patch-file=ci/files/master-heat-patch.yaml # required for autoscaling
     oc patch --type merge openstackversions openstack-galera-network-isolation --patch-file=ci/files/master-openstackclient-patch.yaml # required for "openstack metric" commands to work correctly
+    ```
+
+    4.e. Enable CADF audit logging for OpenStack services (barbican, cinder, glance, keystone, neutron, nova):
+
+    ```bash
+    ansible-playbook ci/enable-audit-logging.yml -e enable_audit_logging_local_apply=true
     ```
 
     Return to the install_yamls directory before continuing.

--- a/ci/enable-audit-logging.yml
+++ b/ci/enable-audit-logging.yml
@@ -1,0 +1,11 @@
+---
+- name: "Enable audit logging for OpenStack services"
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig | default(ansible_env.HOME + '/.kube/config') }}"
+    PATH: "{{ cifmw_path | default(ansible_env.PATH) }}"
+  tasks:
+    - name: Enable audit logging
+      ansible.builtin.import_role:
+        name: enable-audit-logging

--- a/ci/enable-audit-logging/README.md
+++ b/ci/enable-audit-logging/README.md
@@ -1,0 +1,46 @@
+enable-audit-logging
+=========
+
+A role for enabling CADF audit logging on OpenStack services deployed by openstack-k8s-operators. The role creates the necessary audit configuration secrets and applies kustomizations to the OpenStackControlPlane CR.
+
+Currently supported services:
+- Cinder
+- Glance
+- Keystone
+- Neutron
+
+Services not yet supported (config files included for future use):
+- Barbican (blocked by [OSPRH-25781](https://issues.redhat.com/browse/OSPRH-25781))
+- Nova (blocked by a nova-operator issue with audit map file naming)
+
+Audit map files
+----------------
+The `*_api_audit_map.conf` files in `files/` are copies of the upstream pycadf defaults from https://github.com/openstack/pycadf/tree/master/etc/pycadf. If the upstream files change, the local copies should be updated to match.
+
+Requirements
+------------
+- An OpenStack deployed with the openstack-k8s-operators
+- `oc` CLI configured with cluster access
+
+Side effects
+------------
+After the role runs, the following secrets are created in the `openstack` namespace:
+- `cinder-audit-config-secret`
+- `glance-audit-config-secret`
+- `neutron-audit-config-secret`
+
+The OpenStackControlPlane CR is patched (via kustomization) to mount these secrets and enable the audit middleware notification driver for each service.
+
+Role Variables
+--------------
+- enable\_audit\_logging\_local\_apply: When `true`, the role fetches the live OSCP CR and applies the kustomization directly. When `false` (default), the kustomization is copied to the ci-framework kustomizations directory for pre-deploy use.
+
+Example Playbook
+----------------
+
+    ansible-playbook ci/enable-audit-logging.yml -e enable_audit_logging_local_apply=true
+
+License
+-------
+
+Apache 2

--- a/ci/enable-audit-logging/defaults/main.yml
+++ b/ci/enable-audit-logging/defaults/main.yml
@@ -1,0 +1,5 @@
+enable_audit_logging_namespace: "{{ cifmw_openstack_namespace | default('openstack') }}"
+# Set to true to apply the kustomization against a live OSCP CR.
+# When false (default), the kustomization is only copied to the
+# ci-framework kustomizations directory for pre-deploy use.
+enable_audit_logging_local_apply: false

--- a/ci/enable-audit-logging/files/barbican-api-paste.ini
+++ b/ci/enable-audit-logging/files/barbican-api-paste.ini
@@ -1,0 +1,75 @@
+[composite:main]
+use = egg:Paste#urlmap
+/: barbican_version
+/healthcheck: healthcheck
+/v1: barbican-api-keystone-audit
+
+# Use this pipeline for Barbican API - versions no authentication
+[pipeline:barbican_version]
+pipeline = cors http_proxy_to_wsgi microversion versionapp
+
+# Use this pipeline for Barbican API - DEFAULT no authentication
+[pipeline:barbican_api]
+pipeline = cors http_proxy_to_wsgi unauthenticated-context microversion apiapp
+
+#Use this pipeline to activate a repoze.profile middleware and HTTP port,
+#  to provide profiling information for the REST API processing.
+[pipeline:barbican-profile]
+pipeline = cors http_proxy_to_wsgi unauthenticated-context microversion egg:Paste#cgitb egg:Paste#httpexceptions profile apiapp
+
+#Use this pipeline for keystone auth
+[pipeline:barbican-api-keystone]
+pipeline = cors http_proxy_to_wsgi authtoken context microversion apiapp
+
+#Use this pipeline for keystone auth with audit feature
+[pipeline:barbican-api-keystone-audit]
+pipeline = http_proxy_to_wsgi authtoken context microversion audit apiapp
+
+[app:apiapp]
+paste.app_factory = barbican.api.app:create_main_app
+
+[app:versionapp]
+paste.app_factory = barbican.api.app:create_version_app
+
+[filter:simple]
+paste.filter_factory = barbican.api.middleware.simple:SimpleFilter.factory
+
+[filter:unauthenticated-context]
+paste.filter_factory = barbican.api.middleware.context:UnauthenticatedContextMiddleware.factory
+
+[filter:context]
+paste.filter_factory = barbican.api.middleware.context:ContextMiddleware.factory
+
+[filter:microversion]
+paste.filter_factory = barbican.api.middleware.microversion:MicroversionMiddleware.factory
+
+[filter:audit]
+paste.filter_factory = keystonemiddleware.audit:filter_factory
+audit_map_file = /etc/barbican/api_audit_map.conf
+
+[filter:authtoken]
+paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+
+[filter:profile]
+use = egg:repoze.profile
+log_filename = myapp.profile
+cachegrind_filename = cachegrind.out.myapp
+discard_first_request = true
+path = /__profile__
+flush_at_shutdown = true
+unwind = false
+
+[filter:cors]
+paste.filter_factory = oslo_middleware.cors:filter_factory
+oslo_config_project = barbican
+
+[filter:http_proxy_to_wsgi]
+paste.filter_factory = oslo_middleware:HTTPProxyToWSGI.factory
+
+[app:healthcheck]
+paste.app_factory = oslo_middleware:Healthcheck.app_factory
+backends = disable_by_file
+disable_by_file_path = /etc/barbican/healthcheck_disable
+
+[server:main]
+use = egg:gunicorn#main

--- a/ci/enable-audit-logging/files/barbican-api-paste.ini
+++ b/ci/enable-audit-logging/files/barbican-api-paste.ini
@@ -46,6 +46,8 @@ paste.filter_factory = barbican.api.middleware.microversion:MicroversionMiddlewa
 [filter:audit]
 paste.filter_factory = keystonemiddleware.audit:filter_factory
 audit_map_file = /etc/barbican/api_audit_map.conf
+use_oslo_messaging = false
+log_name = barbican.audit
 
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory

--- a/ci/enable-audit-logging/files/cinder-api-paste.ini
+++ b/ci/enable-audit-logging/files/cinder-api-paste.ini
@@ -1,0 +1,72 @@
+#############
+# OpenStack #
+#############
+
+[composite:osapi_volume]
+use = call:cinder.api:root_app_factory
+/: apiversions
+/healthcheck: healthcheck
+/v3: openstack_volume_api_v3
+
+[composite:openstack_volume_api_v3]
+use = call:cinder.api.middleware.auth:pipeline_factory
+noauth = request_id cors http_proxy_to_wsgi faultwrap sizelimit osprofiler noauth apiv3
+noauth_include_project_id = request_id cors http_proxy_to_wsgi faultwrap sizelimit osprofiler noauth_include_project_id apiv3
+keystone = request_id cors http_proxy_to_wsgi faultwrap sizelimit osprofiler authtoken keystonecontext audit apiv3
+keystone_nolimit = request_id cors http_proxy_to_wsgi faultwrap sizelimit osprofiler authtoken keystonecontext audit apiv3
+
+[filter:http_proxy_to_wsgi]
+paste.filter_factory = oslo_middleware.http_proxy_to_wsgi:HTTPProxyToWSGI.factory
+
+[filter:cors]
+paste.filter_factory = oslo_middleware.cors:filter_factory
+oslo_config_project = cinder
+
+[filter:faultwrap]
+paste.filter_factory = cinder.api.middleware.fault:FaultWrapper.factory
+
+[filter:osprofiler]
+paste.filter_factory = osprofiler.web:WsgiMiddleware.factory
+
+[filter:noauth]
+paste.filter_factory = cinder.api.middleware.auth:NoAuthMiddleware.factory
+
+[filter:noauth_include_project_id]
+paste.filter_factory = cinder.api.middleware.auth:NoAuthMiddlewareIncludeProjectID.factory
+
+[filter:sizelimit]
+paste.filter_factory = oslo_middleware.sizelimit:RequestBodySizeLimiter.factory
+
+[app:apiv3]
+paste.app_factory = cinder.api.v3.router:APIRouter.factory
+
+[pipeline:apiversions]
+pipeline = request_id cors http_proxy_to_wsgi faultwrap osvolumeversionapp
+
+[app:osvolumeversionapp]
+paste.app_factory = cinder.api.versions:Versions.factory
+
+[pipeline:healthcheck]
+pipeline = request_id healthcheckapp
+
+[app:healthcheckapp]
+paste.app_factory = oslo_middleware:Healthcheck.app_factory
+backends = disable_by_file
+disable_by_file_path = /etc/cinder/healthcheck_disable
+
+##########
+# Shared #
+##########
+
+[filter:keystonecontext]
+paste.filter_factory = cinder.api.middleware.auth:CinderKeystoneContext.factory
+
+[filter:authtoken]
+paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+
+[filter:request_id]
+paste.filter_factory = cinder.api.middleware.request_id:RequestId.factory
+
+[filter:audit]
+paste.filter_factory = keystonemiddleware.audit:filter_factory
+audit_map_file = /etc/cinder/custom/cinder_api_audit_map.conf

--- a/ci/enable-audit-logging/files/cinder-api-paste.ini
+++ b/ci/enable-audit-logging/files/cinder-api-paste.ini
@@ -70,3 +70,5 @@ paste.filter_factory = cinder.api.middleware.request_id:RequestId.factory
 [filter:audit]
 paste.filter_factory = keystonemiddleware.audit:filter_factory
 audit_map_file = /etc/cinder/custom/cinder_api_audit_map.conf
+use_oslo_messaging = false
+log_name = cinder.audit

--- a/ci/enable-audit-logging/files/cinder_api_audit_map.conf
+++ b/ci/enable-audit-logging/files/cinder_api_audit_map.conf
@@ -1,0 +1,26 @@
+[DEFAULT]
+# default target endpoint type
+# should match the endpoint type defined in service catalog
+target_endpoint_type = None
+
+# map urls ending with specific text to a unique action
+[custom_actions]
+associate = update/associate
+disassociate = update/disassociate
+disassociate_all = update/disassociate_all
+associations = read/list/associations
+
+# possible end path of api requests
+[path_keywords]
+defaults = None
+detail = None
+limits = None
+os-quota-specs = project
+qos-specs = qos-spec
+snapshots = snapshot
+types = type
+volumes = volume
+
+# map endpoint type defined in service catalog to CADF typeURI
+[service_endpoints]
+volumev3 = service/storage/block

--- a/ci/enable-audit-logging/files/glance-api-paste.ini
+++ b/ci/enable-audit-logging/files/glance-api-paste.ini
@@ -1,0 +1,76 @@
+# Use this pipeline for no auth or image caching - DEFAULT
+[pipeline:glance-api]
+pipeline = cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context rootapp
+
+# Use this pipeline for image caching and no auth
+[pipeline:glance-api-caching]
+pipeline = cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context cache rootapp
+
+# Use this pipeline for caching w/ management interface but no auth
+[pipeline:glance-api-cachemanagement]
+pipeline = cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler unauthenticated-context cache cachemanage rootapp
+
+# Use this pipeline for keystone auth
+[pipeline:glance-api-keystone]
+pipeline = cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler authtoken context audit rootapp
+
+# Use this pipeline for keystone auth with image caching
+[pipeline:glance-api-keystone+caching]
+pipeline = cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler authtoken context cache audit rootapp
+
+# Use this pipeline for keystone auth with caching and cache management
+[pipeline:glance-api-keystone+cachemanagement]
+pipeline = cors healthcheck http_proxy_to_wsgi versionnegotiation osprofiler authtoken context cache cachemanage audit rootapp
+
+[composite:rootapp]
+paste.composite_factory = glance.api:root_app_factory
+/: apiversions
+/v2: apiv2app
+
+[app:apiversions]
+paste.app_factory = glance.api.versions:create_resource
+
+[app:apiv2app]
+paste.app_factory = glance.api.v2.router:API.factory
+
+[filter:healthcheck]
+paste.filter_factory = oslo_middleware:Healthcheck.factory
+backends = disable_by_file
+disable_by_file_path = /etc/glance/healthcheck_disable
+
+[filter:versionnegotiation]
+paste.filter_factory = glance.api.middleware.version_negotiation:VersionNegotiationFilter.factory
+
+[filter:cache]
+paste.filter_factory = glance.api.middleware.cache:CacheFilter.factory
+
+[filter:cachemanage]
+paste.filter_factory = glance.api.middleware.cache_manage:CacheManageFilter.factory
+
+[filter:context]
+paste.filter_factory = glance.api.middleware.context:ContextMiddleware.factory
+
+[filter:unauthenticated-context]
+paste.filter_factory = glance.api.middleware.context:UnauthenticatedContextMiddleware.factory
+
+[filter:authtoken]
+paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+delay_auth_decision = true
+
+[filter:gzip]
+paste.filter_factory = glance.api.middleware.gzip:GzipMiddleware.factory
+
+[filter:osprofiler]
+paste.filter_factory = osprofiler.web:WsgiMiddleware.factory
+
+[filter:cors]
+paste.filter_factory =  oslo_middleware.cors:filter_factory
+oslo_config_project = glance
+oslo_config_program = glance-api
+
+[filter:http_proxy_to_wsgi]
+paste.filter_factory = oslo_middleware:HTTPProxyToWSGI.factory
+
+[filter:audit]
+paste.filter_factory = keystonemiddleware.audit:filter_factory
+audit_map_file = /etc/glance/custom/glance_api_audit_map.conf

--- a/ci/enable-audit-logging/files/glance-api-paste.ini
+++ b/ci/enable-audit-logging/files/glance-api-paste.ini
@@ -74,3 +74,5 @@ paste.filter_factory = oslo_middleware:HTTPProxyToWSGI.factory
 [filter:audit]
 paste.filter_factory = keystonemiddleware.audit:filter_factory
 audit_map_file = /etc/glance/custom/glance_api_audit_map.conf
+use_oslo_messaging = false
+log_name = glance.audit

--- a/ci/enable-audit-logging/files/glance_api_audit_map.conf
+++ b/ci/enable-audit-logging/files/glance_api_audit_map.conf
@@ -1,0 +1,16 @@
+[DEFAULT]
+# default target endpoint type
+# should match the endpoint type defined in service catalog
+target_endpoint_type = None
+
+# possible end path of api requests
+[path_keywords]
+detail = None
+file = None
+images = image
+members = member
+tags = tag
+
+# map endpoint type defined in service catalog to CADF typeURI
+[service_endpoints]
+image = service/storage/image

--- a/ci/enable-audit-logging/files/neutron-api-paste.ini
+++ b/ci/enable-audit-logging/files/neutron-api-paste.ini
@@ -1,0 +1,62 @@
+[composite:neutron]
+use = egg:Paste#urlmap
+/: neutronversions_composite
+/healthcheck: healthcheck
+/v2.0: neutronapi_v2_0
+
+[composite:neutronapi_v2_0]
+use = call:neutron.auth:pipeline_factory
+noauth = cors http_proxy_to_wsgi request_id fake_project_id catch_errors osprofiler extensions neutronapiapp_v2_0
+keystone = cors http_proxy_to_wsgi request_id catch_errors osprofiler authtoken keystonecontext extensions audit neutronapiapp_v2_0
+
+[composite:neutronversions_composite]
+use = call:neutron.auth:pipeline_factory
+noauth = cors http_proxy_to_wsgi neutronversions
+keystone = cors http_proxy_to_wsgi neutronversions
+
+[filter:request_id]
+paste.filter_factory = oslo_middleware:RequestId.factory
+
+[filter:catch_errors]
+paste.filter_factory = oslo_middleware:CatchErrors.factory
+
+[filter:cors]
+paste.filter_factory = oslo_middleware.cors:filter_factory
+oslo_config_project = neutron
+
+[filter:project_id]
+paste.filter_factory = neutron.api.extensions:ProjectIdMiddleware.factory
+oslo_config_project = neutron
+
+[filter:fake_project_id]
+paste.filter_factory = neutron.auth:NoauthFakeProjectId.factory
+
+[filter:http_proxy_to_wsgi]
+paste.filter_factory = oslo_middleware.http_proxy_to_wsgi:HTTPProxyToWSGI.factory
+
+[filter:keystonecontext]
+paste.filter_factory = neutron.auth:NeutronKeystoneContext.factory
+
+[filter:authtoken]
+paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+
+[filter:extensions]
+paste.filter_factory = neutron.api.extensions:plugin_aware_extension_middleware_factory
+
+[app:neutronversions]
+paste.app_factory = neutron.pecan_wsgi.app:versions_factory
+
+[app:neutronapiapp_v2_0]
+paste.app_factory = neutron.api.v2.router:APIRouter.factory
+
+[filter:osprofiler]
+paste.filter_factory = osprofiler.web:WsgiMiddleware.factory
+
+[app:healthcheck]
+paste.app_factory = oslo_middleware:Healthcheck.app_factory
+backends = disable_by_file
+disable_by_file_path = /var/lib/neutron/healthcheck_disable
+
+[filter:audit]
+paste.filter_factory = keystonemiddleware.audit:filter_factory
+audit_map_file = /etc/neutron/custom/neutron_api_audit_map.conf

--- a/ci/enable-audit-logging/files/neutron-api-paste.ini
+++ b/ci/enable-audit-logging/files/neutron-api-paste.ini
@@ -60,3 +60,5 @@ disable_by_file_path = /var/lib/neutron/healthcheck_disable
 [filter:audit]
 paste.filter_factory = keystonemiddleware.audit:filter_factory
 audit_map_file = /etc/neutron/custom/neutron_api_audit_map.conf
+use_oslo_messaging = false
+log_name = neutron.audit

--- a/ci/enable-audit-logging/files/neutron_api_audit_map.conf
+++ b/ci/enable-audit-logging/files/neutron_api_audit_map.conf
@@ -1,0 +1,31 @@
+[DEFAULT]
+# default target endpoint type
+# should match the endpoint type defined in service catalog
+target_endpoint_type = None
+
+[custom_actions]
+add_router_interface = update/add
+remove_router_interface = update/remove
+
+# possible end path of api requests
+[path_keywords]
+floatingips = ip
+healthmonitors = healthmonitor
+health_monitors = health_monitor
+lb = None
+members = member
+metering-labels = label
+metering-label-rules = rule
+networks = network
+pools = pool
+ports = port
+routers = router
+quotas = quota
+security-groups = security-group
+security-group-rules = rule
+subnets = subnet
+vips = vip
+
+# map endpoint type defined in service catalog to CADF typeURI
+[service_endpoints]
+network = service/network

--- a/ci/enable-audit-logging/files/nova-api-paste.ini
+++ b/ci/enable-audit-logging/files/nova-api-paste.ini
@@ -1,0 +1,94 @@
+############
+# Metadata #
+############
+[composite:metadata]
+use = egg:Paste#urlmap
+/: meta
+
+[pipeline:meta]
+pipeline = cors http_proxy_to_wsgi metaapp
+
+[app:metaapp]
+paste.app_factory = nova.api.metadata.handler:MetadataRequestHandler.factory
+
+#############
+# OpenStack #
+#############
+
+[composite:osapi_compute]
+use = call:nova.api.openstack.urlmap:urlmap_factory
+/: oscomputeversions
+/v2: oscomputeversion_legacy_v2
+/v2.1: oscomputeversion_v2
+/v2/+: openstack_compute_api_v21_legacy_v2_compatible
+/v2.1/+: openstack_compute_api_v21
+
+[composite:openstack_compute_api_v21]
+use = call:nova.api.auth:pipeline_factory_v21
+keystone = cors http_proxy_to_wsgi compute_req_id faultwrap request_log sizelimit osprofiler authtoken keystonecontext audit osapi_compute_app_v21
+noauth2 = cors http_proxy_to_wsgi compute_req_id faultwrap request_log sizelimit osprofiler noauth2 audit osapi_compute_app_v21
+
+[composite:openstack_compute_api_v21_legacy_v2_compatible]
+use = call:nova.api.auth:pipeline_factory_v21
+keystone = cors http_proxy_to_wsgi compute_req_id faultwrap request_log sizelimit osprofiler authtoken keystonecontext legacy_v2_compatible audit osapi_compute_app_v21
+noauth2 = cors http_proxy_to_wsgi compute_req_id faultwrap request_log sizelimit osprofiler noauth2 legacy_v2_compatible audit osapi_compute_app_v21
+
+[filter:request_log]
+paste.filter_factory = nova.api.openstack.requestlog:RequestLog.factory
+
+[filter:compute_req_id]
+paste.filter_factory = nova.api.compute_req_id:ComputeReqIdMiddleware.factory
+
+[filter:faultwrap]
+paste.filter_factory = nova.api.openstack:FaultWrapper.factory
+
+[filter:noauth2]
+paste.filter_factory = nova.api.openstack.auth:NoAuthMiddleware.factory
+
+[filter:osprofiler]
+paste.filter_factory = nova.profiler:WsgiMiddleware.factory
+
+[filter:sizelimit]
+paste.filter_factory = oslo_middleware:RequestBodySizeLimiter.factory
+
+[filter:http_proxy_to_wsgi]
+paste.filter_factory = oslo_middleware.http_proxy_to_wsgi:HTTPProxyToWSGI.factory
+
+[filter:legacy_v2_compatible]
+paste.filter_factory = nova.api.openstack:LegacyV2CompatibleWrapper.factory
+
+[app:osapi_compute_app_v21]
+paste.app_factory = nova.api.openstack.compute:APIRouterV21.factory
+
+[pipeline:oscomputeversions]
+pipeline = cors faultwrap request_log http_proxy_to_wsgi oscomputeversionapp
+
+[pipeline:oscomputeversion_v2]
+pipeline = cors compute_req_id faultwrap request_log http_proxy_to_wsgi oscomputeversionapp_v2
+
+[pipeline:oscomputeversion_legacy_v2]
+pipeline = cors compute_req_id faultwrap request_log http_proxy_to_wsgi legacy_v2_compatible oscomputeversionapp_v2
+
+[app:oscomputeversionapp]
+paste.app_factory = nova.api.openstack.compute.versions:Versions.factory
+
+[app:oscomputeversionapp_v2]
+paste.app_factory = nova.api.openstack.compute.versions:VersionsV2.factory
+
+##########
+# Shared #
+##########
+
+[filter:cors]
+paste.filter_factory = oslo_middleware.cors:filter_factory
+oslo_config_project = nova
+
+[filter:keystonecontext]
+paste.filter_factory = nova.api.auth:NovaKeystoneContext.factory
+
+[filter:authtoken]
+paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+
+[filter:audit]
+paste.filter_factory = keystonemiddleware.audit:filter_factory
+audit_map_file = /etc/nova/nova_api_audit_map.conf

--- a/ci/enable-audit-logging/files/nova-api-paste.ini
+++ b/ci/enable-audit-logging/files/nova-api-paste.ini
@@ -92,3 +92,5 @@ paste.filter_factory = keystonemiddleware.auth_token:filter_factory
 [filter:audit]
 paste.filter_factory = keystonemiddleware.audit:filter_factory
 audit_map_file = /etc/nova/nova_api_audit_map.conf
+use_oslo_messaging = false
+log_name = nova.audit

--- a/ci/enable-audit-logging/files/nova_api_audit_map.conf
+++ b/ci/enable-audit-logging/files/nova_api_audit_map.conf
@@ -1,0 +1,68 @@
+[DEFAULT]
+target_endpoint_type = None
+
+[custom_actions]
+enable = enable
+disable = disable
+delete = delete
+startup = start/startup
+shutdown = stop/shutdown
+reboot = start/reboot
+os-migrations/get = read
+os-server-password/post = update
+
+[path_keywords]
+add = None
+action = None
+enable = None
+disable = None
+configure-project = None
+defaults = None
+delete = None
+detail = None
+diagnostics = None
+entries = entry
+extensions = alias
+flavors = flavor
+images = image
+ips = label
+limits = None
+metadata = key
+os-agents = os-agent
+os-aggregates = os-aggregate
+os-availability-zone = None
+os-certificates = None
+os-cloudpipe = None
+os-fixed-ips = ip
+os-extra_specs = key
+os-flavor-access = None
+os-floating-ip-dns = domain
+os-floating-ips-bulk = host
+os-floating-ip-pools = None
+os-floating-ips = floating-ip
+os-hosts = host
+os-hypervisors = hypervisor
+os-instance-actions = instance-action
+os-keypairs = keypair
+os-migrations = None
+os-networks = network
+os-quota-sets = tenant
+os-security-groups = security_group
+os-security-group-rules = rule
+os-server-password = None
+os-services = None
+os-simple-tenant-usage = tenant
+os-virtual-interfaces = None
+os-volume_attachments = attachment
+os-volumes_boot = None
+os-volumes = volume
+os-volume-types = volume-type
+os-snapshots = snapshot
+reboot = None
+servers = server
+shutdown = None
+startup = None
+statistics = None
+
+[service_endpoints]
+compute = service/compute

--- a/ci/enable-audit-logging/tasks/apply-local.yml
+++ b/ci/enable-audit-logging/tasks/apply-local.yml
@@ -1,0 +1,29 @@
+- name: Create temp directory for local kustomization
+  ansible.builtin.tempfile:
+    state: directory
+    prefix: audit-logging-
+  register: audit_kustomize_dir
+
+- name: Fetch current OSCP CR
+  ansible.builtin.shell: >
+    oc get openstackcontrolplane -o yaml
+    > {{ audit_kustomize_dir.path }}/oscp.yaml
+
+- name: Render kustomization to temp directory
+  ansible.builtin.template:
+    src: 90-kustomize-controlplane-audit-logging.yaml.j2
+    dest: "{{ audit_kustomize_dir.path }}/kustomization.yaml"
+
+- name: Add OSCP resource to local kustomization
+  ansible.builtin.lineinfile:
+    path: "{{ audit_kustomize_dir.path }}/kustomization.yaml"
+    line: "resources:\n- oscp.yaml"
+
+- name: Apply audit logging kustomization locally
+  ansible.builtin.command: >
+    oc apply --server-side --force-conflicts -k {{ audit_kustomize_dir.path }}
+
+- name: Clean up temp directory
+  ansible.builtin.file:
+    path: "{{ audit_kustomize_dir.path }}"
+    state: absent

--- a/ci/enable-audit-logging/tasks/create-secrets.yml
+++ b/ci/enable-audit-logging/tasks/create-secrets.yml
@@ -1,0 +1,20 @@
+- name: Create cinder audit config secret
+  ansible.builtin.command: >
+    oc create secret generic {{ enable_audit_logging_cinder_secret }}
+    -n {{ enable_audit_logging_namespace }}
+    --from-file=api-paste.ini={{ role_path }}/files/cinder-api-paste.ini
+    --from-file=cinder_api_audit_map.conf={{ role_path }}/files/cinder_api_audit_map.conf
+
+- name: Create glance audit config secret
+  ansible.builtin.command: >
+    oc create secret generic {{ enable_audit_logging_glance_secret }}
+    -n {{ enable_audit_logging_namespace }}
+    --from-file=glance-api-paste.ini={{ role_path }}/files/glance-api-paste.ini
+    --from-file=glance_api_audit_map.conf={{ role_path }}/files/glance_api_audit_map.conf
+
+- name: Create neutron audit config secret
+  ansible.builtin.command: >
+    oc create secret generic {{ enable_audit_logging_neutron_secret }}
+    -n {{ enable_audit_logging_namespace }}
+    --from-file=api-paste.ini={{ role_path }}/files/neutron-api-paste.ini
+    --from-file=neutron_api_audit_map.conf={{ role_path }}/files/neutron_api_audit_map.conf

--- a/ci/enable-audit-logging/tasks/main.yml
+++ b/ci/enable-audit-logging/tasks/main.yml
@@ -1,0 +1,21 @@
+- name: Create service audit config secrets
+  ansible.builtin.import_tasks: create-secrets.yml
+
+# Barbican: disabled - the barbican-operator does not currently support
+# providing a custom api-paste.ini through defaultConfigOverwrite.
+# Config files are included in files/ for future use.
+# Tracked in: https://issues.redhat.com/browse/OSPRH-25781
+
+# Nova: disabled - there is a known issue with the nova-operator that
+# requires naming the audit map file as policy.yaml. Config files are
+# included in files/ for future use.
+
+- name: Copy controlplane kustomization for audit logging
+  ansible.builtin.template:
+    src: 90-kustomize-controlplane-audit-logging.yaml.j2
+    dest: "{{ cifmw_basedir }}/artifacts/manifests/kustomizations/controlplane/90-kustomize-controlplane-audit-logging.yaml"
+  when: not enable_audit_logging_local_apply
+
+- name: Apply kustomization against live OSCP
+  ansible.builtin.import_tasks: apply-local.yml
+  when: enable_audit_logging_local_apply

--- a/ci/enable-audit-logging/templates/90-kustomize-controlplane-audit-logging.yaml.j2
+++ b/ci/enable-audit-logging/templates/90-kustomize-controlplane-audit-logging.yaml.j2
@@ -1,0 +1,78 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: {{ enable_audit_logging_namespace }}
+patches:
+- patch: |-
+    apiVersion: core.openstack.org/v1beta1
+    kind: OpenStackControlPlane
+    metadata:
+      name: unused
+    spec:
+      cinder:
+        template:
+          cinderAPI:
+            customServiceConfig: |
+              [DEFAULT]
+              api_paste_config = "/etc/cinder/custom/api-paste.ini"
+              [audit_middleware_notifications]
+              driver = log
+          extraMounts:
+          - name: audit-config-files
+            region: r1
+            extraVol:
+            - mounts:
+              - mountPath: /etc/cinder/custom
+                name: audit
+                readOnly: true
+              volumes:
+              - name: audit
+                secret:
+                  secretName: {{ enable_audit_logging_cinder_secret }}
+      glance:
+        template:
+          glanceAPIs:
+            default:
+              customServiceConfig: |
+                [paste_deploy]
+                config_file = /etc/glance/custom/glance-api-paste.ini
+                [audit_middleware_notifications]
+                driver = log
+          extraMounts:
+          - name: audit-config-files
+            region: r1
+            extraVol:
+            - mounts:
+              - mountPath: /etc/glance/custom
+                name: audit
+                readOnly: true
+              volumes:
+              - name: audit
+                secret:
+                  secretName: {{ enable_audit_logging_glance_secret }}
+      keystone:
+        template:
+          customServiceConfig: |
+            [DEFAULT]
+            notification_opt_out=""
+            [oslo_messaging_notifications]
+            driver = messagingv2
+            driver = log
+      neutron:
+        template:
+          customServiceConfig: |
+            [DEFAULT]
+            api_paste_config = /etc/neutron/custom/api-paste.ini
+            [audit_middleware_notifications]
+            driver = log
+          extraMounts:
+          - extraVol:
+            - mounts:
+              - mountPath: /etc/neutron/custom
+                name: audit
+                readOnly: true
+              volumes:
+              - name: audit
+                secret:
+                  secretName: {{ enable_audit_logging_neutron_secret }}
+  target:
+    kind: OpenStackControlPlane

--- a/ci/enable-audit-logging/templates/90-kustomize-controlplane-audit-logging.yaml.j2
+++ b/ci/enable-audit-logging/templates/90-kustomize-controlplane-audit-logging.yaml.j2
@@ -14,8 +14,6 @@ patches:
             customServiceConfig: |
               [DEFAULT]
               api_paste_config = "/etc/cinder/custom/api-paste.ini"
-              [audit_middleware_notifications]
-              driver = log
           extraMounts:
           - name: audit-config-files
             region: r1
@@ -35,8 +33,6 @@ patches:
               customServiceConfig: |
                 [paste_deploy]
                 config_file = /etc/glance/custom/glance-api-paste.ini
-                [audit_middleware_notifications]
-                driver = log
           extraMounts:
           - name: audit-config-files
             region: r1
@@ -62,8 +58,6 @@ patches:
           customServiceConfig: |
             [DEFAULT]
             api_paste_config = /etc/neutron/custom/api-paste.ini
-            [audit_middleware_notifications]
-            driver = log
           extraMounts:
           - extraVol:
             - mounts:

--- a/ci/enable-audit-logging/vars/main.yml
+++ b/ci/enable-audit-logging/vars/main.yml
@@ -1,0 +1,3 @@
+enable_audit_logging_cinder_secret: cinder-audit-config-secret
+enable_audit_logging_glance_secret: glance-audit-config-secret
+enable_audit_logging_neutron_secret: neutron-audit-config-secret

--- a/ci/vars-audit-logging.yml
+++ b/ci/vars-audit-logging.yml
@@ -1,0 +1,5 @@
+---
+cifmw_run_tests: false
+pre_deploy_enable_audit_logging:
+  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/enable-audit-logging.yml"
+  type: playbook

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -105,6 +105,18 @@
     irrelevant-files: *irrelevant_files
 
 - job:
+    name: telemetry-operator-multinode-audit-logging
+    parent: podified-multinode-edpm-deployment-crc
+    dependencies: ["openstack-k8s-operators-content-provider"]
+    description: |
+      Deploy OpenStack with CADF audit logging enabled for supported services
+    vars:
+      cifmw_extras:
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir  }}/scenarios/centos-9/multinode-ci.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-audit-logging.yml"
+    irrelevant-files: *irrelevant_files
+
+- job:
     name: telemetry-operator-multinode-power-monitoring
     parent: podified-multinode-edpm-deployment-crc
     dependencies: ["openstack-k8s-operators-content-provider"]
@@ -176,6 +188,7 @@
               - telemetry-openstack-meta-content-provider-master
         - telemetry-openstack-meta-content-provider-master
         - telemetry-operator-multinode-default-telemetry
+        - telemetry-operator-multinode-audit-logging
         - functional-tests-osp18: &fvt_jobs_config
             voting: true
             required-projects:


### PR DESCRIPTION
Add an enable-audit-logging role that creates audit config secrets and applies kustomizations to enable CADF audit logging on cinder, glance, keystone, and neutron. Includes a Zuul job definition and ci-framework vars file for CI, plus a local apply mode for manual use.

Generated-By: Claude-Code claude-opus-4-6