### PR TITLE
Use project_name instead of project_id in dashboards

### DIFF
--- a/internal/dashboards/openstack-network-traffic.go
+++ b/internal/dashboards/openstack-network-traffic.go
@@ -109,12 +109,12 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "vm:ceilometer_network_incoming_bytes:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
+                                        "expr": "vm:ceilometer_network_incoming_bytes:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
                                         "legendFormat": "{{vm_name}} in ({{device}})",
                                         "refId": "B"
                                     },
                                     {
-                                        "expr": "vm:ceilometer_network_outgoing_bytes:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
+                                        "expr": "vm:ceilometer_network_outgoing_bytes:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
                                         "legendFormat": "{{vm_name}} out ({{device}})",
                                         "refId": "A"
                                     }
@@ -224,7 +224,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "vm:ceilometer_network_incoming_bytes:rate1m{resource_name=~\"$VM:.*\", project=~\"$project\" } / 1000000",
+                                        "expr": "vm:ceilometer_network_incoming_bytes:rate1m{resource_name=~\"$VM:.*\", project_name=~\"$project\" } / 1000000",
                                         "editorMode": "code",
                                         "range": true,
                                         "legendFormat": "{{vm_name}} in ({{device}})",
@@ -319,7 +319,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "vm:ceilometer_network_incoming_packets_drop:rate1m{project =~ \"$project\",vm_name =~ \"$VM\", device =~\"$In_adapter\" }",
+                                        "expr": "vm:ceilometer_network_incoming_packets_drop:rate1m{project_name =~ \"$project\",vm_name =~ \"$VM\", device =~\"$In_adapter\" }",
                                         "editorMode": "code",
                                         "range": true,
                                         "legendFormat": "{{vm_name}} in ({{device}})",
@@ -425,7 +425,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "(vm:ceilometer_network_incoming_packets_drop:rate1m{project =~ \"$project\",vm_name =~ \"$VM\", device =~\"$In_adapter\" } / vm:ceilometer_network_incoming_packets:rate1m{project =~ \"$project\",vm_name =~ \"$VM\", device =~\"$In_adapter\"}) * 100\n",
+                                        "expr": "(vm:ceilometer_network_incoming_packets_drop:rate1m{project_name =~ \"$project\",vm_name =~ \"$VM\", device =~\"$In_adapter\" } / vm:ceilometer_network_incoming_packets:rate1m{project_name =~ \"$project\",vm_name =~ \"$VM\", device =~\"$In_adapter\"}) * 100\n",
                                         "editorMode": "code",
                                         "range": true,
                                         "legendFormat": "{{vm_name}} in ({{device}})",
@@ -531,7 +531,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "vm:ceilometer_network_incoming_packets_error:rate1m{project =~ \"$project\",vm_name =~ \"$VM\", device =~\"$In_adapter\"}",
+                                        "expr": "vm:ceilometer_network_incoming_packets_error:rate1m{project_name =~ \"$project\",vm_name =~ \"$VM\", device =~\"$In_adapter\"}",
                                         "editorMode": "code",
                                         "hide": false,
                                         "interval": "",
@@ -642,7 +642,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "vm:ceilometer_network_outgoing_bytes:rate1m{resource_name=~\"$VM:.+\", project=~\"$project\" } / 1000000",
+                                        "expr": "vm:ceilometer_network_outgoing_bytes:rate1m{resource_name=~\"$VM:.+\", project_name=~\"$project\" } / 1000000",
                                         "editorMode": "code",
                                         "range": true,
                                         "legendFormat": "{{vm_name}} out ({{device}})",
@@ -738,7 +738,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "vm:ceilometer_network_outgoing_packets_drop:rate1m{project =~ \"$project\",vm_name =~ \"$VM\", device =~\"$Out_adapter\" }",
+                                        "expr": "vm:ceilometer_network_outgoing_packets_drop:rate1m{project_name =~ \"$project\",vm_name =~ \"$VM\", device =~\"$Out_adapter\" }",
                                         "editorMode": "code",
                                         "range": true,
                                         "legendFormat": "{{vm_name}} out ({{device}})",
