### PR TITLE
[18.0-fr6] Revert identity name discovery

### DIFF
--- a/internal/dashboards/openstack-network-traffic.go
+++ b/internal/dashboards/openstack-network-traffic.go
@@ -109,12 +109,12 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "vm:ceilometer_network_incoming_bytes:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
+                                        "expr": "vm:ceilometer_network_incoming_bytes:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
                                         "legendFormat": "{{vm_name}} in ({{device}})",
                                         "refId": "B"
                                     },
                                     {
-                                        "expr": "vm:ceilometer_network_outgoing_bytes:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
+                                        "expr": "vm:ceilometer_network_outgoing_bytes:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
                                         "legendFormat": "{{vm_name}} out ({{device}})",
                                         "refId": "A"
                                     }
@@ -224,7 +224,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "vm:ceilometer_network_incoming_bytes:rate1m{resource_name=~\"$VM:.*\", project_name=~\"$project\" } / 1000000",
+                                        "expr": "vm:ceilometer_network_incoming_bytes:rate1m{resource_name=~\"$VM:.*\", project=~\"$project\" } / 1000000",
                                         "editorMode": "code",
                                         "range": true,
                                         "legendFormat": "{{vm_name}} in ({{device}})",
@@ -319,7 +319,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "vm:ceilometer_network_incoming_packets_drop:rate1m{project_name =~ \"$project\",vm_name =~ \"$VM\", device =~\"$In_adapter\" }",
+                                        "expr": "vm:ceilometer_network_incoming_packets_drop:rate1m{project =~ \"$project\",vm_name =~ \"$VM\", device =~\"$In_adapter\" }",
                                         "editorMode": "code",
                                         "range": true,
                                         "legendFormat": "{{vm_name}} in ({{device}})",
@@ -425,7 +425,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "(vm:ceilometer_network_incoming_packets_drop:rate1m{project_name =~ \"$project\",vm_name =~ \"$VM\", device =~\"$In_adapter\" } / vm:ceilometer_network_incoming_packets:rate1m{project_name =~ \"$project\",vm_name =~ \"$VM\", device =~\"$In_adapter\"}) * 100\n",
+                                        "expr": "(vm:ceilometer_network_incoming_packets_drop:rate1m{project =~ \"$project\",vm_name =~ \"$VM\", device =~\"$In_adapter\" } / vm:ceilometer_network_incoming_packets:rate1m{project =~ \"$project\",vm_name =~ \"$VM\", device =~\"$In_adapter\"}) * 100\n",
                                         "editorMode": "code",
                                         "range": true,
                                         "legendFormat": "{{vm_name}} in ({{device}})",
@@ -531,7 +531,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "vm:ceilometer_network_incoming_packets_error:rate1m{project_name =~ \"$project\",vm_name =~ \"$VM\", device =~\"$In_adapter\"}",
+                                        "expr": "vm:ceilometer_network_incoming_packets_error:rate1m{project =~ \"$project\",vm_name =~ \"$VM\", device =~\"$In_adapter\"}",
                                         "editorMode": "code",
                                         "hide": false,
                                         "interval": "",
@@ -642,7 +642,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "vm:ceilometer_network_outgoing_bytes:rate1m{resource_name=~\"$VM:.+\", project_name=~\"$project\" } / 1000000",
+                                        "expr": "vm:ceilometer_network_outgoing_bytes:rate1m{resource_name=~\"$VM:.+\", project=~\"$project\" } / 1000000",
                                         "editorMode": "code",
                                         "range": true,
                                         "legendFormat": "{{vm_name}} out ({{device}})",
@@ -738,7 +738,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "vm:ceilometer_network_outgoing_packets_drop:rate1m{project_name =~ \"$project\",vm_name =~ \"$VM\", device =~\"$Out_adapter\" }",
+                                        "expr": "vm:ceilometer_network_outgoing_packets_drop:rate1m{project =~ \"$project\",vm_name =~ \"$VM\", device =~\"$Out_adapter\" }",
                                         "editorMode": "code",
                                         "range": true,
                                         "legendFormat": "{{vm_name}} out ({{device}})",
@@ -834,7 +834,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "(vm:ceilometer_network_outgoing_packets_drop:rate1m{project_name =~ \"$project\",vm_name =~ \"$VM\", device =~\"$Out_adapter\" } / vm:ceilometer_network_outgoing_packets:rate1m{project_name =~ \"$project\",vm_name =~ \"$VM\", device =~\"$Out_adapter\" }) * 100\n",
+                                        "expr": "(vm:ceilometer_network_outgoing_packets_drop:rate1m{project =~ \"$project\",vm_name =~ \"$VM\", device =~\"$Out_adapter\" } / vm:ceilometer_network_outgoing_packets:rate1m{project =~ \"$project\",vm_name =~ \"$VM\", device =~\"$Out_adapter\" }) * 100\n",
                                         "editorMode": "code",
                                         "range": true,
                                         "legendFormat": "{{vm_name}} out ({{device}})",
