### PR TITLE
Set sg-core prometheus plugin listen address to localhost

### DIFF
--- a/templates/ceilometercentral/config/sg-core.conf.yaml
+++ b/templates/ceilometercentral/config/sg-core.conf.yaml
@@ -15,6 +15,6 @@ transports:
 applications:
   - name: prometheus
     config:
-      host: 0.0.0.0
+      host: 127.0.0.1
       port: 3001
       withTimeStamp: True


### PR DESCRIPTION
The httpd proxy is the only thing connecting to the sg-core prometheus scrape endpoint. Httpd runs inside the same pod, so there is no reason for sg-core's prometheus plugin to listen on more than just the loopback network.