### PR TITLE
Set service_type in [keystone_authtoken] for access rule validation

### DIFF
--- a/templates/autoscaling/config/aodh.conf
+++ b/templates/autoscaling/config/aodh.conf
@@ -60,6 +60,7 @@ project_domain_name = Default
 {{- end }}
 auth_url = {{ .KeystoneInternalURL }}
 service_token_roles_required = True
+service_type = alarming
 {{ if (index . "Region") -}}
 region_name = {{ .Region }}
 {{ end -}}

--- a/templates/cloudkitty/config/cloudkitty.conf
+++ b/templates/cloudkitty/config/cloudkitty.conf
@@ -102,6 +102,7 @@ auth_type = password
 region_name = {{ .Region }}
 {{ end -}}
 interface = internal
+service_type = rating
 {{- if .TLS }}
 cafile = {{ .CAFile }}
 {{- end }}


### PR DESCRIPTION
Without service_type configured, keystonemiddleware cannot validate application credentials with custom access rules, causing HTTP 401 for end users.

Closes: [OSPRH-22365](https://redhat.atlassian.net/browse/OSPRH-22365)