@@ -940,7 +940,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "steppedLine": false,
                                 "targets": [
                                     {
-                                        "expr": "vm:ceilometer_network_outgoing_packets_error:rate1m{project_name =~ \"$project\",vm_name =~ \"$VM\", device =~\"$Out_adapter\"}",
+                                        "expr": "vm:ceilometer_network_outgoing_packets_error:rate1m{project =~ \"$project\",vm_name =~ \"$VM\", device =~\"$Out_adapter\"}",
                                         "editorMode": "code",
                                         "range": true,
                                         "legendFormat": "{{vm_name}} out ({{device}})",
@@ -1026,16 +1026,16 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                             "allValue": ".*",
                             "current": {
                                 "tags": [],
-                                "text": "admin",
+                                "text": "539c3dc2361f4fd191aaa21c14360e35",
                                 "value": [
-                                    "admin"
+                                    "539c3dc2361f4fd191aaa21c14360e35"
                                 ]
                             },
                             "datasource": {
                                 "name": "` + dsName + `",
                                 "type": "prometheus"
                             },
-                            "definition": "label_values(ceilometer_cpu{vm_instance=~\"$compute_node\"}, project_name)",
+                            "definition": "label_values(ceilometer_cpu{vm_instance=~\"$compute_node\"}, project)",
                             "hide": 0,
                             "includeAll": true,
                             "index": -1,
@@ -1043,7 +1043,7 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                             "multi": true,
                             "name": "project",
                             "options": [],
-                            "query": "label_values(ceilometer_cpu{vm_instance=~\"$compute_node\"}, project_name)",
+                            "query": "label_values(ceilometer_cpu{vm_instance=~\"$compute_node\"}, project)",
                             "refresh": 0,
                             "regex": "",
                             "skipUrlSync": false,
@@ -1064,14 +1064,14 @@ func OpenstackNetworkTraffic(dsName string) *corev1.ConfigMap {
                                 "name": "` + dsName + `",
                                 "type": "prometheus"
                             },
-                            "definition": "label_values(ceilometer_cpu{project_name =~ \"$project\"}, vm_instance)",
+                            "definition": "label_values(ceilometer_cpu{project =~ \"$project\"}, vm_instance)",
                             "hide": 0,
                             "includeAll": true,
                             "label": null,
                             "multi": true,
                             "name": "VM",
                             "options": [],
-                            "query": "label_values(vm:ceilometer_cpu:ratio1m{project_name =~ \"$project\"}, vm_name)",
+                            "query": "label_values(vm:ceilometer_cpu:ratio1m{project =~ \"$project\"}, vm_name)",
                             "refresh": 0,
                             "regex": "",
                             "skipUrlSync": false,

--- a/internal/dashboards/openstack-vm.go
+++ b/internal/dashboards/openstack-vm.go
@@ -181,7 +181,7 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 					"steppedLine": false,
 					"targets": [
 						{
-						"expr": "vm:ceilometer_cpu:ratio1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_cpu:ratio1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}}",
@@ -271,7 +271,7 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 					"steppedLine": false,
 					"targets": [
 						{
-						"expr": "vm:ceilometer_memory_usage:total{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_memory_usage:total{project =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}}",
@@ -360,7 +360,7 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 					"steppedLine": false,
 					"targets": [
 						{
-						"expr": "vm:ceilometer_disk_device_usage:total{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_disk_device_usage:total{project =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}}({{device}})",
@@ -449,13 +449,13 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 					"steppedLine": false,
 					"targets": [
 						{
-						"expr": "vm:ceilometer_disk_device_read_bytes:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_disk_device_read_bytes:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
 						"interval": "",
 						"legendFormat": "{{vm_name}} read ({{device}})",
 						"refId": "A"
 						},
 						{
-						"expr": "vm:ceilometer_disk_device_write_bytes:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_disk_device_write_bytes:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}} write ({{device}})",
@@ -544,14 +544,14 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 					"steppedLine": false,
 					"targets": [
 						{
-							"expr": "vm:ceilometer_network_incoming_bytes:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
+							"expr": "vm:ceilometer_network_incoming_bytes:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
 							"hide": false,
 							"interval": "",
 							"legendFormat": "{{vm_name}} in ({{device}})",
 							"refId": "B"
 						},
 						{
-						"expr": "vm:ceilometer_network_outgoing_bytes:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_network_outgoing_bytes:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}} out ({{device}})",
@@ -640,14 +640,14 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 					"steppedLine": false,
 					"targets": [
 						{
-						"expr": "vm:ceilometer_network_incoming_packets_drop:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_network_incoming_packets_drop:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}} in ({{device}})",
 						"refId": "A"
 						},
 						{
-						"expr": "vm:ceilometer_network_outgoing_packets_drop:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_network_outgoing_packets_drop:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}} out ({{device}})",
@@ -736,14 +736,14 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 					"steppedLine": false,
 					"targets": [
 						{
-						"expr": "vm:ceilometer_network_incoming_packets_error:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_network_incoming_packets_error:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}} in ({{device}})",
 						"refId": "A"
 						},
 						{
-						"expr": "vm:ceilometer_network_outgoing_packets_error:rate1m{project_name =~ \"$project\", vm_name =~ \"$VM\"}",
+						"expr": "vm:ceilometer_network_outgoing_packets_error:rate1m{project =~ \"$project\", vm_name =~ \"$VM\"}",
 						"hide": false,
 						"interval": "",
 						"legendFormat": "{{vm_name}} out ({{device}})",
@@ -804,13 +804,13 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 						"allValue": ".*",
 						"current": {
 						"tags": [],
-						"text": "admin",
+						"text": "66ad788dfacb4560b4c4e27e7ebc3b35",
 						"value": [
-							"admin"
+							"66ad788dfacb4560b4c4e27e7ebc3b35"
 						]
 						},
 						"datasource": { "name": "` + dsName + `", "type": "prometheus" },
-						"definition": "label_values(ceilometer_cpu, project_name)",
+						"definition": "label_values(ceilometer_cpu, project)",
 						"hide": 0,
 						"includeAll": true,
 						"index": -1,
@@ -825,11 +825,16 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 						},
 						{
 							"selected": true,
-							"text": "admin",
-							"value": "admin"
+							"text": "66ad788dfacb4560b4c4e27e7ebc3b35",
+							"value": "66ad788dfacb4560b4c4e27e7ebc3b35"
+						},
+						{
+							"selected": false,
+							"text": "ad3f0a004afc41fc80bb2a6e69ec4e6e",
+							"value": "ad3f0a004afc41fc80bb2a6e69ec4e6e"
 						}
 						],
-						"query": "label_values(ceilometer_cpu, project_name)",
+						"query": "label_values(ceilometer_cpu, project)",
 						"refresh": 0,
 						"regex": "",
 						"skipUrlSync": false,
@@ -851,7 +856,7 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 						]
 						},
 						"datasource": { "name": "` + dsName + `", "type": "prometheus" },
-						"definition": "label_values(ceilometer_cpu{project_name =~ \"$project\"}, vm_instance)",
+						"definition": "label_values(ceilometer_cpu{project =~ \"$project\"}, vm_instance)",
 						"hide": 0,
 						"includeAll": false,
 						"index": -1,
@@ -875,7 +880,7 @@ func OpenstackVM(dsName string) *corev1.ConfigMap {
 							"value": "1d0808c7d062b9b20bfb2979b0d940b55c10312b1a56894a4b7c3238"
 						}
 						],
-						"query": "label_values(vm:ceilometer_cpu:ratio1m{project_name =~ \"$project\"}, vm_name)",
+						"query": "label_values(vm:ceilometer_cpu:ratio1m{project =~ \"$project\"}, vm_name)",
 						"refresh": 0,
 						"regex": "",
 						"skipUrlSync": false,

--- a/templates/ceilometercompute/config/ceilometer.conf
+++ b/templates/ceilometercompute/config/ceilometer.conf
@@ -42,7 +42,6 @@ notify_address_prefix=
 driver=noop
 
 [polling]
-identity_name_discovery=True
 heartbeat_socket_dir=/var/lib/ceilometer
 {{- if .TLS }}
 prometheus_tls_enable = True


### PR DESCRIPTION
We discovered, that ceilometer version we use has a bug, where it tries to reach Keystone through the public endpoint no matter what's the configuration when performing the identity name discovery. We can't assume the public service endpoints are reachable from the compute nodes. So having identity_name_discovery=True started causing issues in environments without access to public endpoint from the computes. This caused ceilometer compute agent to completely fail and not produce any metrics. We'll need to revert these 2 commits until ceilometer is fixed to adhere to its configuration, so that we can unblock further development of other features.

cherry-pick of: https://github.com/openstack-k8s-operators/telemetry-operator/pull/922

Depends-On: https://github.com/openstack-k8s-operators/watcher-operator/pull/390
Depends-On: https://github.com/openstack-k8s-operators/telemetry-operator/pull/924