### PR TITLE
Use mysqld_exporter default image from oko quay

### DIFF
--- a/api/v1beta1/ceilometer_types.go
+++ b/api/v1beta1/ceilometer_types.go
@@ -43,7 +43,7 @@ const (
 	// KubeStateMetricsImage - default fall-back image for KSM
 	KubeStateMetricsImage = "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.0"
 	// MysqldExporterImage - default fall-back image for mysqld_exporter
-	MysqldExporterContainerImage = "quay.io/prometheus/mysqld-exporter:v0.15.1"
+	MysqldExporterContainerImage = "quay.io/openstack-k8s-operators/mysqld_exporter:latest"
 )
 
 // CeilometerSpec defines the desired state of Ceilometer


### PR DESCRIPTION
Now that we have a workflow setup to automatically build mysqld_exporter latest image whenever there is new content in
openstack-k8s-operators/mysqld_exporter main branch. We can consume those images by default instead of relating on upstream images, which may have slightly different content.

Related PRs:
https://github.com/openstack-k8s-operators/edpm-ansible/pull/1179
https://github.com/openstack-k8s-operators/openstack-operator/pull/1925

Closes: https://redhat.atlassian.net/browse/OSPRH-29306