### PR TITLE
Simplify ClusterLogForwarder condition check

### DIFF
--- a/ci/deploy-logging-dependencies/tasks/deploy-cluster-logging.yml
+++ b/ci/deploy-logging-dependencies/tasks/deploy-cluster-logging.yml
@@ -21,15 +21,13 @@
   register: output
   until: output.stdout_lines | length != 0
 
-- name: Wait for 2 "True" and 0 "False" conditions in ClusterLogForwarder status
+- name: Wait for all conditions to be "True" in ClusterLogForwarder status
   ansible.builtin.shell:
     cmd: >
-      oc get clusterlogforwarder collector -n openshift-logging -o json | jq --raw-output '[
-        ([.status.conditions[] | select(.status == "True")] | length),
-        ([.status.conditions[] | select(.status == "False")] | length)
-      ] | @csv'
-  register: clf_condition_counts
-  until: clf_condition_counts.stdout == "2,0"
+      oc get clusterlogforwarder collector -n openshift-logging -o json |
+      jq '.status.conditions | length > 0 and all(.status == "True")'
+  register: clf_conditions
+  until: clf_conditions.stdout == "true"
   retries: 20
   delay: 20
   changed_when: false


### PR DESCRIPTION
Instead of counting specific numbers of True/False conditions, check that all conditions are True. This is more robust if the number of conditions changes in the future.

Generated-By: Claude-Code claude-opus-4-6