### PR TITLE
Fix client IP logging in Telemetry VirtualHosts

### DIFF
--- a/templates/autoscaling/config/wsgi-aodh.conf
+++ b/templates/autoscaling/config/wsgi-aodh.conf
@@ -17,7 +17,9 @@
   ## Logging
   ErrorLog /dev/stdout
   ServerSignature Off
-  CustomLog /dev/stdout combined
+  SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+  CustomLog /dev/stdout combined env=!forwarded
+  CustomLog /dev/stdout proxy env=forwarded
 
   ## Request header rules
   ## as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#requestheader

--- a/templates/ceilometercentral/config/httpd.conf
+++ b/templates/ceilometercentral/config/httpd.conf
@@ -30,7 +30,9 @@ CustomLog /dev/stdout proxy env=forwarded
   ## Logging
   ErrorLog /dev/stdout
   ServerSignature Off
-  CustomLog /dev/stdout combined
+  SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+  CustomLog /dev/stdout combined env=!forwarded
+  CustomLog /dev/stdout proxy env=forwarded
 
   ## Request header rules
   ## as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#requestheader

--- a/templates/cloudkitty/config/wsgi-cloudkitty.conf
+++ b/templates/cloudkitty/config/wsgi-cloudkitty.conf
@@ -19,7 +19,9 @@
   ## Logging
   ErrorLog /dev/stdout
   ServerSignature Off
-  CustomLog /dev/stdout combined
+  SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+  CustomLog /dev/stdout combined env=!forwarded
+  CustomLog /dev/stdout proxy env=forwarded
 
 {{- if $vhost.TLS }}
   SetEnvIf X-Forwarded-Proto https HTTPS=1


### PR DESCRIPTION
The `VirtualHost` `CustomLog` directive was overriding the server-level dual-log setup, causing all requests to be logged with the OpenShift router IP instead of the real client IP from `X-Forwarded-For`.

Add `SetEnvIf` and dual `CustomLog` lines inside the `VirtualHost` block to match the `nova-operator` pattern.

Jira: [OSPRH-32126](https://redhat.atlassian.net/browse/OSPRH-32126)