### PR TITLE
[OSPRH-33383] Remove unused privileged SCC from CloudKitty kubebuilde…

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -322,15 +322,6 @@ rules:
   verbs:
   - use
 - apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - anyuid
-  - privileged
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
-- apiGroups:
   - telemetry.openstack.org
   resources:
   - autoscalings

--- a/internal/controller/cloudkitty_controller.go
+++ b/internal/controller/cloudkitty_controller.go
@@ -124,7 +124,7 @@ func (r *CloudKittyReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
-// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid,resources=securitycontextconstraints,verbs=use
 
 // Reconcile -
 func (r *CloudKittyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {


### PR DESCRIPTION
…r RBAC marker

The CloudKitty controller's kubebuilder marker requested use on both anyuid and privileged SCCs, but no generated workload sets Privileged: true or uses host namespaces. The workload Role the controller creates only delegates anyuid. This removes the dead-weight privileged grant from the marker and regenerates config/rbac/role.yaml.