### PR TITLE
Add scrapeconfig discovery for InstanceHA metrics

### DIFF
--- a/internal/controller/metricstorage_controller.go
+++ b/internal/controller/metricstorage_controller.go
@@ -897,6 +897,12 @@ func (r *MetricStorageReconciler) createScrapeConfigs(
 		return ctrl.Result{}, err
 	}
 
+	// ScrapeConfig for InstanceHA metrics
+	err = r.createInstanceHAScrapeConfig(ctx, instance, helper, serviceLabels)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	instance.Status.Conditions.MarkTrue(telemetryv1.ScrapeConfigReadyCondition, condition.ReadyMessage)
 	return ctrl.Result{}, nil
 }
@@ -1109,6 +1115,25 @@ func (r *MetricStorageReconciler) createOVSDBServerSBScrapeConfig(
 	return r.createServiceScrapeConfigFromLabelSelector(
 		ctx, instance, helper, serviceLabels,
 		labelSelector, "metrics", ovsdbServerSBCfgName, "OVS DB server SB",
+	)
+}
+
+// createInstanceHAScrapeConfig creates a scrape configuration for InstanceHA metrics
+// This function discovers InstanceHA metrics services using label selectors
+func (r *MetricStorageReconciler) createInstanceHAScrapeConfig(
+	ctx context.Context,
+	instance *telemetryv1.MetricStorage,
+	helper *helper.Helper,
+	serviceLabels map[string]string,
+) error {
+	labelSelector := map[string]string{
+		"metrics": "enabled",
+		"service": "instanceha",
+	}
+	instancehaCfgName := fmt.Sprintf("%s-instanceha", telemetry.ServiceName)
+	return r.createServiceScrapeConfigFromLabelSelector(
+		ctx, instance, helper, serviceLabels,
+		labelSelector, "metrics", instancehaCfgName, "InstanceHA",
 	)
 }
 
@@ -1492,13 +1517,11 @@ func (r *MetricStorageReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 		return nil
 	}
 
-	ovnMetricsServiceWatchFn := func(_ context.Context, o client.Object) []reconcile.Request {
+	metricsServiceWatchFn := func(_ context.Context, o client.Object) []reconcile.Request {
 		result := []reconcile.Request{}
 
-		// Watch OVN metrics services
 		if labels := o.GetLabels(); labels != nil {
-			if labels["metrics"] == "enabled" && (labels["service"] == "ovn-northd" || labels["service"] == "ovn-controller-metrics" || labels["service"] == "ovsdbserver-nb" || labels["service"] == "ovsdbserver-sb") {
-				// get all metricstorage CRs in the same namespace
+			if labels["metrics"] == "enabled" && (labels["service"] == "ovn-northd" || labels["service"] == "ovn-controller-metrics" || labels["service"] == "ovsdbserver-nb" || labels["service"] == "ovsdbserver-sb" || labels["service"] == "instanceha") {
 				metricStorages := &telemetryv1.MetricStorageList{}
 				listOpts := []client.ListOption{
 					client.InNamespace(o.GetNamespace()),
@@ -1513,7 +1536,7 @@ func (r *MetricStorageReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 						Namespace: o.GetNamespace(),
 						Name:      cr.Name,
 					}
-					Log.Info(fmt.Sprintf("OVN metrics service %s changed, reconciling MetricStorage CR %s", o.GetName(), cr.Name))
+					Log.Info(fmt.Sprintf("Metrics service %s changed, reconciling MetricStorage CR %s", o.GetName(), cr.Name))
 					result = append(result, reconcile.Request{NamespacedName: name})
 				}
 			}
@@ -1587,7 +1610,7 @@ func (r *MetricStorageReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 		Watches(&corev1.Service{},
 			handler.EnqueueRequestsFromMapFunc(prometheusServiceWatchFn)).
 		Watches(&corev1.Service{},
-			handler.EnqueueRequestsFromMapFunc(ovnMetricsServiceWatchFn)).
+			handler.EnqueueRequestsFromMapFunc(metricsServiceWatchFn)).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(r.findObjectsForSrc),

--- a/test/kuttl/tests/metricstorage/01-assert.yaml
+++ b/test/kuttl/tests/metricstorage/01-assert.yaml
@@ -143,6 +143,27 @@ kind: ScrapeConfig
 metadata:
   labels:
     service: metricStorage
+  name: telemetry-instanceha
+  ownerReferences:
+  - kind: MetricStorage
+    name: telemetry-kuttl
+spec:
+  scrapeInterval: 30s
+  metricRelabelings:
+  - action: labeldrop
+    regex: pod
+  - action: labeldrop
+    regex: namespace
+  - action: labeldrop
+    regex: job
+  - action: labeldrop
+    regex: publisher
+---
+apiVersion: monitoring.rhobs/v1alpha1
+kind: ScrapeConfig
+metadata:
+  labels:
+    service: metricStorage
   name: telemetry-mysqld-exporter
   ownerReferences:
   - kind: MetricStorage

--- a/test/kuttl/tests/metricstorage/01-deploy.yaml
+++ b/test/kuttl/tests/metricstorage/01-deploy.yaml
@@ -15,6 +15,23 @@ spec:
         pvcStorageRequest: 20G
   networkAttachments: []
 ---
+# Required, so that the instanceha scrapeconfig is created
+apiVersion: v1
+kind: Service
+metadata:
+  name: instanceha-0-metrics
+  labels:
+    metrics: enabled
+    service: instanceha
+spec:
+  ports:
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    service: instanceha
+---
 # Required, so that the mysqld_exporter scrapeconfig is created
 apiVersion: telemetry.openstack.org/v1beta1
 kind: Ceilometer

--- a/test/kuttl/tests/metricstorage/04-assert.yaml
+++ b/test/kuttl/tests/metricstorage/04-assert.yaml
@@ -148,3 +148,24 @@ metadata:
     name: telemetry-kuttl
 spec:
   scrapeInterval: 40s
+---
+apiVersion: monitoring.rhobs/v1alpha1
+kind: ScrapeConfig
+metadata:
+  labels:
+    service: metricStorage
+  name: telemetry-instanceha
+  ownerReferences:
+  - kind: MetricStorage
+    name: telemetry-kuttl
+spec:
+  scrapeInterval: 40s
+  metricRelabelings:
+  - action: labeldrop
+    regex: pod
+  - action: labeldrop
+    regex: namespace
+  - action: labeldrop
+    regex: job
+  - action: labeldrop
+    regex: publisher


### PR DESCRIPTION
Discover InstanceHA metrics services using label selectors (metrics=enabled, service=instanceha) and automatically generate a Prometheus ScrapeConfig for them, following the existing OVN pattern.

Depends-on: https://github.com/openstack-k8s-operators/infra-operator/pull/590