### PR TITLE
Don't use newest images for some OpenStack services in master CI jobs

### DIFF
--- a/ci/patch-mcp-telemetry-containers.yaml.j2
+++ b/ci/patch-mcp-telemetry-containers.yaml.j2
@@ -1,0 +1,18 @@
+---
+# Patch only telemetry-related images from the MCP local registry.
+# Core OpenStack services keep install_yamls default images (current-podified).
+spec:
+  customContainerImages:
+    aodhAPIImage: {{ telemetry_registry }}/openstack-aodh-api:{{ telemetry_tag }}
+    aodhEvaluatorImage: {{ telemetry_registry }}/openstack-aodh-evaluator:{{ telemetry_tag }}
+    aodhListenerImage: {{ telemetry_registry }}/openstack-aodh-listener:{{ telemetry_tag }}
+    aodhNotifierImage: {{ telemetry_registry }}/openstack-aodh-notifier:{{ telemetry_tag }}
+    ceilometerCentralImage: {{ telemetry_registry }}/openstack-ceilometer-central:{{ telemetry_tag }}
+    ceilometerComputeImage: {{ telemetry_registry }}/openstack-ceilometer-compute:{{ telemetry_tag }}
+    ceilometerIpmiImage: {{ telemetry_registry }}/openstack-ceilometer-ipmi:{{ telemetry_tag }}
+    ceilometerNotificationImage: {{ telemetry_registry }}/openstack-ceilometer-notification:{{ telemetry_tag }}
+    cloudkittyAPIImage: {{ telemetry_registry }}/openstack-cloudkitty-api:{{ telemetry_tag }}
+    cloudkittyProcImage: {{ telemetry_registry }}/openstack-cloudkitty-processor:{{ telemetry_tag }}
+    heatAPIImage: {{ telemetry_registry }}/openstack-heat-api:{{ telemetry_tag }}
+    heatCfnapiImage: {{ telemetry_registry }}/openstack-heat-api-cfn:{{ telemetry_tag }}
+    heatEngineImage: {{ telemetry_registry }}/openstack-heat-engine:{{ telemetry_tag }}

--- a/ci/use-mcp-telemetry-containers.yml
+++ b/ci/use-mcp-telemetry-containers.yml
@@ -1,0 +1,41 @@
+---
+- name: Patch OpenStackVersion with MCP telemetry containers only
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  vars:
+    patch_dir: "{{ cifmw_basedir }}/artifacts/manifests"
+    telemetry_registry: >-
+      {%- if content_provider_os_registry_url is defined and content_provider_os_registry_url -%}
+      {{ content_provider_os_registry_url }}
+      {%- else -%}
+      quay.rdoproject.org/podified-master-centos10
+      {%- endif -%}
+    telemetry_tag: >-
+      {%- if content_provider_os_registry_url is defined and content_provider_os_registry_url -%}
+      telemetry_latest
+      {%- else -%}
+      current-tested
+      {%- endif -%}
+  tasks:
+    - name: Ensure patch output directory exists
+      ansible.builtin.file:
+        path: "{{ patch_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Generate telemetry container patch file
+      ansible.builtin.template:
+        src: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/patch-mcp-telemetry-containers.yaml.j2"
+        dest: "{{ patch_dir }}/patch-mcp-telemetry-containers.yaml"
+        mode: "0644"
+
+    - name: Patch OpenStackVersion with MCP telemetry images
+      ansible.builtin.command:
+        cmd: >-
+          oc patch openstackversions controlplane
+          --namespace={{ cifmw_openstack_namespace | default('openstack') }}
+          --type merge
+          --patch-file {{ patch_dir }}/patch-mcp-telemetry-containers.yaml

--- a/ci/vars-use-mcp-telemetry-containers.yml
+++ b/ci/vars-use-mcp-telemetry-containers.yml
@@ -1,0 +1,4 @@
+---
+post_ctlplane_deploy_99_patch_mcp_telemetry_containers:
+  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/use-mcp-telemetry-containers.yml"
+  type: playbook

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,10 +1,36 @@
 ---
 - job:
