### PR TITLE
Don't use newest images for some OpenStack services in master CI jobs

### DIFF
--- a/ci/files/containers.yaml
+++ b/ci/files/containers.yaml
@@ -1,0 +1,15 @@
+container_images:
+  - imagename: quay.io/podified-master-centos10/openstack-aodh-api:current-podified
+  - imagename: quay.io/podified-master-centos10/openstack-aodh-evaluator:current-podified
+  - imagename: quay.io/podified-master-centos10/openstack-aodh-listener:current-podified
+  - imagename: quay.io/podified-master-centos10/openstack-aodh-notifier:current-podified
+  - imagename: quay.io/podified-master-centos10/openstack-ceilometer-central:current-podified
+  - imagename: quay.io/podified-master-centos10/openstack-ceilometer-compute:current-podified
+  - imagename: quay.io/podified-master-centos10/openstack-ceilometer-notification:current-podified
+  - imagename: quay.io/podified-master-centos10/openstack-ceilometer-ipmi:current-podified
+  - imagename: quay.io/podified-master-centos10/openstack-cloudkitty-api:current-podified
+  - imagename: quay.io/podified-master-centos10/openstack-cloudkitty-processor:current-podified
+  - imagename: quay.io/podified-master-centos10/openstack-heat-api:current-podified
+  - imagename: quay.io/podified-master-centos10/openstack-heat-api-cfn:current-podified
+  - imagename: quay.io/podified-master-centos10/openstack-heat-engine:current-podified
+  - imagename: quay.io/podified-master-centos10/openstack-tempest-all:current-podified

--- a/ci/patch-meta-content-telemetry-containers.yaml.j2
+++ b/ci/patch-meta-content-telemetry-containers.yaml.j2
@@ -1,0 +1,18 @@
+---
+# Patch only telemetry-related images from the Meta Content Provider local registry.
+# Core OpenStack services keep install_yamls default images (current-podified).
+spec:
+  customContainerImages:
+    aodhAPIImage: {{ telemetry_registry }}/openstack-aodh-api:{{ telemetry_tag }}
+    aodhEvaluatorImage: {{ telemetry_registry }}/openstack-aodh-evaluator:{{ telemetry_tag }}
+    aodhListenerImage: {{ telemetry_registry }}/openstack-aodh-listener:{{ telemetry_tag }}
+    aodhNotifierImage: {{ telemetry_registry }}/openstack-aodh-notifier:{{ telemetry_tag }}
+    ceilometerCentralImage: {{ telemetry_registry }}/openstack-ceilometer-central:{{ telemetry_tag }}
+    ceilometerComputeImage: {{ telemetry_registry }}/openstack-ceilometer-compute:{{ telemetry_tag }}
+    ceilometerIpmiImage: {{ telemetry_registry }}/openstack-ceilometer-ipmi:{{ telemetry_tag }}
+    ceilometerNotificationImage: {{ telemetry_registry }}/openstack-ceilometer-notification:{{ telemetry_tag }}
+    cloudkittyAPIImage: {{ telemetry_registry }}/openstack-cloudkitty-api:{{ telemetry_tag }}
+    cloudkittyProcImage: {{ telemetry_registry }}/openstack-cloudkitty-processor:{{ telemetry_tag }}
+    heatAPIImage: {{ telemetry_registry }}/openstack-heat-api:{{ telemetry_tag }}
+    heatCfnapiImage: {{ telemetry_registry }}/openstack-heat-api-cfn:{{ telemetry_tag }}
+    heatEngineImage: {{ telemetry_registry }}/openstack-heat-engine:{{ telemetry_tag }}