@@ -834,7 +834,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "(vm:ceilometer_network_outgoing_packets_drop:rate1m{project =~ \"$project\",vm_name =~ \"$VM\", device =~\"$Out_adapter\" } / vm:ceilometer_network_outgoing_packets:rate1m{project =~ \"$project\",vm_name =~ \"$VM\", device =~\"$Out_adapter\" }) * 100\n",
+                                        "expr": "(vm:ceilometer_network_outgoing_packets_drop:rate1m{project_name =~ \"$project\",vm_name =~ \"$VM\", device =~\"$Out_adapter\" } / vm:ceilometer_network_outgoing_packets:rate1m{project_name =~ \"$project\",vm_name =~ \"$VM\", device =~\"$Out_adapter\" }) * 100\n",
                                         "editorMode": "code",
                                         "range": true,
                                         "legendFormat": "{{vm_name}} out ({{device}})",
@@ -940,7 +940,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "vm:ceilometer_network_outgoing_packets_error:rate1m{project =~ \"$project\",vm_name =~ \"$VM\", device =~\"$Out_adapter\"}",
+                                        "expr": "vm:ceilometer_network_outgoing_packets_error:rate1m{project_name =~ \"$project\",vm_name =~ \"$VM\", device =~\"$Out_adapter\"}",
                                         "editorMode": "code",
                                         "range": true,
                                         "legendFormat": "{{vm_name}} out ({{device}})",
@@ -1026,16 +1026,16 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                             "allValue": ".*",
                             "current": {
                                 "tags": [],
-                                "text": "539c3dc2361f4fd191aaa21c14360e35",
+                                "text": "admin",
                                 "value": [
-                                    "539c3dc2361f4fd191aaa21c14360e35"
+                                    "admin"
                                 ]
                             },
                             "datasource": {
                                 "name": "` + dsName + `",
                                 "type": "prometheus"
                             },
-                            "definition": "label_values(ceilometer_cpu{vm_instance=~\"$compute_node\"}, project)",
+                            "definition": "label_values(ceilometer_cpu{vm_instance=~\"$compute_node\"}, project_name)",
                             "hide": 0,
                             "includeAll": true,
                             "index": -1,
@@ -1043,7 +1043,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                             "multi": true,
                             "name": "project",
                             "options": [],
-                            "query": "label_values(ceilometer_cpu{vm_instance=~\"$compute_node\"}, project)",
+                            "query": "label_values(ceilometer_cpu{vm_instance=~\"$compute_node\"}, project_name)",
                             "refresh": 0,
                             "regex": "",
                             "skipUrlSync": false,
@@ -1064,14 +1064,14 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "name": "` + dsName + `",
                                 "type": "prometheus"
                             },
-                            "definition": "label_values(ceilometer_cpu{project =~ \"$project\"}, vm_instance)",
+                            "definition": "label_values(ceilometer_cpu{project_name =~ \"$project\"}, vm_instance)",
                             "hide": 0,
                             "includeAll": true,
                             "label": null,
                             "multi": true,
                             "name": "VM",
                             "options": [],
-                            "query": "label_values(vm:ceilometer_cpu:ratio1m{project =~ \"$project\"}, vm_name)",
+                            "query": "label_values(vm:ceilometer_cpu:ratio1m{project_name =~ \"$project\"}, vm_name)",
                             "refresh": 0,
                             "regex": "",
                             "skipUrlSync": false,

