### PR TITLE
Add fetch_extra_metadata to ceilometer compute config

### DIFF
--- a/templates/ceilometercompute/config/ceilometer.conf
+++ b/templates/ceilometercompute/config/ceilometer.conf
@@ -31,6 +31,7 @@ cafile = {{ .CAFile }}
 [compute]
 instance_discovery_method=libvirt_metadata
 report_stopped_instance_metrics=True
+fetch_extra_metadata=True
 
 [coordination]
 backend_url=


### PR DESCRIPTION
Ceilometer set the fetch_extra_metadata to false by default in https://github.com/openstack/ceilometer/commit/436296bcf72129336756da6a7ca27ccecf92dabe

We need fetch_extra_metadata=True so that ceilometer retrieves the server group property from VMs. Server group is later used in autoscaling to group VMs from the same stack together.