--- a/ci/use-meta-content-telemetry-containers.yml
+++ b/ci/use-meta-content-telemetry-containers.yml
@@ -1,0 +1,41 @@
+---
+- name: Patch OpenStackVersion with Meta Content Provider telemetry containers only
+  hosts: "{{ cifmw_target_hook_host | default('localhost') }}"
+  gather_facts: false
+  environment:
+    KUBECONFIG: "{{ cifmw_openshift_kubeconfig }}"
+    PATH: "{{ cifmw_path }}"
+  vars:
+    patch_dir: "{{ cifmw_basedir }}/artifacts/manifests"
+    telemetry_registry: >-
+      {%- if content_provider_os_registry_url is defined and content_provider_os_registry_url != '' -%}
+      {{ content_provider_os_registry_url }}
+      {%- else -%}
+      quay.rdoproject.org/podified-master-centos10
+      {%- endif -%}
+    telemetry_tag: >-
+      {%- if content_provider_os_registry_url is defined and content_provider_os_registry_url != '' -%}
+      telemetry_latest
+      {%- else -%}
+      current-tested
+      {%- endif -%}
+  tasks:
+    - name: Ensure patch output directory exists
+      ansible.builtin.file:
+        path: "{{ patch_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Generate telemetry container patch file
+      ansible.builtin.template:
+        src: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/patch-meta-content-telemetry-containers.yaml.j2"
+        dest: "{{ patch_dir }}/patch-meta-content-telemetry-containers.yaml"
+        mode: "0644"
+
+    - name: Patch OpenStackVersion with Meta Content Provider telemetry images
+      ansible.builtin.command:
+        cmd: >-
+          oc patch openstackversions controlplane
+          --namespace={{ cifmw_openstack_namespace | default('openstack') }}
+          --type merge
+          --patch-file {{ patch_dir }}/patch-meta-content-telemetry-containers.yaml

--- a/ci/vars-use-meta-content-telemetry-containers.yml
+++ b/ci/vars-use-meta-content-telemetry-containers.yml
@@ -1,0 +1,4 @@
+---
+post_ctlplane_deploy_99_patch_meta_content_telemetry_containers:
+  source: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/use-meta-content-telemetry-containers.yml"
+  type: playbook

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,14 +1,11 @@
 ---
 - job:
-    name: telemetry-openstack-meta-content-provider-master
+    name: telemetry-openstack-meta-content-provider-all-services-master
     parent: openstack-meta-content-provider-master
     description: |
-      A meta content provider zuul job to build telemetry
-      specific containers.
+      Meta content provider that builds telemetry-operator images and all
+      OpenStack containers from master for early RHOSO 19 testing.
     vars:
-      # Note(Chandan Kumar): image_base is the operator name without -operator.
-      # It is needed by openstack-operator to include telemetry operator images
-      # in the openstack-operator catalog image.
       cifmw_build_containers_force: true
       cifmw_bop_dlrn_from_source: true
       cifmw_build_containers_registry_namespace: podified-master-centos10
@@ -19,10 +16,37 @@
           src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-operator"
           image_base: telemetry
       cifmw_build_containers_image_tag: telemetry_latest
+      # FIXME:Remove horizontest from being excluded when it would be stable
+      # to build on CentOS 10.
       cifmw_build_containers_exclude_containers:
         master:
           centos10:
             - horizontest
+
+- job:
+    name: telemetry-openstack-meta-content-provider-master
+    parent: openstack-meta-content-provider-master
+    description: |
+      Meta content provider that builds telemetry-operator images and only
+      telemetry-related OpenStack containers listed in ci/files/containers.yaml
+      (aodh, ceilometer, cloudkitty, heat, tempest-all). Core OpenStack images
+      are not rebuilt.
+    vars:
+      # Note(Chandan Kumar): image_base is the operator name without -operator.
+      # It is needed by openstack-operator to include telemetry operator images
+      # in the openstack-operator catalog image.
+      cifmw_build_containers_force: true
+      cifmw_bop_dlrn_from_source: true
+      cifmw_build_containers_registry_namespace: podified-master-centos10
+      zuul_project_container_path: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/telemetry-operator/ci/files/containers.yaml"
+      cifmw_build_containers_config_file: "{{ ansible_user_dir }}/containers.yaml"
+      cifmw_operator_build_operators:
+        - name: telemetry-operator
+          src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/telemetry-operator"
+        - name: openstack-operator
+          src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/openstack-operator"
+          image_base: telemetry
+      cifmw_build_containers_image_tag: telemetry_latest
 
 - job:
     name: telemetry-operator-multinode-autoscaling
@@ -81,7 +105,7 @@
       - openstack-k8s-operators-content-provider
     description: |
       Deploy a default OpenStack with telemetry enabled, but without COO installed. Check that the telemetry-operator logs don't have any errors.
