### PR TITLE
Allow empty rsyslogTemplate for Go-constructed CRs

### DIFF
--- a/api/bases/telemetry.openstack.org_loggings.yaml
+++ b/api/bases/telemetry.openstack.org_loggings.yaml
@@ -88,6 +88,7 @@ spec:
                 default: RSYSLOG_TraditionalFileFormat
                 description: The template format for rsyslog forwarding actions
                 enum:
+                - ""
                 - RSYSLOG_TraditionalFileFormat
                 - RSYSLOG_SyslogProtocol23Format
                 type: string

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -1418,6 +1418,7 @@ spec:
                     default: RSYSLOG_TraditionalFileFormat
                     description: The template format for rsyslog forwarding actions
                     enum:
+                    - ""
                     - RSYSLOG_TraditionalFileFormat
                     - RSYSLOG_SyslogProtocol23Format
                     type: string

--- a/api/v1beta1/logging_types.go
+++ b/api/v1beta1/logging_types.go
@@ -62,7 +62,7 @@ type LoggingSpec struct {
 	// The template format for rsyslog forwarding actions
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=RSYSLOG_TraditionalFileFormat
-	// +kubebuilder:validation:Enum=RSYSLOG_TraditionalFileFormat;RSYSLOG_SyslogProtocol23Format
+	// +kubebuilder:validation:Enum="";RSYSLOG_TraditionalFileFormat;RSYSLOG_SyslogProtocol23Format
 	RsyslogTemplate string `json:"rsyslogTemplate"`
 }
 

--- a/config/crd/bases/telemetry.openstack.org_loggings.yaml
+++ b/config/crd/bases/telemetry.openstack.org_loggings.yaml
@@ -88,6 +88,7 @@ spec:
                 default: RSYSLOG_TraditionalFileFormat
                 description: The template format for rsyslog forwarding actions
                 enum:
+                - ""
                 - RSYSLOG_TraditionalFileFormat
                 - RSYSLOG_SyslogProtocol23Format
                 type: string

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -1418,6 +1418,7 @@ spec:
                     default: RSYSLOG_TraditionalFileFormat
                     description: The template format for rsyslog forwarding actions
                     enum:
+                    - ""
                     - RSYSLOG_TraditionalFileFormat
                     - RSYSLOG_SyslogProtocol23Format
                     type: string

--- a/internal/controller/logging_controller.go
+++ b/internal/controller/logging_controller.go
@@ -294,6 +294,10 @@ func (r *LoggingReconciler) generateComputeServiceConfig(
 		instance.Spec.RsyslogQueueType = "linkedList"
 	}
 
+	if instance.Spec.RsyslogTemplate == "" {
+		instance.Spec.RsyslogTemplate = "RSYSLOG_TraditionalFileFormat"
+	}
+
 	templateParameters := map[string]any{
 		"RsyslogAddress":   service.Annotations["metallb.universe.tf/loadBalancerIPs"],
 		"RsyslogPort":      instance.Spec.Port,


### PR DESCRIPTION
The Logging CRD has no defaulting webhook, so when the openstack-operator constructs a LoggingSpec in Go code the RsyslogTemplate field defaults to "" (Go zero value), which fails enum validation. Allow "" in the enum and fall back to RSYSLOG_TraditionalFileFormat in the controller, matching the existing pattern used by RsyslogQueueType.