--- a/internal/dashboards/openstack-vm.go
+++ b/internal/dashboards/openstack-vm.go
@@ -181,7 +181,7 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 					"steppedLine": false,
 					"targets": [
 						{
-						"expr": "vm:ceilometer_cpu:ratio1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_cpu:ratio1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}}",
@@ -271,7 +271,7 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 					"steppedLine": false,
 					"targets": [
 						{
-						"expr": "vm:ceilometer_memory_usage:total{project =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_memory_usage:total{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}}",
@@ -360,7 +360,7 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 					"steppedLine": false,
 					"targets": [
 						{
-						"expr": "vm:ceilometer_disk_device_usage:total{project =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_disk_device_usage:total{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}}({{device}})",
@@ -449,13 +449,13 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 					"steppedLine": false,
 					"targets": [
 						{
-						"expr": "vm:ceilometer_disk_device_read_bytes:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_disk_device_read_bytes:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
 						"interval": "",
 						"legendFormat": "{{vm_name}} read ({{device}})",
 						"refId": "A"
 						},
 						{
-						"expr": "vm:ceilometer_disk_device_write_bytes:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_disk_device_write_bytes:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}} write ({{device}})",
@@ -544,14 +544,14 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 					"steppedLine": false,
 					"targets": [
 						{
-							"expr": "vm:ceilometer_network_incoming_bytes:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
+							"expr": "vm:ceilometer_network_incoming_bytes:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
 							"hide": false,
 							"interval": "",
 							"legendFormat": "{{vm_name}} in ({{device}})",
 							"refId": "B"
 						},
 						{
-						"expr": "vm:ceilometer_network_outgoing_bytes:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_network_outgoing_bytes:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}} out ({{device}})",
@@ -640,14 +640,14 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 					"steppedLine": false,
 					"targets": [
 						{
-						"expr": "vm:ceilometer_network_incoming_packets_drop:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_network_incoming_packets_drop:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}} in ({{device}})",
 						"refId": "A"
 						},
 						{
-						"expr": "vm:ceilometer_network_outgoing_packets_drop:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_network_outgoing_packets_drop:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}} out ({{device}})",
@@ -736,14 +736,14 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 					"steppedLine": false,
 					"targets": [
 						{
-						"expr": "vm:ceilometer_network_incoming_packets_error:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_network_incoming_packets_error:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}} in ({{device}})",
 						"refId": "A"
 						},
 						{
-						"expr": "vm:ceilometer_network_outgoing_packets_error:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_network_outgoing_packets_error:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}} out ({{device}})",
@@ -804,13 +804,13 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 						"allValue": ".*",
 						"current": {
 						"tags": [],
-						"text": "66ad788dfacb4560b4c4e27e7ebc3b35",
+						"text": "admin",
 						"value": [
-							"66ad788dfacb4560b4c4e27e7ebc3b35"
+							"admin"
 						]
 						},
 						"datasource": { "name": "` + dsName + `", "type": "prometheus" },
-						"definition": "label_values(ceilometer_cpu, project)",
+						"definition": "label_values(ceilometer_cpu, project_name)",
 						"hide": 0,
 						"includeAll": true,
 						"index": -1,
@@ -825,16 +825,11 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 						},
 						{
 							"selected": true,
-							"text": "66ad788dfacb4560b4c4e27e7ebc3b35",
-							"value": "66ad788dfacb4560b4c4e27e7ebc3b35"
-						},
-						{
-							"selected": false,
-							"text": "ad3f0a004afc41fc80bb2a6e69ec4e6e",
-							"value": "ad3f0a004afc41fc80bb2a6e69ec4e6e"
+							"text": "admin",
+							"value": "admin"
 						}
 						],
-						"query": "label_values(ceilometer_cpu, project)",
+						"query": "label_values(ceilometer_cpu, project_name)",
 						"refresh": 0,
 						"regex": "",
 						"skipUrlSync": false,
@@ -856,7 +851,7 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 						]
 						},
 						"datasource": { "name": "` + dsName + `", "type": "prometheus" },
-						"definition": "label_values(ceilometer_cpu{project =~ \"$project\"}, vm_instance)",
+						"definition": "label_values(ceilometer_cpu{project_name =~ \"$project\"}, vm_instance)",
 						"hide": 0,
 						"includeAll": false,
 						"index": -1,
@@ -880,7 +875,7 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 							"value": "1d0808c7d062b9b20bfb2979b0d940b55c10312b1a56894a4b7c3238"
 						}
 						],
-						"query": "label_values(vm:ceilometer_cpu:ratio1m{project =~ \"$project\"}, vm_name)",
+						"query": "label_values(vm:ceilometer_cpu:ratio1m{project_name =~ \"$project\"}, vm_name)",
 						"refresh": 0,
 						"regex": "",
 						"skipUrlSync": false,


### PR DESCRIPTION
The ceilometer metrics in Prometheus now carry a project_name label. Update the VM and Network Traffic dashboards to query and display project names instead of opaque project IDs.