-    extra-vars: &mcp_extra_vars
+    extra-vars: &meta_content_extra_vars
       # Override zuul meta content provider provided content_provider_dlrn_md5_hash
       # var. As returned dlrn md5 hash comes from master release but job is using
       # antelope content.
@@ -142,17 +166,40 @@
       - telemetry-openstack-meta-content-provider-master
     parent: telemetry-operator-multinode-autoscaling
     description: |
-      Deploy CloudKitty and run tempest tests - master
-      Basically it is a CI job that uses latest code coming
-      from master branch in related projects.
+      Deploy CloudKitty with telemetry services built from master and run
+      tempest tests. Uses telemetry-openstack-meta-content-provider-master,
+      so only aodh, ceilometer, cloudkitty, heat are rebuilt from meta content provider;
+      core OpenStack stays on stable install_yamls images.
     required-projects:
       - name: infrawatch/feature-verification-tests
         override-checkout: master
-    extra-vars: *mcp_extra_vars
+    extra-vars: *meta_content_extra_vars
     vars:
       #patch_observabilityclient: true
       cifmw_repo_setup_branch: master
       fetch_dlrn_hash: false
+      # Skip full update_containers; patch only telemetry images
+      # from meta content provider after control plane deploy. Core services keep stable images.
+      cifmw_prepare_openstackversion: false
+      cifmw_extras:
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/scenarios/centos-9/multinode-ci.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-cloudkitty-tempest.yml"
+        - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-use-meta-content-telemetry-containers.yml"
+    roles:
+      - zuul: github.com/openstack-k8s-operators/ci-framework
+    irrelevant-files: *irrelevant_files
+
+- job:
+    name: telemetry-operator-multinode-master
+    dependencies:
+      - telemetry-openstack-meta-content-provider-all-services-master
+    parent: telemetry-operator-multinode-cloudkitty
+    description: |
+      Deploy CloudKitty with all OpenStack services built from master and run
+      tempest tests. Uses telemetry-openstack-meta-content-provider-all-services-master
+      for early RHOSO 19 integration testing.
+    vars:
+      cifmw_prepare_openstackversion: true
       cifmw_update_containers: true
       cifmw_update_containers_openstack: true
       cifmw_update_containers_org: podified-master-centos10
@@ -160,8 +207,6 @@
       cifmw_extras:
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/ci-framework'].src_dir }}/scenarios/centos-9/multinode-ci.yml"
         - "@{{ ansible_user_dir }}/{{ zuul.projects['github.com/openstack-k8s-operators/telemetry-operator'].src_dir }}/ci/vars-cloudkitty-tempest.yml"
-    roles:
-      - zuul: github.com/openstack-k8s-operators/ci-framework
     irrelevant-files: *irrelevant_files
 
 - project-template:
@@ -195,9 +240,16 @@
     name: openstack-k8s-operators/telemetry-operator
     github-check:
       jobs:
-        # jobs uses latest available code - local registry, tag: telemetry_latest
+        # jobs uses latest available code just for telemetry
+        # services - local registry, tag: telemetry_latest
+        # All other services including OpenStack core services
+        # would not be recreated.
         - telemetry-openstack-meta-content-provider-master
         - telemetry-operator-multinode-cloudkitty
+        # job uses latest code for all OpenStack services - including
+        # core services
+        - telemetry-openstack-meta-content-provider-all-services-master
+        - telemetry-operator-multinode-master
         # jobs uses latest stable code - tag: current-podified
         - openstack-k8s-operators-content-provider:
             vars:


### PR DESCRIPTION
The telemetry-operator-multinode-cloudkitty CI job does not need to recreate all container images to have latest code. The most important for us it to verify claudkitty service with other telemetry related services.

Also add two new CI jobs that verify telemetry services with all OpenStack services enabled:

    - telemetry-openstack-meta-content-provider-all-services-master
    - telemetry-operator-multinode-master

These jobs use locally-built telemetry images instead of current-podified tags. Since images cannot be updated before the edpm_prepare role's "Wait for OpenStack controlplane to be deployed" task, a post-deployment hook applies use-mcp-telemetry-containers.yml to replace current-podified images with the local registry images built by the MCP job.

Assisted-by: Clause 4.6