### PR TITLE
Enable identity_name_discovery in ceilometer compute polling config

### DIFF
--- a/templates/ceilometercompute/config/ceilometer.conf
+++ b/templates/ceilometercompute/config/ceilometer.conf
@@ -42,6 +42,7 @@ notify_address_prefix=
 driver=noop
 
 [polling]
+identity_name_discovery=True
 heartbeat_socket_dir=/var/lib/ceilometer
 {{- if .TLS }}
 prometheus_tls_enable = True


### PR DESCRIPTION
This enables adding project_name and user_name in addition to the ids as Prometheus metrics labels.

The default was set to False to avoid overwhelming keystone, but cache_utils.py already provides a caching layer (in-memory dict or redis/dogpile backend) with a 600s TTL. With caching in place, the original concern is largely mitigated, so I believe that we can have it enabled by default in RHOSO.