+    name: telemetry-openstack-meta-content-provider-all-services-master
+    parent: openstack-meta-content-provider-master
+    description: |
+      Meta content provider that builds telemetry-operator images and all
+      OpenStack containers from master for early RHOSO 19 testing.
+    vars:
+      cifmw_build_containers_force: true
+      cifmw_bop_dlrn_from_source: true
+      cifmw_build_containers_registry_namespace: podified-master-centos10
+      cifmw_operator_build_operators:
+        - name: telemetry-operator
+          src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/telemetry-operator"
+        - name: openstack-operator
+          src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-operator"
+          image_base: telemetry
+      cifmw_build_containers_image_tag: telemetry_latest
+      # FIXME:Remove horizontest from being excluded when it would be stable
+      # to build on CentOS 10.
+      cifmw_build_containers_exclude_containers:
+        master:
+          centos10:
+            - horizontest
+
+- job:
     name: telemetry-openstack-meta-content-provider-master
     parent: openstack-meta-content-provider-master
     description: |
-      A meta content provider zuul job to build telemetry
-      specific containers.
+      Meta content provider that builds telemetry-operator images and only
+      telemetry-related OpenStack containers (aodh, ceilometer, cloudkitty,
+      heat). Core OpenStack images are left on antelope/RHOSO
+      18-like tags.
     vars:
       # Note(Chandan Kumar): image_base is the operator name without -operator.
       # It is needed by openstack-operator to include telemetry operator images
@@ -223,9 +249,10 @@
       - telemetry-openstack-meta-content-provider-master
     parent: telemetry-operator-multinode-autoscaling
     description: |
-      Deploy CloudKitty and run tempest tests - master
-      Basically it is a CI job that uses latest code coming
-      from master branch in related projects.
+      Deploy CloudKitty with telemetry services built from master and run
+      tempest tests. Uses telemetry-openstack-meta-content-provider-master,
+      so only aodh, ceilometer, cloudkitty, heat are rebuilt;
+      core OpenStack stays on antelope/RHOSO 18-like images.
     required-projects:
       - name: infrawatch/feature-verification-tests
         override-checkout: master
@@ -234,6 +261,26 @@
       #patch_observabilityclient: true
       cifmw_repo_setup_branch: master
       fetch_dlrn_hash: false
+      cifmw_prepare_openstackversion: false
+      cifmw_extras:
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/scenarios/centos-9/multinode-ci.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-cloudkitty-tempest.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-use-mcp-telemetry-containers.yml"
+    roles:
+      - zuul: github.com/openstack-k8s-operators/ci-framework
+    irrelevant-files: *irrelevant_files
+
+- job:
+    name: telemetry-operator-multinode-master
+    dependencies:
+      - telemetry-openstack-meta-content-provider-all-services-master
+    parent: telemetry-operator-multinode-cloudkitty
+    description: |
+      Deploy CloudKitty with all OpenStack services built from master and run
+      tempest tests. Uses telemetry-openstack-meta-content-provider-all-services-master
+      for early RHOSO 19 integration testing.
+    vars:
+      cifmw_prepare_openstackversion: true
       cifmw_update_containers: true
       cifmw_update_containers_openstack: true
       cifmw_update_containers_org: podified-master-centos10
@@ -241,9 +288,6 @@
       cifmw_extras:
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/scenarios/centos-9/multinode-ci.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-cloudkitty-tempest.yml"
-    roles:
-      - zuul: github.com/openstack-k8s-operators/ci-framework
-    irrelevant-files: *irrelevant_files
 
 - project-template:
     name: rdo-telemetry-tempest-plugin-jobs
@@ -276,9 +320,16 @@
     name: openstack-k8s-operators/telemetry-operator
     github-check:
       jobs:
-        # jobs uses latest available code - local registry, tag: telemetry_latest
+        # jobs uses latest available code just for telemetry
+        # services - local registry, tag: telemetry_latest
+        # All other services including OpenStack core services
+        # would not be recreated.
         - telemetry-openstack-meta-content-provider-master
         - telemetry-operator-multinode-cloudkitty
+        # job uses latest code for all OpenStack services - including
+        # core services
+        - telemetry-openstack-meta-content-provider-all-services-master
+        - telemetry-operator-multinode-master
         # jobs uses latest stable code - tag: current-podified
         - openstack-k8s-operators-content-provider:
             vars:

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -19,10 +19,91 @@
           src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-operator"
           image_base: telemetry
       cifmw_build_containers_image_tag: telemetry_latest
+      # Build only telemetry-related containers listed in ci/files/containers.yaml
+      # (aodh, ceilometer, cloudkitty, heat). Exclude everything
+      # else so core OpenStack stays on antelope/RHOSO 18-like images.
       cifmw_build_containers_exclude_containers:
         master:
           centos10:
+            # core OpenStack
+            - keystone
+            - glance-api
+            - nova-api
+            - nova-scheduler
+            - nova-conductor
+            - nova-compute
+            - nova-novncproxy
+            - neutron-server
+            - neutron-dhcp-agent
+            - neutron-ovn-agent
+            - neutron-metadata-agent-ovn
+            - neutron-sriov-agent
+            - cinder-api
+            - cinder-scheduler
+            - cinder-volume
+            - cinder-backup
+            - placement-api
+            - horizon
             - horizontest
+            - openstackclient
+            # infrastructure
+            - mariadb
+            - rabbitmq
+            - memcached
+            - redis
+            - valkey
+            - haproxy
+            - rsyslog
+            - cron
+            - netutils
+            - frr
+            - ovn-controller
+            - ovn-nb-db-server
+            - ovn-sb-db-server
+            - ovn-northd
+            - ovn-bgp-agent
+            - iscsid
+            - multipathd
+            # DNS-as-a-service
+            - designate-api
+            - designate-central
+            - designate-worker
+            - designate-mdns
+            - designate-producer
+            - designate-backend-bind9
+            - designate-sink
+            - unbound
+            # file shares
+            - manila-api
+            - manila-scheduler
+            - manila-share
+            # load balancing
+            - octavia-api
+            - octavia-worker
+            - octavia-housekeeping
+            - octavia-health-manager
+            # bare metal
+            - ironic-api
+            - ironic-conductor
+            - ironic-inspector
+            - ironic-neutron-agent
+            - ironic-pxe
+            # key manager service
+            - barbican-api
+            - barbican-keystone-listener
+            - barbican-worker
+            # object storage
+            - swift-account
+            - swift-container
+            - swift-object
+            - swift-proxy-server
+            # optimization
+            - watcher-api
+            - watcher-applier
+            - watcher-decision-engine
+            # CI / test images
+            - ansible-tests
+            - tobiko
 
 - job:
     name: telemetry-operator-multinode-autoscaling


### PR DESCRIPTION
The telemetry-operator-multinode-cloudkitty CI job does not need to recreate all container images to have latest code. The most important for us it to verify claudkitty service with other telemetry related services.
That change would help to avoid unexpected issues for non-core OpenStack services during the deployment and verification.

Add all-services telemetry master CI jobs

Add two new CI jobs that verify telemetry services with all OpenStack
services enabled:

    - telemetry-openstack-meta-content-provider-all-services-master
    - telemetry-operator-multinode-master

These jobs use locally-built telemetry images instead of current-podified
tags. Since images cannot be updated before the edpm_prepare role's
"Wait for OpenStack controlplane to be deployed" task, a post-deployment
hook applies use-mcp-telemetry-containers.yml to replace current-podified
images with the local registry images built by the MCP job.