### PR TITLE
Implement enable audit logging suggestions

### DIFF
--- a/ci/enable-audit-logging/tasks/apply-local.yml
+++ b/ci/enable-audit-logging/tasks/apply-local.yml
@@ -1,29 +1,32 @@
-- name: Create temp directory for local kustomization
-  ansible.builtin.tempfile:
-    state: directory
-    prefix: audit-logging-
-  register: audit_kustomize_dir
+- name: Enable audit logs locally post-deploy
+  block:
+  - name: Create temp directory for local kustomization
+    ansible.builtin.tempfile:
+      state: directory
+      prefix: audit-logging-
+    register: audit_kustomize_dir
 
-- name: Fetch current OSCP CR
-  ansible.builtin.shell: >
-    oc get openstackcontrolplane -o yaml
-    > {{ audit_kustomize_dir.path }}/oscp.yaml
+  - name: Fetch current OSCP CR
+    ansible.builtin.shell: >
+      oc get openstackcontrolplane -o yaml
+      > {{ audit_kustomize_dir.path }}/oscp.yaml
 
-- name: Render kustomization to temp directory
-  ansible.builtin.template:
-    src: 90-kustomize-controlplane-audit-logging.yaml.j2
-    dest: "{{ audit_kustomize_dir.path }}/kustomization.yaml"
+  - name: Render kustomization to temp directory
+    ansible.builtin.template:
+      src: 90-kustomize-controlplane-audit-logging.yaml.j2
+      dest: "{{ audit_kustomize_dir.path }}/kustomization.yaml"
 
-- name: Add OSCP resource to local kustomization
-  ansible.builtin.lineinfile:
-    path: "{{ audit_kustomize_dir.path }}/kustomization.yaml"
-    line: "resources:\n- oscp.yaml"
+  - name: Add OSCP resource to local kustomization
+    ansible.builtin.lineinfile:
+      path: "{{ audit_kustomize_dir.path }}/kustomization.yaml"
+      line: "resources:\n- oscp.yaml"
 
-- name: Apply audit logging kustomization locally
-  ansible.builtin.command: >
-    oc apply --server-side --force-conflicts -k {{ audit_kustomize_dir.path }}
+  - name: Apply audit logging kustomization locally
+    ansible.builtin.command: >
+      oc apply --server-side --force-conflicts -k {{ audit_kustomize_dir.path }}
 
-- name: Clean up temp directory
-  ansible.builtin.file:
-    path: "{{ audit_kustomize_dir.path }}"
-    state: absent
+  always:
+  - name: Clean up temp directory
+    ansible.builtin.file:
+      path: "{{ audit_kustomize_dir.path }}"
+      state: absent

--- a/ci/enable-audit-logging/tasks/main.yml
+++ b/ci/enable-audit-logging/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Create service audit config secrets
-  ansible.builtin.import_tasks: create-secrets.yml
+  ansible.builtin.include_tasks: create-secrets.yml
 
 # Barbican: disabled - the barbican-operator does not currently support
 # providing a custom api-paste.ini through defaultConfigOverwrite.
@@ -17,5 +17,5 @@
   when: not enable_audit_logging_local_apply
 
 - name: Apply kustomization against live OSCP
-  ansible.builtin.import_tasks: apply-local.yml
+  ansible.builtin.include_tasks: apply-local.yml
   when: enable_audit_logging_local_apply

--- a/ci/enable-audit-logging/templates/90-kustomize-controlplane-audit-logging.yaml.j2
+++ b/ci/enable-audit-logging/templates/90-kustomize-controlplane-audit-logging.yaml.j2
@@ -28,11 +28,22 @@ patches:
                   secretName: {{ enable_audit_logging_cinder_secret }}
       glance:
         template:
-          glanceAPIs:
-            default:
-              customServiceConfig: |
-                [paste_deploy]
-                config_file = /etc/glance/custom/glance-api-paste.ini
+{% raw %}
+          customServiceConfig: |
+            [DEFAULT]
+            enabled_backends = default_backend:swift
+            [glance_store]
+            default_backend = default_backend
+            [default_backend]
+            swift_store_create_container_on_put = True
+            swift_store_auth_version = 3
+            swift_store_auth_address = {{ .KeystoneInternalURL }}
+            swift_store_endpoint_type = internalURL
+            swift_store_user = service:glance
+            swift_store_key = {{ .ServicePassword }}
+            [paste_deploy]
+            config_file = /etc/glance/custom/glance-api-paste.ini
+{% endraw %}
           extraMounts:
           - name: audit-config-files
             region: r1


### PR DESCRIPTION
- explicitly specify glance backend config in customServiceConfig, because otherwise it'll get overwritten by the audit logging config
- use include_tasks instead of import tasks
- use block/always to ensure temporary dir gets always deleted

Closes: [OSPRH-30106](https://redhat.atlassian.net/browse/OSPRH-30106)