### PR TITLE
[OSPRH-30626] Enable audit logs for Barbican and Nova

### DIFF
--- a/ci/enable-audit-logging/README.md
+++ b/ci/enable-audit-logging/README.md
@@ -4,18 +4,12 @@ enable-audit-logging
 A role for enabling CADF audit logging on OpenStack services deployed by openstack-k8s-operators. The role creates the necessary audit configuration secrets and applies kustomizations to the OpenStackControlPlane CR.
 
 Currently supported services:
+- Barbican
 - Cinder
 - Glance
 - Keystone
 - Neutron
-
-Services not yet supported (config files included for future use):
-- Barbican (blocked by [OSPRH-25781](https://issues.redhat.com/browse/OSPRH-25781))
-- Nova (blocked by a nova-operator issue with audit map file naming)
-
-Audit map files
-----------------
-The `*_api_audit_map.conf` files in `files/` are copies of the upstream pycadf defaults from https://github.com/openstack/pycadf/tree/master/etc/pycadf. If the upstream files change, the local copies should be updated to match.
+- Nova
 
 Requirements
 ------------

--- a/ci/enable-audit-logging/tasks/main.yml
+++ b/ci/enable-audit-logging/tasks/main.yml
@@ -1,15 +1,6 @@
 - name: Create service audit config secrets
   ansible.builtin.include_tasks: create-secrets.yml
 
-# Barbican: disabled - the barbican-operator does not currently support
-# providing a custom api-paste.ini through defaultConfigOverwrite.
-# Config files are included in files/ for future use.
-# Tracked in: https://issues.redhat.com/browse/OSPRH-25781
-
-# Nova: disabled - there is a known issue with the nova-operator that
-# requires naming the audit map file as policy.yaml. Config files are
-# included in files/ for future use.
-
 - name: Copy controlplane kustomization for audit logging
   ansible.builtin.template:
     src: 90-kustomize-controlplane-audit-logging.yaml.j2

--- a/ci/enable-audit-logging/templates/90-kustomize-controlplane-audit-logging.yaml.j2
+++ b/ci/enable-audit-logging/templates/90-kustomize-controlplane-audit-logging.yaml.j2
@@ -8,6 +8,12 @@ patches:
     metadata:
       name: unused
     spec:
+      barbican:
+        template:
+          barbicanAPI:
+            defaultConfigOverwrite:
+              barbican-api-paste.ini: |
+{{ lookup('file', role_path + '/files/barbican-api-paste.ini') | indent(16, true) }}
       cinder:
         template:
           cinderAPI:
@@ -79,5 +85,11 @@ patches:
               - name: audit
                 secret:
                   secretName: {{ enable_audit_logging_neutron_secret }}
+      nova:
+        template:
+          apiServiceTemplate:
+            defaultConfigOverwrite:
+              api-paste.ini: |
+{{ lookup('file', role_path + '/files/nova-api-paste.ini') | indent(16, true) }}
   target:
     kind: OpenStackControlPlane


### PR DESCRIPTION
Barbican-operator has been fixed, so the audit logs will work in barbican and with the recent switch to use the audit map files from /etc/pycadf, the nova audit logs can be enabled as well.

Generated-By: Claude Opus 4.6
Depends-On: https://github.com/openstack-k8s-operators/telemetry-operator/pull/913