### PR TITLE
Include ssl.conf in httpd configuration

### DIFF
--- a/templates/autoscaling/config/httpd.conf
+++ b/templates/autoscaling/config/httpd.conf
@@ -21,7 +21,4 @@ CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
 ErrorLog /dev/stdout
 
-# XXX: To disable SSL
-#Include conf.d/*.conf
-# If above include is commented include at least the aodh wsgi file
-Include conf.d/00wsgi-aodh.conf
+Include conf.d/*.conf

--- a/templates/cloudkitty/config/httpd.conf
+++ b/templates/cloudkitty/config/httpd.conf
@@ -21,7 +21,4 @@ CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
 ErrorLog /dev/stdout
 
-# XXX: To disable SSL
-#Include conf.d/*.conf
-# If above include is commented include at least the cloudkitty wsgi file
-Include conf.d/00wsgi-cloudkitty.conf
+Include conf.d/*.conf


### PR DESCRIPTION
The `ssl.conf` rendered by `lib-common` was placed by `kolla` into `conf.d/` but never loaded because the Include `conf.d/*.conf` directive was commented out. This left global `SSL` hardening settings (cipher suite, protocol restrictions, session cache) at `mod_ssl` defaults instead of the operator-managed values.

Replace the explicit Include of `00wsgi-<service>.conf` with the `conf.d` wildcard so both `ssl.conf` and the `wsgi vhost` config are loaded.

Jira: https://redhat.atlassian.net/browse/OSPRH-34160