### PR TITLE
[OSPRH-30223] Update audit logging filter regex

### DIFF
--- a/ci/deploy-logging-dependencies/files/cluster_log_forwarder.yaml
+++ b/ci/deploy-logging-dependencies/files/cluster_log_forwarder.yaml
@@ -51,13 +51,13 @@ spec:
     drop:
     - test:
       - field: .message
-        matches: "oslo.messaging.notification"
+        matches: "http://schemas.dmtf.org/cloud/audit/1.0/event"
   - name: to-loki-audit-filter
     type: drop
     drop:
     - test:
       - field: .message
-        notMatches: "oslo.messaging.notification"
+        notMatches: "http://schemas.dmtf.org/cloud/audit/1.0/event"
   pipelines:
   - name: to-loki
     inputRefs:


### PR DESCRIPTION
Change the filter regex for audit logs to the CADF schema url (http://schemas.dmtf.org/cloud/audit/1.0/event). This will prevent a potential clash in the unlikely scenario of having other notifications routed to logs. Also it allows us to use the pycadf's `use_oslo_messaging = false` option to skip oslo messaging and route audit logs into logs directly.