### PR TITLE
Remove deprecated webhook.Defaulter/Validator interface assertions

### DIFF
--- a/api/v1beta1/autoscaling_webhook.go
+++ b/api/v1beta1/autoscaling_webhook.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -47,8 +46,6 @@ func SetupAutoscalingDefaults(defaults AutoscalingDefaults) {
 	autoscalingDefaults = defaults
 	autoscalinglog.Info("Autoscaling defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Defaulter = &Autoscaling{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Autoscaling) Default() {
@@ -164,8 +161,6 @@ func (spec *AutoscalingSpecCore) SetDefaultRouteAnnotations(annotations map[stri
 	annotations[aodhAnno] = timeout
 	annotations[haProxyAnno] = timeout
 }
-
-var _ webhook.Validator = &Autoscaling{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Autoscaling) ValidateCreate() (admission.Warnings, error) {

--- a/api/v1beta1/ceilometer_webhook.go
+++ b/api/v1beta1/ceilometer_webhook.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	common_webhook "github.com/openstack-k8s-operators/lib-common/modules/common/webhook"
 )
@@ -49,8 +48,6 @@ func SetupCeilometerDefaults(defaults CeilometerDefaults) {
 	ceilometerDefaults = defaults
 	ceilometerlog.Info("Ceilometer defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Defaulter = &Ceilometer{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Ceilometer) Default() {
@@ -145,8 +142,6 @@ func (spec *CeilometerSpecCore) validateDeprecatedFieldsUpdate(old CeilometerSpe
 	deprecatedFields := spec.getDeprecatedFields(&old)
 	return common_webhook.ValidateDeprecatedFieldsUpdate(deprecatedFields, basePath)
 }
-
-var _ webhook.Validator = &Ceilometer{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Ceilometer) ValidateCreate() (admission.Warnings, error) {

--- a/api/v1beta1/cloudkitty_webhook.go
+++ b/api/v1beta1/cloudkitty_webhook.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	common_webhook "github.com/openstack-k8s-operators/lib-common/modules/common/webhook"
 )
@@ -46,8 +45,6 @@ func SetupCloudKittyDefaults(defaults CloudKittyDefaults) {
 	cloudKittyDefaults = defaults
 	cloudKittyLog.Info("CloudKitty defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Defaulter = &CloudKitty{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *CloudKitty) Default() {
@@ -133,8 +130,6 @@ func (spec *CloudKittySpecBase) validateDeprecatedFieldsUpdate(old CloudKittySpe
 	deprecatedFields := spec.getDeprecatedFields(&old)
 	return common_webhook.ValidateDeprecatedFieldsUpdate(deprecatedFields, basePath)
 }
-
-var _ webhook.Validator = &CloudKitty{}
 
 func (r *ObjectStorageSpec) Validate(basePath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList

--- a/api/v1beta1/metricstorage_webhook.go
+++ b/api/v1beta1/metricstorage_webhook.go
@@ -19,14 +19,11 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // log is for logging in this package.
 var metricstoragelog = logf.Log.WithName("metricstorage-resource")
-
-var _ webhook.Defaulter = &MetricStorage{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *MetricStorage) Default() {
@@ -87,8 +84,6 @@ func (ps *PersistentStorage) Default() {
 		ps.PvcStorageRequest = "20G"
 	}
 }
-
-var _ webhook.Validator = &MetricStorage{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *MetricStorage) ValidateCreate() (admission.Warnings, error) {

--- a/api/v1beta1/telemetry_webhook.go
+++ b/api/v1beta1/telemetry_webhook.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -60,8 +59,6 @@ func SetupTelemetryDefaults(defaults TelemetryDefaults) {
 	telemetryDefaults = defaults
 	telemetrylog.Info("Telemetry defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Defaulter = &Telemetry{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Telemetry) Default() {
@@ -129,8 +126,6 @@ func (spec *TelemetrySpecCore) Default() {
 	spec.Ceilometer.Default()
 	spec.CloudKitty.Default()
 }
-
-var _ webhook.Validator = &Telemetry{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Telemetry) ValidateCreate() (admission.Warnings, error) {


### PR DESCRIPTION
These compile-time assertions reference webhook.Defaulter and webhook.Validator interfaces that are removed in controller-runtime v0.21 (OCP 4.20). The assertions are dead code — webhook registration already uses CustomDefaulter/CustomValidator in internal/webhook/.

Removing them makes the API module forward-compatible with CR v0.21 so that consumers (like openstack-operator) can bump controller-runtime without needing replace directives for this operator.

Jira: [OSPRH-32989](https://redhat.atlassian.net/browse/OSPRH-32989)