### PR TITLE
Bump lokistack deployment wait time

### DIFF
--- a/ci/deploy-logging-dependencies/tasks/deploy-loki.yml
+++ b/ci/deploy-logging-dependencies/tasks/deploy-loki.yml
@@ -24,7 +24,7 @@
       -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
   register: loki_ready
   until: loki_ready.stdout == "True"
-  retries: 40
+  retries: 80
   delay: 15
 
 - name: Create audit loki S3 secret
@@ -52,5 +52,5 @@
       oc get lokistack logging-loki-audit -n openshift-logging -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
   register: audit_loki_ready
   until: audit_loki_ready.stdout == "True"
-  retries: 40
+  retries: 80
   delay: 15


### PR DESCRIPTION
The lokistack requires a lot of resources and it seems like we're hitting limits of what our CI is able to handle. It looks like the ingester sometimes flaps between ready and unready state, but eventually gets ready (I haven't seen a must-gather with a lokistack being unready during the must-gather execution). I've seen some lokistacks taking 15 minutes to get ready. Let's raise the wait time to 20 minutes to give CRC enough time to deal with the added load and for lokistack to get ready and settled.