### PR TITLE
Create loki labels for 'host' and 'appname'

### DIFF
--- a/ci/deploy-logging-dependencies/files/cluster_log_forwarder.yaml
+++ b/ci/deploy-logging-dependencies/files/cluster_log_forwarder.yaml
@@ -19,6 +19,11 @@ spec:
         authentication:
           token:
             from: serviceAccount
+        labelKeys:
+          infrastructure:
+            labelKeys:
+              - host
+              - appname
         target:
           name: logging-loki
           namespace: openshift-logging


### PR DESCRIPTION
Right now all dataplane logs end up in the same loki log stream. This patch will improve query and correlation performance under many common scenarios.

I'll do a quick demo about this tomorrow.

This is just CI, though, I think the real fix is is in our docs for the moment[1] - replace the link to the generic "Syslog receiver configuration example"[2] with this content, basically.

[1] https://docs.redhat.com/en/documentation/red_hat_openstack_services_on_openshift/18.0/html/configuring_observability/assembly_enabling-rhoso-observability-logging_observability
[2] https://github.com/openshift/cluster-logging-operator/blob/master/docs/reference/samples/observability.inputs-receivers.yaml